### PR TITLE
fix(admin): convert image URLs to relative paths for display

### DIFF
--- a/src/components/react/admin/speakers/SpeakerList.tsx
+++ b/src/components/react/admin/speakers/SpeakerList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
+import { toImagePath } from "@/lib/image";
 import { Toast } from "../ui/Toast";
 import { FormField } from "../ui/FormField";
 
@@ -328,7 +329,7 @@ export function SpeakerList() {
                 <td className="px-6 py-4">
                   <div className="flex items-center gap-3">
                     <img
-                      src={speaker.photo_url || "/placeholder.svg"}
+                      src={toImagePath(speaker.photo_url)}
                       alt=""
                       className="h-8 w-8 rounded-full object-cover"
                     />

--- a/src/components/react/admin/team/TeamList.tsx
+++ b/src/components/react/admin/team/TeamList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
+import { toImagePath } from "@/lib/image";
 import { Toast } from "../ui/Toast";
 import { TeamMemberForm } from "./TeamMemberForm";
 
@@ -156,7 +157,7 @@ export function TeamList() {
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-3">
                         <img
-                          src={member.photo_url || "/placeholder.svg"}
+                          src={toImagePath(member.photo_url)}
                           alt=""
                           className="h-8 w-8 rounded-full object-cover"
                         />

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,0 +1,9 @@
+/**
+ * Converts a full image URL to a relative path for display.
+ * gdg-ica-data stores URLs as https://gdgxica.github.io/speakers/x.webp
+ * but images are served from the current domain (gdgica.com).
+ */
+export function toImagePath(url: string | null | undefined): string {
+  if (!url) return "/placeholder.svg";
+  return url.replace("https://gdgxica.github.io", "");
+}


### PR DESCRIPTION
## ✨ What this PR does

Las imagenes en el admin (speakers, team) mostraban 404 porque renderizaban la URL completa `https://gdgxica.github.io/speakers/x.webp` pero las imagenes se sirven desde `gdgica.com`.

- Agrega `src/lib/image.ts` con `toImagePath()` que convierte URLs a paths relativos
- Actualiza `SpeakerList` y `TeamList` para usar `toImagePath()`

## 🔗 Related issue

None

## ✅ Checklist

- [x] Build + lint passing
