### PR TITLE
fix(functions): build user object from token instead of Firestore

### DIFF
--- a/functions/src/middleware/auth.ts
+++ b/functions/src/middleware/auth.ts
@@ -40,7 +40,15 @@ export function requireRole(minimumRole: Role) {
         res.status(403).json({ success: false, error: "Invalid user data" });
         return;
       }
-      const user = userData as UserDocument;
+      const user: UserDocument = {
+        uid: decoded.uid,
+        email: decoded.email || userData.email || "",
+        displayName: decoded.name || userData.displayName || "",
+        photoURL: decoded.picture || userData.photoURL || "",
+        role: userData.role,
+        createdAt: userData.createdAt,
+        lastLoginAt: userData.lastLoginAt,
+      };
 
       if (ROLE_HIERARCHY[user.role] < ROLE_HIERARCHY[minimumRole]) {
         res


### PR DESCRIPTION
## ✨ What this PR does

Corrige error 500 en operaciones de escritura (team update, event create, etc.).

**Causa raiz:** El middleware `requireRole` hacia `userDoc.data() as UserDocument`, pero si el documento en Firestore no tenia todos los campos (ej: solo `role`), `user.uid` era `undefined`. Esto causaba que Firestore rechazara la escritura del audit log con "Cannot use undefined as a Firestore value".

**Fix:** Ahora construye el `UserDocument` usando el `uid` del token decodificado (siempre disponible) y complementa con datos de Firestore. Nunca mas depende de que el doc tenga todos los campos.

## 🔗 Related issue

None

## ✅ Checklist

- [x] Functions build passing
- [x] User document in Firestore fixed manually
- [x] Verify team update works after deploy
