### PR TITLE
fix(functions): make rebuild and audit log non-blocking

### DIFF
--- a/functions/src/handlers/events.ts
+++ b/functions/src/handlers/events.ts
@@ -109,10 +109,10 @@ export async function createEvent(req: Request, res: Response) {
     );
 
     // Trigger rebuild
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
     // Audit log
-    await admin
+    admin
       .firestore()
       .collection("audit_log")
       .add({
@@ -163,9 +163,9 @@ export async function updateEvent(req: Request, res: Response) {
       indexSha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin
+    admin
       .firestore()
       .collection("audit_log")
       .add({
@@ -210,9 +210,9 @@ export async function deleteEvent(req: Request, res: Response) {
       indexSha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin.firestore().collection("audit_log").add({
+    admin.firestore().collection("audit_log").add({
       action: "event.delete",
       performedBy: user.uid,
       targetId: eventId,

--- a/functions/src/handlers/speakers.ts
+++ b/functions/src/handlers/speakers.ts
@@ -61,9 +61,9 @@ export async function addSpeaker(req: Request, res: Response) {
       sha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin
+    admin
       .firestore()
       .collection("audit_log")
       .add({
@@ -111,9 +111,9 @@ export async function updateSpeaker(req: Request, res: Response) {
       indexSha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin
+    admin
       .firestore()
       .collection("audit_log")
       .add({
@@ -159,9 +159,9 @@ export async function deleteSpeaker(req: Request, res: Response) {
       indexSha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin.firestore().collection("audit_log").add({
+    admin.firestore().collection("audit_log").add({
       action: "speaker.delete",
       performedBy: user.uid,
       targetId: speakerId,

--- a/functions/src/handlers/sponsors.ts
+++ b/functions/src/handlers/sponsors.ts
@@ -59,9 +59,9 @@ export async function addSponsor(req: Request, res: Response) {
       sha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin
+    admin
       .firestore()
       .collection("audit_log")
       .add({
@@ -110,9 +110,9 @@ export async function updateSponsor(req: Request, res: Response) {
       sha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin
+    admin
       .firestore()
       .collection("audit_log")
       .add({
@@ -153,9 +153,9 @@ export async function deleteSponsor(req: Request, res: Response) {
       sha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin.firestore().collection("audit_log").add({
+    admin.firestore().collection("audit_log").add({
       action: "sponsor.delete",
       performedBy: user.uid,
       targetId: sponsorId,

--- a/functions/src/handlers/stats.ts
+++ b/functions/src/handlers/stats.ts
@@ -37,9 +37,9 @@ export async function updateStats(req: Request, res: Response) {
       sha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin.firestore().collection("audit_log").add({
+    admin.firestore().collection("audit_log").add({
       action: "stats.update",
       performedBy: user.uid,
       targetId: "stats",

--- a/functions/src/handlers/team.ts
+++ b/functions/src/handlers/team.ts
@@ -53,9 +53,9 @@ export async function addTeamMember(req: Request, res: Response) {
       sha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin
+    admin
       .firestore()
       .collection("audit_log")
       .add({
@@ -97,9 +97,9 @@ export async function updateTeamMember(req: Request, res: Response) {
       sha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin
+    admin
       .firestore()
       .collection("audit_log")
       .add({
@@ -139,9 +139,9 @@ export async function deleteTeamMember(req: Request, res: Response) {
       sha
     );
 
-    await github.triggerRebuild();
+    github.triggerRebuild().catch(() => {});
 
-    await admin.firestore().collection("audit_log").add({
+    admin.firestore().collection("audit_log").add({
       action: "team.delete",
       performedBy: user.uid,
       targetId: memberId,


### PR DESCRIPTION
## ✨ What this PR does

Hace que `triggerRebuild()` y las escrituras a `audit_log` sean fire-and-forget (no bloquean la respuesta al cliente).

**Antes:** La API esperaba a que GitHub dispatch + audit log terminen → timeout → 500
**Ahora:** La API responde inmediatamente despues de escribir en gdg-ica-data. El rebuild y el log se ejecutan en background.

Esto afecta: events, team, speakers, sponsors, stats handlers.
No afecta: users (queries que necesitan completarse) ni rebuild.ts (endpoint explicito).

## 🔗 Related issue

None

## ✅ Checklist

- [x] Functions build passing
- [x] Verify team/event updates respond without timeout
