### PR TITLE
fix(functions): enable trust proxy and fix rate limiter errors

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -25,6 +25,7 @@ const ALLOWED_ORIGINS = [
 ];
 
 const app = express();
+app.set("trust proxy", true);
 app.use(
   cors({
     origin: (origin, callback) => {
@@ -43,6 +44,7 @@ app.use(
     max: 100,
     standardHeaders: true,
     legacyHeaders: false,
+    validate: { trustProxy: false, xForwardedForHeader: false },
     message: { success: false, error: "Too many requests, try again later" },
   })
 );


### PR DESCRIPTION
## ✨ What this PR does

Corrige error 500 en todos los endpoints API. El rate limiter lanzaba `ValidationError` porque Cloud Run pone `X-Forwarded-For` pero Express no tenia `trust proxy` habilitado.

- Agrega `app.set("trust proxy", true)` para que Express confie en los headers del proxy
- Deshabilita validaciones del rate limiter que conflictuan con Cloud Run

## 🔗 Related issue

None

## ✅ Checklist

- [x] Functions build passing
- [ ] Verify team update works after deploy
