### PR TITLE
fix(admin): import global CSS in admin layout

### DIFF
--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,4 +1,6 @@
 ---
+import "@/styles/global.css";
+
 interface Props {
   title: string;
 }


### PR DESCRIPTION
## ✨ What this PR does

Agrega `import "@/styles/global.css"` al AdminLayout para que TailwindCSS se cargue en las paginas admin.

## 🔗 Related issue

None

## ✅ Checklist

- [x] Code tested locally
