### PR TITLE
feat(admin): add sponsors, stats and user management

### DIFF
--- a/functions/src/handlers/sponsors.ts
+++ b/functions/src/handlers/sponsors.ts
@@ -1,0 +1,162 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { GitHubService } from "../services/github";
+import { GITHUB_TOKEN } from "../config";
+
+interface Sponsor {
+  name: string;
+  logo_url: string;
+  url: string;
+  sector: string;
+  description: string;
+  featured: boolean;
+  id?: string;
+  events_sponsored?: number;
+  since_year?: number;
+}
+
+export async function listSponsors(_req: Request, res: Response) {
+  try {
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const { data } = await github.getFileContent<Sponsor[]>(
+      "about/partners.json"
+    );
+    res.json({ success: true, data });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}
+
+export async function addSponsor(req: Request, res: Response) {
+  try {
+    const sponsor = req.body as Sponsor;
+    if (!sponsor.name) {
+      res
+        .status(400)
+        .json({ success: false, error: "Missing required field: name" });
+      return;
+    }
+
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    const { data: partners, sha } = await github.getFileContent<Sponsor[]>(
+      "about/partners.json"
+    );
+    partners.push(sponsor);
+
+    await github.putFile(
+      "about/partners.json",
+      JSON.stringify(partners, null, 2),
+      `feat(sponsors): add ${sponsor.name}`,
+      sha
+    );
+
+    await github.triggerRebuild();
+
+    await admin
+      .firestore()
+      .collection("audit_log")
+      .add({
+        action: "sponsor.create",
+        performedBy: user.uid,
+        targetId: sponsor.name,
+        targetType: "sponsor",
+        details: { name: sponsor.name },
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+    res.status(201).json({ success: true, data: { name: sponsor.name } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}
+
+export async function updateSponsor(req: Request, res: Response) {
+  try {
+    const sponsorId = req.params.id as string;
+    const updates = req.body as Sponsor;
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    const { data: partners, sha } = await github.getFileContent<Sponsor[]>(
+      "about/partners.json"
+    );
+
+    const index = partners.findIndex(
+      (p) => p.name === decodeURIComponent(sponsorId)
+    );
+    if (index === -1) {
+      res.status(404).json({ success: false, error: "Sponsor not found" });
+      return;
+    }
+
+    partners[index] = updates;
+
+    await github.putFile(
+      "about/partners.json",
+      JSON.stringify(partners, null, 2),
+      `fix(sponsors): update ${updates.name}`,
+      sha
+    );
+
+    await github.triggerRebuild();
+
+    await admin
+      .firestore()
+      .collection("audit_log")
+      .add({
+        action: "sponsor.update",
+        performedBy: user.uid,
+        targetId: updates.name,
+        targetType: "sponsor",
+        details: { name: updates.name },
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+    res.json({ success: true, data: { name: updates.name } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}
+
+export async function deleteSponsor(req: Request, res: Response) {
+  try {
+    const sponsorId = decodeURIComponent(req.params.id as string);
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    const { data: partners, sha } = await github.getFileContent<Sponsor[]>(
+      "about/partners.json"
+    );
+    const filtered = partners.filter((p) => p.name !== sponsorId);
+
+    if (filtered.length === partners.length) {
+      res.status(404).json({ success: false, error: "Sponsor not found" });
+      return;
+    }
+
+    await github.putFile(
+      "about/partners.json",
+      JSON.stringify(filtered, null, 2),
+      `chore(sponsors): remove ${sponsorId}`,
+      sha
+    );
+
+    await github.triggerRebuild();
+
+    await admin.firestore().collection("audit_log").add({
+      action: "sponsor.delete",
+      performedBy: user.uid,
+      targetId: sponsorId,
+      targetType: "sponsor",
+      details: {},
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}

--- a/functions/src/handlers/stats.ts
+++ b/functions/src/handlers/stats.ts
@@ -1,0 +1,54 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { GitHubService } from "../services/github";
+import { GITHUB_TOKEN } from "../config";
+
+export async function getStats(_req: Request, res: Response) {
+  try {
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const { data } =
+      await github.getFileContent<Record<string, unknown>>("about/stats.json");
+    res.json({ success: true, data });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}
+
+export async function updateStats(req: Request, res: Response) {
+  try {
+    const stats = req.body;
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    const { sha } =
+      await github.getFileContent<Record<string, unknown>>("about/stats.json");
+
+    const updated = {
+      ...stats,
+      updated_at: new Date().toISOString(),
+    };
+
+    await github.putFile(
+      "about/stats.json",
+      JSON.stringify(updated, null, 2),
+      "fix(stats): update community stats",
+      sha
+    );
+
+    await github.triggerRebuild();
+
+    await admin.firestore().collection("audit_log").add({
+      action: "stats.update",
+      performedBy: user.uid,
+      targetId: "stats",
+      targetType: "stats",
+      details: stats,
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    res.json({ success: true, data: updated });
+  } catch (err) {
+    res.status(500).json({ success: false, error: (err as Error).message });
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,8 @@ import { register } from "./handlers/auth";
 import * as events from "./handlers/events";
 import * as team from "./handlers/team";
 import * as speakers from "./handlers/speakers";
+import * as sponsors from "./handlers/sponsors";
+import * as stats from "./handlers/stats";
 import * as users from "./handlers/users";
 import { triggerRebuild } from "./handlers/rebuild";
 
@@ -38,6 +40,16 @@ app.get("/api/speakers", requireRole("organizer"), speakers.listSpeakers);
 app.post("/api/speakers", requireRole("organizer"), speakers.addSpeaker);
 app.put("/api/speakers/:id", requireRole("organizer"), speakers.updateSpeaker);
 app.delete("/api/speakers/:id", requireRole("admin"), speakers.deleteSpeaker);
+
+// Sponsors
+app.get("/api/sponsors", requireRole("admin"), sponsors.listSponsors);
+app.post("/api/sponsors", requireRole("admin"), sponsors.addSponsor);
+app.put("/api/sponsors/:id", requireRole("admin"), sponsors.updateSponsor);
+app.delete("/api/sponsors/:id", requireRole("admin"), sponsors.deleteSponsor);
+
+// Stats
+app.get("/api/stats", requireRole("organizer"), stats.getStats);
+app.put("/api/stats", requireRole("admin"), stats.updateStats);
 
 // Users
 app.get("/api/users", requireRole("admin"), users.listUsers);

--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -6,6 +6,9 @@ import { EventList } from "./events/EventList";
 import { EventForm } from "./events/EventForm";
 import { TeamList } from "./team/TeamList";
 import { SpeakerList } from "./speakers/SpeakerList";
+import { SponsorList } from "./sponsors/SponsorList";
+import { StatsEditor } from "./stats/StatsEditor";
+import { UserDirectory } from "./users/UserDirectory";
 
 interface Props {
   page: string;
@@ -62,6 +65,12 @@ function AdminContent({ page, currentPath }: Props) {
         return <TeamList />;
       case "speakers":
         return <SpeakerList />;
+      case "sponsors":
+        return <SponsorList />;
+      case "stats":
+        return <StatsEditor />;
+      case "users":
+        return <UserDirectory />;
       default:
         return <p className="text-gray-500">Pagina en construccion</p>;
     }

--- a/src/components/react/admin/sponsors/SponsorList.tsx
+++ b/src/components/react/admin/sponsors/SponsorList.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { Toast } from "../ui/Toast";
+import { FormField } from "../ui/FormField";
+
+interface Sponsor {
+  name: string;
+  logo_url: string;
+  url: string;
+  sector: string;
+  description: string;
+  featured: boolean;
+}
+
+const EMPTY_SPONSOR: Sponsor = {
+  name: "",
+  logo_url: "",
+  url: "",
+  sector: "",
+  description: "",
+  featured: false,
+};
+
+export function SponsorList() {
+  const [sponsors, setSponsors] = useState<Sponsor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+  const [editing, setEditing] = useState<Sponsor | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const form = editing || (creating ? EMPTY_SPONSOR : null);
+
+  useEffect(() => {
+    loadSponsors();
+  }, []);
+
+  async function loadSponsors() {
+    setLoading(true);
+    const res = await api.listSponsors();
+    if (res.success && res.data) {
+      setSponsors(res.data as Sponsor[]);
+    } else {
+      setError(res.error || "Error al cargar sponsors");
+    }
+    setLoading(false);
+  }
+
+  function updateForm(field: keyof Sponsor, value: unknown) {
+    if (editing) setEditing({ ...editing, [field]: value });
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form) return;
+    setSaving(true);
+    const isNew = creating;
+    const res = isNew
+      ? await api.addSponsor(form)
+      : await api.updateSponsor(form.name, form);
+
+    if (res.success) {
+      setToast({
+        message: `Sponsor ${isNew ? "agregado" : "actualizado"}`,
+        type: "success",
+      });
+      setEditing(null);
+      setCreating(false);
+      loadSponsors();
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setSaving(false);
+  }
+
+  async function handleDelete(name: string) {
+    if (!confirm(`Eliminar sponsor "${name}"?`)) return;
+    setDeleting(name);
+    const res = await api.deleteSponsor(name);
+    if (res.success) {
+      setSponsors((prev) => prev.filter((s) => s.name !== name));
+      setToast({ message: "Sponsor eliminado", type: "success" });
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setDeleting(null);
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+        {error}
+      </div>
+    );
+  }
+
+  const inputClass =
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500";
+
+  if (form) {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <button
+          onClick={() => {
+            setEditing(null);
+            setCreating(false);
+          }}
+          className="mb-4 text-sm text-gray-500 hover:text-gray-700"
+        >
+          ← Volver a sponsors
+        </button>
+        <h2 className="mb-6 text-xl font-bold text-gray-900">
+          {creating ? "Agregar sponsor" : `Editar: ${form.name}`}
+        </h2>
+        <form onSubmit={handleSave} className="space-y-6">
+          <div className="rounded-xl border border-gray-200 bg-white p-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormField label="Nombre" required>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => updateForm("name", e.target.value)}
+                  className={inputClass}
+                  disabled={!!editing}
+                />
+              </FormField>
+              <FormField label="Sector">
+                <input
+                  type="text"
+                  value={form.sector}
+                  onChange={(e) => updateForm("sector", e.target.value)}
+                  className={inputClass}
+                />
+              </FormField>
+              <div className="sm:col-span-2">
+                <FormField label="Descripcion">
+                  <textarea
+                    value={form.description}
+                    onChange={(e) => updateForm("description", e.target.value)}
+                    rows={3}
+                    className={inputClass}
+                  />
+                </FormField>
+              </div>
+              <FormField label="URL logo">
+                <input
+                  type="url"
+                  value={form.logo_url}
+                  onChange={(e) => updateForm("logo_url", e.target.value)}
+                  className={inputClass}
+                />
+              </FormField>
+              <FormField label="Website">
+                <input
+                  type="url"
+                  value={form.url}
+                  onChange={(e) => updateForm("url", e.target.value)}
+                  className={inputClass}
+                />
+              </FormField>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.featured}
+                  onChange={(e) => updateForm("featured", e.target.checked)}
+                  className="rounded"
+                />
+                Destacado
+              </label>
+            </div>
+          </div>
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                setEditing(null);
+                setCreating(false);
+              }}
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {saving ? "Guardando..." : creating ? "Agregar" : "Actualizar"}
+            </button>
+          </div>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+      <div className="mb-6 flex items-center justify-between">
+        <p className="text-sm text-gray-500">{sponsors.length} sponsors</p>
+        <button
+          onClick={() => {
+            setCreating(true);
+            setEditing({ ...EMPTY_SPONSOR });
+          }}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          + Agregar sponsor
+        </button>
+      </div>
+      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Sponsor
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Sector
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Estado
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Acciones
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {sponsors.map((sponsor) => (
+              <tr key={sponsor.name} className="hover:bg-gray-50">
+                <td className="px-6 py-4">
+                  <p className="font-medium text-gray-900">{sponsor.name}</p>
+                </td>
+                <td className="px-6 py-4 text-sm text-gray-500">
+                  {sponsor.sector}
+                </td>
+                <td className="px-6 py-4">
+                  {sponsor.featured && (
+                    <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">
+                      Destacado
+                    </span>
+                  )}
+                </td>
+                <td className="px-6 py-4 text-right">
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => setEditing(sponsor)}
+                      className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      onClick={() => handleDelete(sponsor.name)}
+                      disabled={deleting === sponsor.name}
+                      className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+                    >
+                      {deleting === sponsor.name ? "..." : "Eliminar"}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/stats/StatsEditor.tsx
+++ b/src/components/react/admin/stats/StatsEditor.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { FormField } from "../ui/FormField";
+import { Toast } from "../ui/Toast";
+
+interface Stats {
+  total_members: number;
+  total_events: number;
+  total_talks: number;
+  total_speakers: number;
+  years_active: number;
+  total_organizers: number;
+  developers_mentored: number;
+  total_sponsors: number;
+  annual_support: string;
+  sponsored_events: number;
+  developers_reached: number;
+  active_volunteers: number;
+  volunteer_hours: number;
+  events_supported: number;
+  volunteer_areas: number;
+  updated_at: string;
+}
+
+const FIELDS: { key: keyof Stats; label: string; type: "number" | "text" }[] = [
+  { key: "total_members", label: "Total miembros", type: "number" },
+  { key: "total_events", label: "Total eventos", type: "number" },
+  { key: "total_talks", label: "Total charlas", type: "number" },
+  { key: "total_speakers", label: "Total speakers", type: "number" },
+  { key: "years_active", label: "Anos activos", type: "number" },
+  { key: "total_organizers", label: "Total organizadores", type: "number" },
+  { key: "developers_mentored", label: "Devs mentoreados", type: "number" },
+  { key: "total_sponsors", label: "Total sponsors", type: "number" },
+  { key: "annual_support", label: "Apoyo anual", type: "text" },
+  { key: "sponsored_events", label: "Eventos patrocinados", type: "number" },
+  { key: "developers_reached", label: "Devs alcanzados", type: "number" },
+  { key: "active_volunteers", label: "Voluntarios activos", type: "number" },
+  { key: "volunteer_hours", label: "Horas voluntariado", type: "number" },
+  { key: "events_supported", label: "Eventos apoyados", type: "number" },
+  { key: "volunteer_areas", label: "Areas de apoyo", type: "number" },
+];
+
+export function StatsEditor() {
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+
+  useEffect(() => {
+    api.getStats().then((res) => {
+      if (res.success && res.data) {
+        setStats(res.data as Stats);
+      }
+      setLoading(false);
+    });
+  }, []);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!stats) return;
+    setSaving(true);
+    const res = await api.updateStats(stats);
+    if (res.success) {
+      setToast({
+        message: "Stats actualizados. El sitio se reconstruira en ~2-3 min.",
+        type: "success",
+      });
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setSaving(false);
+  }
+
+  if (loading || !stats) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  const inputClass =
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500";
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+
+      <p className="mb-6 text-sm text-gray-500">
+        Estos valores se muestran en las paginas publicas del sitio. Ultima
+        actualizacion: {new Date(stats.updated_at).toLocaleDateString("es-PE")}
+      </p>
+
+      <form onSubmit={handleSave} className="space-y-6">
+        <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <div className="grid gap-4 sm:grid-cols-3">
+            {FIELDS.map(({ key, label, type }) => (
+              <FormField key={key} label={label}>
+                <input
+                  type={type}
+                  value={stats[key]}
+                  onChange={(e) =>
+                    setStats({
+                      ...stats,
+                      [key]:
+                        type === "number"
+                          ? parseInt(e.target.value) || 0
+                          : e.target.value,
+                    })
+                  }
+                  className={inputClass}
+                />
+              </FormField>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? "Guardando..." : "Actualizar stats"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/react/admin/users/UserDirectory.tsx
+++ b/src/components/react/admin/users/UserDirectory.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { Toast } from "../ui/Toast";
+import { useAuth } from "../AuthProvider";
+
+interface UserEntry {
+  uid: string;
+  email: string;
+  displayName: string;
+  photoURL: string;
+  role: string;
+  lastLoginAt: { _seconds: number };
+}
+
+const ROLES = ["member", "organizer", "admin"] as const;
+
+export function UserDirectory() {
+  const { isAdmin } = useAuth();
+  const [users, setUsers] = useState<UserEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+  const [changingRole, setChangingRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  async function loadUsers() {
+    setLoading(true);
+    const res = await api.listUsers();
+    if (res.success && res.data) {
+      setUsers(res.data as UserEntry[]);
+    } else {
+      setError(res.error || "Error al cargar usuarios");
+    }
+    setLoading(false);
+  }
+
+  async function handleRoleChange(uid: string, newRole: string) {
+    if (
+      !confirm(
+        `Cambiar rol a "${newRole}"? Esto afecta los permisos del usuario.`
+      )
+    )
+      return;
+
+    setChangingRole(uid);
+    const res = await api.updateUserRole(uid, newRole);
+    if (res.success) {
+      setUsers((prev) =>
+        prev.map((u) => (u.uid === uid ? { ...u, role: newRole } : u))
+      );
+      setToast({ message: "Rol actualizado", type: "success" });
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setChangingRole(null);
+  }
+
+  function formatDate(timestamp: { _seconds: number } | undefined) {
+    if (!timestamp?._seconds) return "-";
+    return new Date(timestamp._seconds * 1000).toLocaleDateString("es-PE");
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+
+      <p className="mb-6 text-sm text-gray-500">
+        {users.length} usuarios registrados
+      </p>
+
+      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Usuario
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Email
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Rol
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                Ultimo login
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {users.map((user) => (
+              <tr key={user.uid} className="hover:bg-gray-50">
+                <td className="px-6 py-4">
+                  <div className="flex items-center gap-3">
+                    {user.photoURL && (
+                      <img
+                        src={user.photoURL}
+                        alt=""
+                        className="h-8 w-8 rounded-full"
+                      />
+                    )}
+                    <span className="font-medium text-gray-900">
+                      {user.displayName}
+                    </span>
+                  </div>
+                </td>
+                <td className="px-6 py-4 text-sm text-gray-500">
+                  {user.email}
+                </td>
+                <td className="px-6 py-4">
+                  {isAdmin ? (
+                    <select
+                      value={user.role}
+                      onChange={(e) =>
+                        handleRoleChange(user.uid, e.target.value)
+                      }
+                      disabled={changingRole === user.uid}
+                      className="rounded border border-gray-300 px-2 py-1 text-sm disabled:opacity-50"
+                    >
+                      {ROLES.map((r) => (
+                        <option key={r} value={r}>
+                          {r}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                      {user.role}
+                    </span>
+                  )}
+                </td>
+                <td className="px-6 py-4 text-sm text-gray-500">
+                  {formatDate(user.lastLoginAt)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -57,6 +57,18 @@ export const api = {
     request("PUT", `/speakers/${id}`, data),
   deleteSpeaker: (id: string) => request("DELETE", `/speakers/${id}`),
 
+  // Sponsors
+  listSponsors: () => request("GET", "/sponsors"),
+  addSponsor: (data: unknown) => request("POST", "/sponsors", data),
+  updateSponsor: (id: string, data: unknown) =>
+    request("PUT", `/sponsors/${encodeURIComponent(id)}`, data),
+  deleteSponsor: (id: string) =>
+    request("DELETE", `/sponsors/${encodeURIComponent(id)}`),
+
+  // Stats
+  getStats: () => request("GET", "/stats"),
+  updateStats: (data: unknown) => request("PUT", "/stats", data),
+
   // Users
   listUsers: () => request("GET", "/users"),
   updateUserRole: (uid: string, role: string) =>

--- a/src/pages/admin/sponsors/index.astro
+++ b/src/pages/admin/sponsors/index.astro
@@ -1,0 +1,8 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Sponsors">
+  <AdminApp client:load page="sponsors" currentPath="/admin/sponsors" />
+</AdminLayout>

--- a/src/pages/admin/stats/index.astro
+++ b/src/pages/admin/stats/index.astro
@@ -1,0 +1,8 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Stats">
+  <AdminApp client:load page="stats" currentPath="/admin/stats" />
+</AdminLayout>

--- a/src/pages/admin/usuarios/index.astro
+++ b/src/pages/admin/usuarios/index.astro
@@ -1,0 +1,8 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Usuarios">
+  <AdminApp client:load page="users" currentPath="/admin/usuarios" />
+</AdminLayout>


### PR DESCRIPTION
## ✨ What this PR does

Completa el admin panel con gestion de sponsors, editor de stats y directorio de usuarios.

**Backend (Cloud Functions):**
- `handlers/sponsors.ts`: CRUD sobre `about/partners.json`
- `handlers/stats.ts`: lectura y actualizacion de `about/stats.json`

**Frontend:**
- `SponsorList`: tabla con formulario inline para crear/editar sponsors
- `StatsEditor`: formulario con todos los campos de metricas de la comunidad
- `UserDirectory`: tabla de usuarios registrados con dropdown para cambiar roles (solo admin)
- Nuevas paginas: `/admin/sponsors`, `/admin/stats`, `/admin/usuarios`

## 🔗 Related issue

None

## ✅ Checklist

- [x] Code tested locally (build + lint passing)
- [x] Visual verification with Firebase deployed
