### PR TITLE
feat(admin): add team and speaker management

### DIFF
--- a/functions/src/handlers/speakers.ts
+++ b/functions/src/handlers/speakers.ts
@@ -1,0 +1,176 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { GitHubService } from "../services/github";
+import { GITHUB_TOKEN } from "../config";
+
+interface Speaker {
+  id: string;
+  name: string;
+  bio: string;
+  photo_url: string;
+  company: string;
+  role: string;
+  topics: string[];
+  social_links: Record<string, string>;
+  talk_ids: string[];
+}
+
+export async function listSpeakers(_req: Request, res: Response) {
+  try {
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const { data } = await github.getFileContent<Speaker[]>(
+      "speakers/index.json"
+    );
+    res.json({ success: true, data });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}
+
+export async function addSpeaker(req: Request, res: Response) {
+  try {
+    const speaker = req.body as Speaker;
+    if (!speaker.id || !speaker.name) {
+      res
+        .status(400)
+        .json({ success: false, error: "Missing required fields: id, name" });
+      return;
+    }
+
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    // Create individual speaker file
+    await github.putFile(
+      `speakers/${speaker.id}.json`,
+      JSON.stringify(speaker, null, 2),
+      `feat(speakers): add ${speaker.name}`
+    );
+
+    // Update index
+    const { data: index, sha } = await github.getFileContent<Speaker[]>(
+      "speakers/index.json"
+    );
+    index.push(speaker);
+    await github.putFile(
+      "speakers/index.json",
+      JSON.stringify(index, null, 2),
+      `feat(speakers): add ${speaker.name} to index`,
+      sha
+    );
+
+    await github.triggerRebuild();
+
+    await admin
+      .firestore()
+      .collection("audit_log")
+      .add({
+        action: "speaker.create",
+        performedBy: user.uid,
+        targetId: speaker.id,
+        targetType: "speaker",
+        details: { name: speaker.name },
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+    res.status(201).json({ success: true, data: { id: speaker.id } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}
+
+export async function updateSpeaker(req: Request, res: Response) {
+  try {
+    const speakerId = req.params.id as string;
+    const updates = { ...req.body, id: speakerId } as Speaker;
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    // Update individual file
+    const { sha: fileSha } = await github.getFileContent<Speaker>(
+      `speakers/${speakerId}.json`
+    );
+    await github.putFile(
+      `speakers/${speakerId}.json`,
+      JSON.stringify(updates, null, 2),
+      `fix(speakers): update ${speakerId}`,
+      fileSha
+    );
+
+    // Update index
+    const { data: index, sha: indexSha } = await github.getFileContent<
+      Speaker[]
+    >("speakers/index.json");
+    const updatedIndex = index.map((s) => (s.id === speakerId ? updates : s));
+    await github.putFile(
+      "speakers/index.json",
+      JSON.stringify(updatedIndex, null, 2),
+      `fix(speakers): update ${speakerId} in index`,
+      indexSha
+    );
+
+    await github.triggerRebuild();
+
+    await admin
+      .firestore()
+      .collection("audit_log")
+      .add({
+        action: "speaker.update",
+        performedBy: user.uid,
+        targetId: speakerId,
+        targetType: "speaker",
+        details: { name: updates.name },
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+    res.json({ success: true, data: { id: speakerId } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}
+
+export async function deleteSpeaker(req: Request, res: Response) {
+  try {
+    const speakerId = req.params.id as string;
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    // Delete individual file
+    const { sha: fileSha } = await github.getFileContent<Speaker>(
+      `speakers/${speakerId}.json`
+    );
+    await github.deleteFile(
+      `speakers/${speakerId}.json`,
+      `chore(speakers): delete ${speakerId}`,
+      fileSha
+    );
+
+    // Remove from index
+    const { data: index, sha: indexSha } = await github.getFileContent<
+      Speaker[]
+    >("speakers/index.json");
+    const filtered = index.filter((s) => s.id !== speakerId);
+    await github.putFile(
+      "speakers/index.json",
+      JSON.stringify(filtered, null, 2),
+      `chore(speakers): remove ${speakerId} from index`,
+      indexSha
+    );
+
+    await github.triggerRebuild();
+
+    await admin.firestore().collection("audit_log").add({
+      action: "speaker.delete",
+      performedBy: user.uid,
+      targetId: speakerId,
+      targetType: "speaker",
+      details: {},
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}

--- a/functions/src/handlers/team.ts
+++ b/functions/src/handlers/team.ts
@@ -1,0 +1,156 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { GitHubService } from "../services/github";
+import { GITHUB_TOKEN } from "../config";
+
+interface TeamMember {
+  id: string;
+  name: string;
+  role: string;
+  photo_url: string;
+  bio: string;
+  social_links: Record<string, string>;
+  type: "organizer" | "member";
+  tags?: string[];
+  joined_date?: string;
+  responsibilities?: string[];
+}
+
+export async function listTeam(_req: Request, res: Response) {
+  try {
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const { data } =
+      await github.getFileContent<TeamMember[]>("about/team.json");
+    res.json({ success: true, data });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}
+
+export async function addTeamMember(req: Request, res: Response) {
+  try {
+    const member = req.body as TeamMember;
+    if (!member.id || !member.name) {
+      res
+        .status(400)
+        .json({ success: false, error: "Missing required fields: id, name" });
+      return;
+    }
+
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    const { data: team, sha } =
+      await github.getFileContent<TeamMember[]>("about/team.json");
+    team.push(member);
+
+    await github.putFile(
+      "about/team.json",
+      JSON.stringify(team, null, 2),
+      `feat(team): add ${member.name}`,
+      sha
+    );
+
+    await github.triggerRebuild();
+
+    await admin
+      .firestore()
+      .collection("audit_log")
+      .add({
+        action: "team.create",
+        performedBy: user.uid,
+        targetId: member.id,
+        targetType: "team",
+        details: { name: member.name },
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+    res.status(201).json({ success: true, data: { id: member.id } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}
+
+export async function updateTeamMember(req: Request, res: Response) {
+  try {
+    const memberId = req.params.id as string;
+    const updates = req.body as TeamMember;
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    const { data: team, sha } =
+      await github.getFileContent<TeamMember[]>("about/team.json");
+    const index = team.findIndex((m) => m.id === memberId);
+    if (index === -1) {
+      res.status(404).json({ success: false, error: "Member not found" });
+      return;
+    }
+
+    team[index] = { ...updates, id: memberId };
+
+    await github.putFile(
+      "about/team.json",
+      JSON.stringify(team, null, 2),
+      `fix(team): update ${memberId}`,
+      sha
+    );
+
+    await github.triggerRebuild();
+
+    await admin
+      .firestore()
+      .collection("audit_log")
+      .add({
+        action: "team.update",
+        performedBy: user.uid,
+        targetId: memberId,
+        targetType: "team",
+        details: { name: updates.name },
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+    res.json({ success: true, data: { id: memberId } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}
+
+export async function deleteTeamMember(req: Request, res: Response) {
+  try {
+    const memberId = req.params.id as string;
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    const { data: team, sha } =
+      await github.getFileContent<TeamMember[]>("about/team.json");
+    const filtered = team.filter((m) => m.id !== memberId);
+
+    if (filtered.length === team.length) {
+      res.status(404).json({ success: false, error: "Member not found" });
+      return;
+    }
+
+    await github.putFile(
+      "about/team.json",
+      JSON.stringify(filtered, null, 2),
+      `chore(team): remove ${memberId}`,
+      sha
+    );
+
+    await github.triggerRebuild();
+
+    await admin.firestore().collection("audit_log").add({
+      action: "team.delete",
+      performedBy: user.uid,
+      targetId: memberId,
+      targetType: "team",
+      details: {},
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,6 +6,8 @@ import { GITHUB_TOKEN } from "./config";
 import { requireRole, requireAuth } from "./middleware/auth";
 import { register } from "./handlers/auth";
 import * as events from "./handlers/events";
+import * as team from "./handlers/team";
+import * as speakers from "./handlers/speakers";
 import * as users from "./handlers/users";
 import { triggerRebuild } from "./handlers/rebuild";
 
@@ -24,6 +26,18 @@ app.get("/api/events/:id", requireRole("organizer"), events.getEvent);
 app.post("/api/events", requireRole("organizer"), events.createEvent);
 app.put("/api/events/:id", requireRole("organizer"), events.updateEvent);
 app.delete("/api/events/:id", requireRole("admin"), events.deleteEvent);
+
+// Team
+app.get("/api/team", requireRole("organizer"), team.listTeam);
+app.post("/api/team", requireRole("admin"), team.addTeamMember);
+app.put("/api/team/:id", requireRole("admin"), team.updateTeamMember);
+app.delete("/api/team/:id", requireRole("admin"), team.deleteTeamMember);
+
+// Speakers
+app.get("/api/speakers", requireRole("organizer"), speakers.listSpeakers);
+app.post("/api/speakers", requireRole("organizer"), speakers.addSpeaker);
+app.put("/api/speakers/:id", requireRole("organizer"), speakers.updateSpeaker);
+app.delete("/api/speakers/:id", requireRole("admin"), speakers.deleteSpeaker);
 
 // Users
 app.get("/api/users", requireRole("admin"), users.listUsers);

--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -4,6 +4,8 @@ import { AdminShell } from "./AdminShell";
 import { Dashboard } from "./Dashboard";
 import { EventList } from "./events/EventList";
 import { EventForm } from "./events/EventForm";
+import { TeamList } from "./team/TeamList";
+import { SpeakerList } from "./speakers/SpeakerList";
 
 interface Props {
   page: string;
@@ -56,6 +58,10 @@ function AdminContent({ page, currentPath }: Props) {
         return <EventList />;
       case "event-form":
         return <EventForm />;
+      case "team":
+        return <TeamList />;
+      case "speakers":
+        return <SpeakerList />;
       default:
         return <p className="text-gray-500">Pagina en construccion</p>;
     }

--- a/src/components/react/admin/speakers/SpeakerList.tsx
+++ b/src/components/react/admin/speakers/SpeakerList.tsx
@@ -1,0 +1,390 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { Toast } from "../ui/Toast";
+import { FormField } from "../ui/FormField";
+
+interface Speaker {
+  id: string;
+  name: string;
+  bio: string;
+  photo_url: string;
+  company: string;
+  role: string;
+  topics: string[];
+  social_links: Record<string, string>;
+  talk_ids: string[];
+}
+
+const EMPTY_SPEAKER: Speaker = {
+  id: "",
+  name: "",
+  bio: "",
+  photo_url: "",
+  company: "",
+  role: "",
+  topics: [],
+  social_links: {},
+  talk_ids: [],
+};
+
+export function SpeakerList() {
+  const [speakers, setSpeakers] = useState<Speaker[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+  const [editing, setEditing] = useState<Speaker | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [topicInput, setTopicInput] = useState("");
+
+  const form = editing || (creating ? EMPTY_SPEAKER : null);
+
+  useEffect(() => {
+    loadSpeakers();
+  }, []);
+
+  async function loadSpeakers() {
+    setLoading(true);
+    const res = await api.listSpeakers();
+    if (res.success && res.data) {
+      setSpeakers(res.data as Speaker[]);
+    } else {
+      setError(res.error || "Error al cargar speakers");
+    }
+    setLoading(false);
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form) return;
+    setSaving(true);
+    const isNew = creating;
+    const res = isNew
+      ? await api.addSpeaker(form)
+      : await api.updateSpeaker(form.id, form);
+
+    if (res.success) {
+      setToast({
+        message: `Speaker ${isNew ? "agregado" : "actualizado"}`,
+        type: "success",
+      });
+      setEditing(null);
+      setCreating(false);
+      loadSpeakers();
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setSaving(false);
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm(`Eliminar speaker "${id}"?`)) return;
+    setDeleting(id);
+    const res = await api.deleteSpeaker(id);
+    if (res.success) {
+      setSpeakers((prev) => prev.filter((s) => s.id !== id));
+      setToast({ message: "Speaker eliminado", type: "success" });
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setDeleting(null);
+  }
+
+  function updateForm(field: keyof Speaker, value: unknown) {
+    if (editing) setEditing({ ...editing, [field]: value });
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+        {error}
+      </div>
+    );
+  }
+
+  const inputClass =
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500";
+
+  if (form) {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <button
+          onClick={() => {
+            setEditing(null);
+            setCreating(false);
+          }}
+          className="mb-4 text-sm text-gray-500 hover:text-gray-700"
+        >
+          ← Volver a speakers
+        </button>
+        <h2 className="mb-6 text-xl font-bold text-gray-900">
+          {creating ? "Agregar speaker" : `Editar: ${form.name}`}
+        </h2>
+        <form onSubmit={handleSave} className="space-y-6">
+          <div className="rounded-xl border border-gray-200 bg-white p-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormField label="ID (slug)" required>
+                <input
+                  type="text"
+                  value={form.id}
+                  onChange={(e) => updateForm("id", e.target.value)}
+                  placeholder="juan-perez"
+                  className={inputClass}
+                  disabled={!!editing}
+                />
+              </FormField>
+              <FormField label="Nombre" required>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => updateForm("name", e.target.value)}
+                  className={inputClass}
+                />
+              </FormField>
+              <FormField label="Empresa">
+                <input
+                  type="text"
+                  value={form.company}
+                  onChange={(e) => updateForm("company", e.target.value)}
+                  className={inputClass}
+                />
+              </FormField>
+              <FormField label="Rol">
+                <input
+                  type="text"
+                  value={form.role}
+                  onChange={(e) => updateForm("role", e.target.value)}
+                  className={inputClass}
+                />
+              </FormField>
+              <div className="sm:col-span-2">
+                <FormField label="Bio">
+                  <textarea
+                    value={form.bio}
+                    onChange={(e) => updateForm("bio", e.target.value)}
+                    rows={3}
+                    className={inputClass}
+                  />
+                </FormField>
+              </div>
+              <div className="sm:col-span-2">
+                <FormField label="URL foto">
+                  <input
+                    type="url"
+                    value={form.photo_url}
+                    onChange={(e) => updateForm("photo_url", e.target.value)}
+                    className={inputClass}
+                  />
+                </FormField>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-6">
+            <h3 className="mb-4 font-semibold text-gray-900">Topics</h3>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={topicInput}
+                onChange={(e) => setTopicInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    if (topicInput.trim()) {
+                      updateForm("topics", [...form.topics, topicInput.trim()]);
+                      setTopicInput("");
+                    }
+                  }
+                }}
+                placeholder="Agregar topic"
+                className={inputClass}
+              />
+            </div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {form.topics.map((topic, i) => (
+                <span
+                  key={i}
+                  className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800"
+                >
+                  {topic}
+                  <button
+                    type="button"
+                    onClick={() =>
+                      updateForm(
+                        "topics",
+                        form.topics.filter((_, idx) => idx !== i)
+                      )
+                    }
+                    className="text-blue-600 hover:text-blue-800"
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-gray-200 bg-white p-6">
+            <h3 className="mb-4 font-semibold text-gray-900">Redes sociales</h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {["linkedin", "github", "twitter", "web"].map((key) => (
+                <FormField key={key} label={key}>
+                  <input
+                    type="url"
+                    value={form.social_links[key] || ""}
+                    onChange={(e) =>
+                      updateForm("social_links", {
+                        ...form.social_links,
+                        [key]: e.target.value,
+                      })
+                    }
+                    className={inputClass}
+                  />
+                </FormField>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                setEditing(null);
+                setCreating(false);
+              }}
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {saving ? "Guardando..." : creating ? "Agregar" : "Actualizar"}
+            </button>
+          </div>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+
+      <div className="mb-6 flex items-center justify-between">
+        <p className="text-sm text-gray-500">{speakers.length} speakers</p>
+        <button
+          onClick={() => {
+            setCreating(true);
+            setEditing({ ...EMPTY_SPEAKER });
+          }}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          + Agregar speaker
+        </button>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Speaker
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Empresa
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Topics
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Acciones
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {speakers.map((speaker) => (
+              <tr key={speaker.id} className="hover:bg-gray-50">
+                <td className="px-6 py-4">
+                  <div className="flex items-center gap-3">
+                    <img
+                      src={speaker.photo_url || "/placeholder.svg"}
+                      alt=""
+                      className="h-8 w-8 rounded-full object-cover"
+                    />
+                    <div>
+                      <p className="font-medium text-gray-900">
+                        {speaker.name}
+                      </p>
+                      <p className="text-xs text-gray-500">{speaker.role}</p>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-6 py-4 text-sm text-gray-500">
+                  {speaker.company}
+                </td>
+                <td className="px-6 py-4">
+                  <div className="flex flex-wrap gap-1">
+                    {speaker.topics.slice(0, 3).map((t, i) => (
+                      <span
+                        key={i}
+                        className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                    {speaker.topics.length > 3 && (
+                      <span className="text-xs text-gray-400">
+                        +{speaker.topics.length - 3}
+                      </span>
+                    )}
+                  </div>
+                </td>
+                <td className="px-6 py-4 text-right">
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => setEditing(speaker)}
+                      className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      onClick={() => handleDelete(speaker.id)}
+                      disabled={deleting === speaker.id}
+                      className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+                    >
+                      {deleting === speaker.id ? "..." : "Eliminar"}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {speakers.length === 0 && (
+          <p className="py-8 text-center text-gray-500">No hay speakers.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/team/TeamList.tsx
+++ b/src/components/react/admin/team/TeamList.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { Toast } from "../ui/Toast";
+import { TeamMemberForm } from "./TeamMemberForm";
+
+interface TeamMember {
+  id: string;
+  name: string;
+  role: string;
+  photo_url: string;
+  bio: string;
+  social_links: Record<string, string>;
+  type: "organizer" | "member";
+  tags?: string[];
+}
+
+export function TeamList() {
+  const [members, setMembers] = useState<TeamMember[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+  const [editing, setEditing] = useState<TeamMember | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadTeam();
+  }, []);
+
+  async function loadTeam() {
+    setLoading(true);
+    const res = await api.listTeam();
+    if (res.success && res.data) {
+      setMembers(res.data as TeamMember[]);
+    } else {
+      setError(res.error || "Error al cargar equipo");
+    }
+    setLoading(false);
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm(`Eliminar miembro "${id}"?`)) return;
+    setDeleting(id);
+    const res = await api.deleteTeamMember(id);
+    if (res.success) {
+      setMembers((prev) => prev.filter((m) => m.id !== id));
+      setToast({ message: "Miembro eliminado", type: "success" });
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setDeleting(null);
+  }
+
+  async function handleSave(member: TeamMember, isNew: boolean) {
+    const res = isNew
+      ? await api.addTeamMember(member)
+      : await api.updateTeamMember(member.id, member);
+
+    if (res.success) {
+      setToast({
+        message: `Miembro ${isNew ? "agregado" : "actualizado"}`,
+        type: "success",
+      });
+      setEditing(null);
+      setCreating(false);
+      loadTeam();
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+        {error}
+      </div>
+    );
+  }
+
+  if (creating || editing) {
+    return (
+      <TeamMemberForm
+        member={editing || undefined}
+        onSave={handleSave}
+        onCancel={() => {
+          setEditing(null);
+          setCreating(false);
+        }}
+      />
+    );
+  }
+
+  const organizers = members.filter((m) => m.type === "organizer");
+  const teamMembers = members.filter((m) => m.type === "member");
+
+  return (
+    <div>
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+
+      <div className="mb-6 flex items-center justify-between">
+        <p className="text-sm text-gray-500">{members.length} miembros</p>
+        <button
+          onClick={() => setCreating(true)}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          + Agregar miembro
+        </button>
+      </div>
+
+      {[
+        { title: "Organizadores", items: organizers },
+        { title: "Miembros", items: teamMembers },
+      ].map((group) => (
+        <div key={group.title} className="mb-8">
+          <h3 className="mb-3 text-lg font-semibold text-gray-900">
+            {group.title} ({group.items.length})
+          </h3>
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                    Nombre
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                    Rol
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                    Bio
+                  </th>
+                  <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">
+                    Acciones
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {group.items.map((member) => (
+                  <tr key={member.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4">
+                      <div className="flex items-center gap-3">
+                        <img
+                          src={member.photo_url || "/placeholder.svg"}
+                          alt=""
+                          className="h-8 w-8 rounded-full object-cover"
+                        />
+                        <span className="font-medium text-gray-900">
+                          {member.name}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500">
+                      {member.role}
+                    </td>
+                    <td className="max-w-xs truncate px-6 py-4 text-sm text-gray-500">
+                      {member.bio}
+                    </td>
+                    <td className="px-6 py-4 text-right">
+                      <div className="flex justify-end gap-2">
+                        <button
+                          onClick={() => setEditing(member)}
+                          className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                        >
+                          Editar
+                        </button>
+                        <button
+                          onClick={() => handleDelete(member.id)}
+                          disabled={deleting === member.id}
+                          className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+                        >
+                          {deleting === member.id ? "..." : "Eliminar"}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/react/admin/team/TeamMemberForm.tsx
+++ b/src/components/react/admin/team/TeamMemberForm.tsx
@@ -1,0 +1,219 @@
+import { useState } from "react";
+import { FormField } from "../ui/FormField";
+
+interface TeamMember {
+  id: string;
+  name: string;
+  role: string;
+  photo_url: string;
+  bio: string;
+  social_links: Record<string, string>;
+  type: "organizer" | "member";
+  tags?: string[];
+}
+
+interface Props {
+  member?: TeamMember;
+  onSave: (member: TeamMember, isNew: boolean) => Promise<void>;
+  onCancel: () => void;
+}
+
+const EMPTY_MEMBER: TeamMember = {
+  id: "",
+  name: "",
+  role: "",
+  photo_url: "",
+  bio: "",
+  social_links: {},
+  type: "member",
+  tags: [],
+};
+
+export function TeamMemberForm({ member, onSave, onCancel }: Props) {
+  const [form, setForm] = useState<TeamMember>(member || EMPTY_MEMBER);
+  const [saving, setSaving] = useState(false);
+  const [tagInput, setTagInput] = useState("");
+  const isNew = !member;
+
+  function updateField(field: keyof TeamMember, value: unknown) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function updateSocialLink(key: string, value: string) {
+    setForm((prev) => ({
+      ...prev,
+      social_links: { ...prev.social_links, [key]: value },
+    }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    await onSave(form, isNew);
+    setSaving(false);
+  }
+
+  const inputClass =
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500";
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <button
+        onClick={onCancel}
+        className="mb-4 text-sm text-gray-500 hover:text-gray-700"
+      >
+        ← Volver a equipo
+      </button>
+
+      <h2 className="mb-6 text-xl font-bold text-gray-900">
+        {isNew ? "Agregar miembro" : `Editar: ${member?.name}`}
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField label="ID (slug)" required>
+              <input
+                type="text"
+                value={form.id}
+                onChange={(e) => updateField("id", e.target.value)}
+                placeholder="juan-perez"
+                className={inputClass}
+                disabled={!isNew}
+              />
+            </FormField>
+            <FormField label="Nombre" required>
+              <input
+                type="text"
+                value={form.name}
+                onChange={(e) => updateField("name", e.target.value)}
+                className={inputClass}
+              />
+            </FormField>
+            <FormField label="Rol">
+              <input
+                type="text"
+                value={form.role}
+                onChange={(e) => updateField("role", e.target.value)}
+                placeholder="Leadership, Technology, etc."
+                className={inputClass}
+              />
+            </FormField>
+            <FormField label="Tipo">
+              <select
+                value={form.type}
+                onChange={(e) =>
+                  updateField("type", e.target.value as "organizer" | "member")
+                }
+                className={inputClass}
+              >
+                <option value="organizer">Organizador</option>
+                <option value="member">Miembro</option>
+              </select>
+            </FormField>
+            <div className="sm:col-span-2">
+              <FormField label="Bio">
+                <textarea
+                  value={form.bio}
+                  onChange={(e) => updateField("bio", e.target.value)}
+                  rows={3}
+                  className={inputClass}
+                />
+              </FormField>
+            </div>
+            <div className="sm:col-span-2">
+              <FormField label="URL foto">
+                <input
+                  type="url"
+                  value={form.photo_url}
+                  onChange={(e) => updateField("photo_url", e.target.value)}
+                  className={inputClass}
+                />
+              </FormField>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <h3 className="mb-4 font-semibold text-gray-900">Redes sociales</h3>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {["linkedin", "github", "twitter", "web"].map((key) => (
+              <FormField key={key} label={key}>
+                <input
+                  type="url"
+                  value={form.social_links[key] || ""}
+                  onChange={(e) => updateSocialLink(key, e.target.value)}
+                  className={inputClass}
+                />
+              </FormField>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <h3 className="mb-4 font-semibold text-gray-900">Tags</h3>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  if (tagInput.trim()) {
+                    updateField("tags", [
+                      ...(form.tags || []),
+                      tagInput.trim(),
+                    ]);
+                    setTagInput("");
+                  }
+                }
+              }}
+              placeholder="Agregar tag y presionar Enter"
+              className={inputClass}
+            />
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {(form.tags || []).map((tag, i) => (
+              <span
+                key={i}
+                className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() =>
+                    updateField(
+                      "tags",
+                      (form.tags || []).filter((_, idx) => idx !== i)
+                    )
+                  }
+                  className="text-blue-600 hover:text-blue-800"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? "Guardando..." : isNew ? "Agregar" : "Actualizar"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,6 +43,20 @@ export const api = {
     request("PUT", `/events/${id}`, data),
   deleteEvent: (id: string) => request("DELETE", `/events/${id}`),
 
+  // Team
+  listTeam: () => request("GET", "/team"),
+  addTeamMember: (data: unknown) => request("POST", "/team", data),
+  updateTeamMember: (id: string, data: unknown) =>
+    request("PUT", `/team/${id}`, data),
+  deleteTeamMember: (id: string) => request("DELETE", `/team/${id}`),
+
+  // Speakers
+  listSpeakers: () => request("GET", "/speakers"),
+  addSpeaker: (data: unknown) => request("POST", "/speakers", data),
+  updateSpeaker: (id: string, data: unknown) =>
+    request("PUT", `/speakers/${id}`, data),
+  deleteSpeaker: (id: string) => request("DELETE", `/speakers/${id}`),
+
   // Users
   listUsers: () => request("GET", "/users"),
   updateUserRole: (uid: string, role: string) =>

--- a/src/pages/admin/equipo/index.astro
+++ b/src/pages/admin/equipo/index.astro
@@ -1,0 +1,8 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Equipo">
+  <AdminApp client:load page="team" currentPath="/admin/equipo" />
+</AdminLayout>

--- a/src/pages/admin/speakers/index.astro
+++ b/src/pages/admin/speakers/index.astro
@@ -1,0 +1,8 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Speakers">
+  <AdminApp client:load page="speakers" currentPath="/admin/speakers" />
+</AdminLayout>


### PR DESCRIPTION
## ✨ What this PR does

Agrega gestion completa de equipo y speakers en el admin panel.

**Backend (Cloud Functions):**
- `handlers/team.ts`: CRUD sobre `about/team.json` con audit log y rebuild
- `handlers/speakers.ts`: CRUD sobre `speakers/index.json` + archivos individuales

**Frontend:**
- `TeamList`: tabla agrupada por tipo (organizer/member) con crear/editar/eliminar
- `TeamMemberForm`: formulario con campos, redes sociales y tags dinamicos
- `SpeakerList`: tabla con formulario inline para crear/editar speakers
- Nuevas paginas: `/admin/equipo`, `/admin/speakers`

## 🔗 Related issue

None

## ✅ Checklist

- [x] Code tested locally (`pnpm build` + functions build + lint passing)
- [ ] Visual verification with Firebase deployed
