### PR TITLE
fix(functions): allow public invocation of Cloud Function

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -58,4 +58,7 @@ app.patch("/api/users/:uid/role", requireRole("admin"), users.updateRole);
 // Rebuild
 app.post("/api/rebuild", requireRole("admin"), triggerRebuild);
 
-export const api = onRequest({ secrets: [GITHUB_TOKEN] }, app);
+export const api = onRequest(
+  { secrets: [GITHUB_TOKEN], invoker: "public" },
+  app
+);


### PR DESCRIPTION
## ✨ What this PR does

Agrega `invoker: "public"` a la Cloud Function para que Cloud Run permita requests HTTP sin autenticacion IAM. La autenticacion se maneja en el middleware de Express con Firebase Auth tokens.

Sin esto, todas las requests a `/api/*` devuelven 403 Forbidden antes de llegar al codigo.

## 🔗 Related issue

None

## ✅ Checklist

- [x] Code tested locally (functions build passing)
