### PR TITLE
fix(ui): improve event image layout and card sizing

### DIFF
--- a/src/components/EventCard.astro
+++ b/src/components/EventCard.astro
@@ -25,10 +25,10 @@ const {
 {
   isHorizontal ? (
     <article class="border-gray-custom relative overflow-hidden rounded-lg border bg-white shadow-sm md:flex">
-      <div class="md:basis-1/2">
+      <div class="bg-gray-100 md:basis-1/2">
         <img
           src={image || "/placeholder.svg"}
-          class="h- aspect-video h-full w-full rounded-t-lg object-cover md:rounded-none md:rounded-tl-lg md:rounded-bl-lg"
+          class="h-full w-full rounded-t-lg object-contain md:rounded-none md:rounded-tl-lg md:rounded-bl-lg"
           width={385}
           height={192}
           alt={`Foto del evento de ${name}`}

--- a/src/pages/eventos/[slug].astro
+++ b/src/pages/eventos/[slug].astro
@@ -135,14 +135,16 @@ const hasSchedule = isArraySchedule ? (schedule as unknown[]).length > 0 : true;
 ---
 
 <Layout {...metadata}>
-  <section class="relative py-20">
+  <section
+    class="relative flex min-h-[24rem] items-end py-12 md:min-h-[28rem] md:py-16"
+  >
     <span class="absolute inset-0 z-[1] bg-black/50"></span>
     <Image
       src={event.data.image || "/placeholder.svg"}
       alt={`Foto de evento ${event.data.name}`}
       class="absolute inset-0 h-full w-full object-cover object-center"
-      width={1200}
-      height={600}
+      width={1920}
+      height={1080}
     />
     <div class="relative z-[2] container">
       <div class="max-w-[768px]">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,7 @@ const upcomingEvents = allEvents
 
 const gridClasses =
   upcomingEvents.length === 1
-    ? "flex justify-center"
+    ? "mx-auto grid max-w-md"
     : upcomingEvents.length === 2
       ? "grid grid-cols-1 gap-8 sm:grid-cols-2 justify-center"
       : "grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3";


### PR DESCRIPTION
## Summary
- Constrain single upcoming event card width (`max-w-md`) on homepage to prevent it from stretching too wide
- Increase event detail hero image resolution to 1920×1080 and add `min-height` with bottom-aligned content for better image display
- Switch horizontal EventCard image to `object-contain` with `bg-gray-100` background to prevent excessive zoom on portrait/square event images

## Test plan
- [x] Verify single upcoming event card on homepage is properly constrained
- [x] Verify event detail hero image looks proportional
- [x] Verify horizontal EventCard (Próximo Evento Destacado) shows image without heavy zoom
- [x] Check responsive behavior on mobile and desktop