### PR TITLE
fix(ci): add --force flag to firebase deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
-          firebase deploy --only "hosting:gdgica,functions,firestore:rules"
+          firebase deploy --only "hosting:gdgica,functions,firestore:rules" --force


### PR DESCRIPTION
## ✨ What this PR does

Agrega `--force` al comando de deploy de Firebase para que configure automaticamente la politica de limpieza de imagenes de Cloud Functions.

## 🔗 Related issue

None

## ✅ Checklist

- [x] Fix for CI deploy error
