### PR TITLE
feat(admin): add dark mode to admin panel

### DIFF
--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -32,23 +32,23 @@ function AdminContent({ page, currentPath }: Props) {
 
   if (!isOrganizer) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <div className="max-w-md rounded-xl bg-white p-8 text-center shadow-lg">
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
+        <div className="max-w-md rounded-xl bg-white p-8 text-center shadow-lg dark:bg-gray-800">
           <p className="text-4xl">🔒</p>
-          <h1 className="mt-4 text-xl font-bold text-gray-900">
+          <h1 className="mt-4 text-xl font-bold text-gray-900 dark:text-white">
             Acceso restringido
           </h1>
-          <p className="mt-2 text-gray-600">
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
             Solo organizadores y administradores pueden acceder al panel de
             administracion.
           </p>
-          <p className="mt-2 text-sm text-gray-400">
+          <p className="mt-2 text-sm text-gray-400 dark:text-gray-500">
             Sesion: {user.email} (rol: {role})
           </p>
           <div className="mt-6 flex justify-center gap-3">
             <button
               onClick={signOut}
-              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
             >
               Cerrar sesion
             </button>
@@ -83,7 +83,11 @@ function AdminContent({ page, currentPath }: Props) {
       case "users":
         return <UserDirectory />;
       default:
-        return <p className="text-gray-500">Pagina en construccion</p>;
+        return (
+          <p className="text-gray-500 dark:text-gray-400">
+            Pagina en construccion
+          </p>
+        );
     }
   };
 

--- a/src/components/react/admin/AdminShell.tsx
+++ b/src/components/react/admin/AdminShell.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { useAuth } from "./AuthProvider";
 
 const NAV_ITEMS = [
@@ -17,17 +18,33 @@ interface Props {
 
 export function AdminShell({ currentPage, children }: Props) {
   const { user, role, signOut, isAdmin } = useAuth();
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    setDark(document.documentElement.classList.contains("dark"));
+  }, []);
+
+  function toggleTheme() {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("admin-theme", next ? "dark" : "light");
+  }
 
   const visibleItems = NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin);
 
   return (
-    <div className="flex min-h-screen bg-gray-50">
-      <aside className="hidden w-64 border-r border-gray-200 bg-white lg:block">
-        <div className="flex h-16 items-center gap-3 border-b border-gray-200 px-6">
+    <div className="flex min-h-screen bg-gray-50 dark:bg-gray-900">
+      <aside className="hidden w-64 border-r border-gray-200 bg-white lg:block dark:border-gray-700 dark:bg-gray-800">
+        <div className="flex h-16 items-center gap-3 border-b border-gray-200 px-6 dark:border-gray-700">
           <img src="/gdg-logo.png" alt="GDG ICA" className="h-8 w-8" />
           <div>
-            <p className="text-sm font-bold text-gray-900">GDG ICA</p>
-            <p className="text-xs text-gray-500">Admin Panel</p>
+            <p className="text-sm font-bold text-gray-900 dark:text-white">
+              GDG ICA
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Admin Panel
+            </p>
           </div>
         </div>
         <nav className="p-4">
@@ -38,8 +55,8 @@ export function AdminShell({ currentPage, children }: Props) {
                   href={item.href}
                   className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                     currentPage === item.href
-                      ? "bg-blue-50 text-blue-700"
-                      : "text-gray-700 hover:bg-gray-100"
+                      ? "bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                      : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
                   }`}
                 >
                   <span>{item.icon}</span>
@@ -49,10 +66,16 @@ export function AdminShell({ currentPage, children }: Props) {
             ))}
           </ul>
         </nav>
-        <div className="absolute bottom-0 w-64 border-t border-gray-200 p-4">
+        <div className="absolute bottom-0 w-64 space-y-3 border-t border-gray-200 p-4 dark:border-gray-700">
+          <button
+            onClick={toggleTheme}
+            className="flex w-full items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            {dark ? "☀️ Modo claro" : "🌙 Modo oscuro"}
+          </button>
           <a
             href="/"
-            className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700"
+            className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
           >
             ← Volver al sitio
           </a>
@@ -60,19 +83,25 @@ export function AdminShell({ currentPage, children }: Props) {
       </aside>
 
       <div className="flex flex-1 flex-col">
-        <header className="flex h-16 items-center justify-between border-b border-gray-200 bg-white px-6">
-          <h1 className="text-lg font-semibold text-gray-900">
+        <header className="flex h-16 items-center justify-between border-b border-gray-200 bg-white px-6 dark:border-gray-700 dark:bg-gray-800">
+          <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
             {currentPage === "/admin"
               ? "Dashboard"
               : visibleItems.find((i) => i.href === currentPage)?.label ||
                 "Admin"}
           </h1>
           <div className="flex items-center gap-4">
-            <div className="text-right">
-              <p className="text-sm font-medium text-gray-900">
+            <button
+              onClick={toggleTheme}
+              className="rounded-lg px-2 py-1.5 text-sm text-gray-600 transition-colors hover:bg-gray-100 lg:hidden dark:text-gray-400 dark:hover:bg-gray-700"
+            >
+              {dark ? "☀️" : "🌙"}
+            </button>
+            <div className="hidden text-right sm:block">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">
                 {user?.displayName}
               </p>
-              <p className="text-xs text-gray-500">{role}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">{role}</p>
             </div>
             {user?.photoURL && (
               <img
@@ -83,7 +112,7 @@ export function AdminShell({ currentPage, children }: Props) {
             )}
             <button
               onClick={signOut}
-              className="rounded-lg px-3 py-1.5 text-sm text-gray-600 transition-colors hover:bg-gray-100"
+              className="rounded-lg px-3 py-1.5 text-sm text-gray-600 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
             >
               Salir
             </button>

--- a/src/components/react/admin/Dashboard.tsx
+++ b/src/components/react/admin/Dashboard.tsx
@@ -10,17 +10,17 @@ export function Dashboard() {
 
   return (
     <div className="space-y-8">
-      <div className="rounded-xl border border-blue-100 bg-blue-50 p-6">
-        <h2 className="text-xl font-bold text-gray-900">
+      <div className="rounded-xl border border-blue-100 bg-blue-50 p-6 dark:border-blue-800 dark:bg-blue-900/30">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-white">
           Bienvenido, {user?.displayName}
         </h2>
-        <p className="mt-1 text-gray-600">
+        <p className="mt-1 text-gray-600 dark:text-gray-400">
           Rol: <span className="font-medium capitalize">{role}</span>
         </p>
       </div>
 
       <div>
-        <h3 className="mb-4 text-lg font-semibold text-gray-900">
+        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
           Acciones rapidas
         </h3>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -28,10 +28,12 @@ export function Dashboard() {
             <a
               key={link.href}
               href={link.href}
-              className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white p-4 transition-shadow hover:shadow-md"
+              className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white p-4 transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
             >
               <span className="text-2xl">{link.icon}</span>
-              <span className="font-medium text-gray-900">{link.label}</span>
+              <span className="font-medium text-gray-900 dark:text-white">
+                {link.label}
+              </span>
             </a>
           ))}
         </div>

--- a/src/components/react/admin/LoginScreen.tsx
+++ b/src/components/react/admin/LoginScreen.tsx
@@ -5,31 +5,31 @@ export function LoginScreen() {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-screen items-center justify-center dark:bg-gray-900">
         <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
       </div>
     );
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-lg">
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
+      <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-lg dark:bg-gray-800">
         <div className="mb-8 text-center">
           <img
             src="/gdg-logo.png"
             alt="GDG ICA"
             className="mx-auto mb-4 h-16 w-16"
           />
-          <h1 className="text-2xl font-bold text-gray-900">
-            Panel de Administración
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            Panel de Administracion
           </h1>
-          <p className="mt-2 text-gray-600">
-            Inicia sesión para gestionar el contenido de GDG ICA
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            Inicia sesion para gestionar el contenido de GDG ICA
           </p>
         </div>
         <button
           onClick={signIn}
-          className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50"
+          className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
         >
           <svg className="h-5 w-5" viewBox="0 0 24 24">
             <path
@@ -49,9 +49,9 @@ export function LoginScreen() {
               fill="#EA4335"
             />
           </svg>
-          Iniciar sesión con Google
+          Iniciar sesion con Google
         </button>
-        <p className="mt-6 text-center text-sm text-gray-500">
+        <p className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
           Solo organizadores y administradores pueden acceder
         </p>
       </div>

--- a/src/components/react/admin/events/EventForm.tsx
+++ b/src/components/react/admin/events/EventForm.tsx
@@ -155,7 +155,7 @@ export function EventForm() {
   }
 
   const inputClass =
-    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500";
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400";
 
   return (
     <div className="mx-auto max-w-3xl">
@@ -170,15 +170,15 @@ export function EventForm() {
       <div className="mb-6 flex items-center gap-4">
         <a
           href="/admin/eventos"
-          className="text-sm text-gray-500 hover:text-gray-700"
+          className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
         >
           ← Volver a eventos
         </a>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
-          <h3 className="mb-4 font-semibold text-gray-900">
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-4 font-semibold text-gray-900 dark:text-white">
             Informacion basica
           </h3>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -226,8 +226,10 @@ export function EventForm() {
           </div>
         </div>
 
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
-          <h3 className="mb-4 font-semibold text-gray-900">Fecha y lugar</h3>
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-4 font-semibold text-gray-900 dark:text-white">
+            Fecha y lugar
+          </h3>
           <div className="grid gap-4 sm:grid-cols-2">
             <FormField label="Fecha y hora" required>
               <input
@@ -279,7 +281,7 @@ export function EventForm() {
               />
             </FormField>
             <div className="flex items-center gap-4">
-              <label className="flex items-center gap-2 text-sm">
+              <label className="flex items-center gap-2 text-sm dark:text-gray-300">
                 <input
                   type="checkbox"
                   checked={form.is_virtual}
@@ -288,7 +290,7 @@ export function EventForm() {
                 />
                 Virtual
               </label>
-              <label className="flex items-center gap-2 text-sm">
+              <label className="flex items-center gap-2 text-sm dark:text-gray-300">
                 <input
                   type="checkbox"
                   checked={form.is_highlight}
@@ -303,8 +305,10 @@ export function EventForm() {
           </div>
         </div>
 
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
-          <h3 className="mb-4 font-semibold text-gray-900">Detalles</h3>
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-4 font-semibold text-gray-900 dark:text-white">
+            Detalles
+          </h3>
           <div className="grid gap-4 sm:grid-cols-2">
             <FormField label="Categoria">
               <select
@@ -367,8 +371,10 @@ export function EventForm() {
           </div>
         </div>
 
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
-          <h3 className="mb-4 font-semibold text-gray-900">Topics</h3>
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-4 font-semibold text-gray-900 dark:text-white">
+            Topics
+          </h3>
           <div className="flex gap-2">
             <input
               type="text"
@@ -389,13 +395,13 @@ export function EventForm() {
             {form.topics.map((topic, i) => (
               <span
                 key={i}
-                className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800"
+                className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
               >
                 {topic}
                 <button
                   type="button"
                   onClick={() => removeFromList("topics", i)}
-                  className="text-blue-600 hover:text-blue-800"
+                  className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
                 >
                   ×
                 </button>
@@ -404,8 +410,10 @@ export function EventForm() {
           </div>
         </div>
 
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
-          <h3 className="mb-4 font-semibold text-gray-900">Requisitos</h3>
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-4 font-semibold text-gray-900 dark:text-white">
+            Requisitos
+          </h3>
           <div className="flex gap-2">
             <input
               type="text"
@@ -426,13 +434,13 @@ export function EventForm() {
             {form.requirements.map((req, i) => (
               <li
                 key={i}
-                className="flex items-center justify-between rounded bg-gray-50 px-3 py-1 text-sm"
+                className="flex items-center justify-between rounded bg-gray-50 px-3 py-1 text-sm dark:bg-gray-900"
               >
                 {req}
                 <button
                   type="button"
                   onClick={() => removeFromList("requirements", i)}
-                  className="text-red-500 hover:text-red-700"
+                  className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
                 >
                   ×
                 </button>
@@ -441,8 +449,10 @@ export function EventForm() {
           </ul>
         </div>
 
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
-          <h3 className="mb-4 font-semibold text-gray-900">Incluye</h3>
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-4 font-semibold text-gray-900 dark:text-white">
+            Incluye
+          </h3>
           <div className="flex gap-2">
             <input
               type="text"
@@ -463,13 +473,13 @@ export function EventForm() {
             {form.includes.map((item, i) => (
               <li
                 key={i}
-                className="flex items-center justify-between rounded bg-gray-50 px-3 py-1 text-sm"
+                className="flex items-center justify-between rounded bg-gray-50 px-3 py-1 text-sm dark:bg-gray-900"
               >
                 {item}
                 <button
                   type="button"
                   onClick={() => removeFromList("includes", i)}
-                  className="text-red-500 hover:text-red-700"
+                  className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
                 >
                   ×
                 </button>
@@ -481,7 +491,7 @@ export function EventForm() {
         <div className="flex justify-end gap-3">
           <a
             href="/admin/eventos"
-            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             Cancelar
           </a>

--- a/src/components/react/admin/events/EventList.tsx
+++ b/src/components/react/admin/events/EventList.tsx
@@ -61,7 +61,7 @@ export function EventList() {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
         {error}
       </div>
     );
@@ -78,7 +78,9 @@ export function EventList() {
       )}
 
       <div className="mb-6 flex items-center justify-between">
-        <p className="text-sm text-gray-500">{events.length} eventos</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {events.length} eventos
+        </p>
         <a
           href="/admin/eventos/nuevo"
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
@@ -87,49 +89,56 @@ export function EventList() {
         </a>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Evento
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Fecha
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Sede
               </th>
-              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Acciones
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
             {events.map((event) => (
-              <tr key={event.id} className="hover:bg-gray-50">
+              <tr
+                key={event.id}
+                className="hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
                 <td className="px-6 py-4">
-                  <p className="font-medium text-gray-900">{event.title}</p>
-                  <p className="text-sm text-gray-500">{event.id}</p>
+                  <p className="font-medium text-gray-900 dark:text-white">
+                    {event.title}
+                  </p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    {event.id}
+                  </p>
                 </td>
-                <td className="px-6 py-4 text-sm text-gray-500">
+                <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                   {event.date}
                 </td>
-                <td className="px-6 py-4 text-sm text-gray-500">
+                <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                   {event.venue || "Virtual"}
                 </td>
                 <td className="px-6 py-4 text-right">
                   <div className="flex justify-end gap-2">
                     <a
                       href={`/admin/eventos/nuevo?edit=${event.id}`}
-                      className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                      className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
                     >
                       Editar
                     </a>
                     <button
                       onClick={() => handleDelete(event.id)}
                       disabled={deleting === event.id}
-                      className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+                      className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
                     >
                       {deleting === event.id ? "..." : "Eliminar"}
                     </button>
@@ -140,7 +149,7 @@ export function EventList() {
           </tbody>
         </table>
         {events.length === 0 && (
-          <p className="py-8 text-center text-gray-500">
+          <p className="py-8 text-center text-gray-500 dark:text-gray-400">
             No hay eventos. Crea el primero.
           </p>
         )}

--- a/src/components/react/admin/speakers/SpeakerList.tsx
+++ b/src/components/react/admin/speakers/SpeakerList.tsx
@@ -132,14 +132,14 @@ export function SpeakerList() {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
         {error}
       </div>
     );
   }
 
   const inputClass =
-    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500";
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400";
 
   if (form) {
     return (
@@ -149,15 +149,15 @@ export function SpeakerList() {
             setEditing(null);
             setCreating(false);
           }}
-          className="mb-4 text-sm text-gray-500 hover:text-gray-700"
+          className="mb-4 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
         >
           ← Volver a speakers
         </button>
-        <h2 className="mb-6 text-xl font-bold text-gray-900">
+        <h2 className="mb-6 text-xl font-bold text-gray-900 dark:text-white">
           {creating ? "Agregar speaker" : `Editar: ${form.name}`}
         </h2>
         <form onSubmit={handleSave} className="space-y-6">
-          <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
             <div className="grid gap-4 sm:grid-cols-2">
               <FormField label="ID (slug)" required>
                 <input
@@ -216,8 +216,10 @@ export function SpeakerList() {
             </div>
           </div>
 
-          <div className="rounded-xl border border-gray-200 bg-white p-6">
-            <h3 className="mb-4 font-semibold text-gray-900">Topics</h3>
+          <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+            <h3 className="mb-4 font-semibold text-gray-900 dark:text-white">
+              Topics
+            </h3>
             <div className="flex gap-2">
               <input
                 type="text"
@@ -240,7 +242,7 @@ export function SpeakerList() {
               {form.topics.map((topic, i) => (
                 <span
                   key={i}
-                  className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800"
+                  className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
                 >
                   {topic}
                   <button
@@ -251,7 +253,7 @@ export function SpeakerList() {
                         form.topics.filter((_, idx) => idx !== i)
                       )
                     }
-                    className="text-blue-600 hover:text-blue-800"
+                    className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
                   >
                     ×
                   </button>
@@ -260,8 +262,10 @@ export function SpeakerList() {
             </div>
           </div>
 
-          <div className="rounded-xl border border-gray-200 bg-white p-6">
-            <h3 className="mb-4 font-semibold text-gray-900">Redes sociales</h3>
+          <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+            <h3 className="mb-4 font-semibold text-gray-900 dark:text-white">
+              Redes sociales
+            </h3>
             <div className="grid gap-4 sm:grid-cols-2">
               {["linkedin", "github", "twitter", "web"].map((key) => (
                 <FormField key={key} label={key}>
@@ -288,7 +292,7 @@ export function SpeakerList() {
                 setEditing(null);
                 setCreating(false);
               }}
-              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
             >
               Cancelar
             </button>
@@ -322,9 +326,9 @@ export function SpeakerList() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Buscar speaker..."
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none sm:w-64"
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none sm:w-64 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
           />
-          <span className="shrink-0 text-sm text-gray-500">
+          <span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
             {filtered.length} speaker{filtered.length !== 1 && "s"}
           </span>
         </div>
@@ -340,44 +344,49 @@ export function SpeakerList() {
       </div>
 
       {/* Desktop table */}
-      <div className="hidden overflow-hidden rounded-lg border border-gray-200 bg-white md:block">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+      <div className="hidden overflow-hidden rounded-lg border border-gray-200 bg-white md:block dark:border-gray-700 dark:bg-gray-800">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Speaker
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Empresa
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Topics
               </th>
-              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Acciones
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
             {paginated.map((speaker) => (
-              <tr key={speaker.id} className="hover:bg-gray-50">
+              <tr
+                key={speaker.id}
+                className="hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
                 <td className="px-6 py-4">
                   <div className="flex items-center gap-3">
                     <img
                       src={toImagePath(speaker.photo_url)}
                       alt=""
                       loading="lazy"
-                      className="h-8 w-8 rounded-full bg-gray-100 object-cover"
+                      className="h-8 w-8 rounded-full bg-gray-100 object-cover dark:bg-gray-700"
                     />
                     <div>
-                      <p className="font-medium text-gray-900">
+                      <p className="font-medium text-gray-900 dark:text-white">
                         {speaker.name}
                       </p>
-                      <p className="text-xs text-gray-500">{speaker.role}</p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                        {speaker.role}
+                      </p>
                     </div>
                   </div>
                 </td>
-                <td className="px-6 py-4 text-sm text-gray-500">
+                <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                   {speaker.company}
                 </td>
                 <td className="px-6 py-4">
@@ -385,13 +394,13 @@ export function SpeakerList() {
                     {speaker.topics.slice(0, 3).map((t, i) => (
                       <span
                         key={i}
-                        className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600"
+                        className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-400"
                       >
                         {t}
                       </span>
                     ))}
                     {speaker.topics.length > 3 && (
-                      <span className="text-xs text-gray-400">
+                      <span className="text-xs text-gray-400 dark:text-gray-500">
                         +{speaker.topics.length - 3}
                       </span>
                     )}
@@ -401,14 +410,14 @@ export function SpeakerList() {
                   <div className="flex justify-end gap-2">
                     <button
                       onClick={() => setEditing(speaker)}
-                      className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                      className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
                     >
                       Editar
                     </button>
                     <button
                       onClick={() => handleDelete(speaker.id)}
                       disabled={deleting === speaker.id}
-                      className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+                      className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
                     >
                       {deleting === speaker.id ? "..." : "Eliminar"}
                     </button>
@@ -425,33 +434,39 @@ export function SpeakerList() {
         {paginated.map((speaker) => (
           <div
             key={speaker.id}
-            className="rounded-lg border border-gray-200 bg-white p-4"
+            className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
           >
             <div className="flex items-start gap-3">
               <img
                 src={toImagePath(speaker.photo_url)}
                 alt=""
                 loading="lazy"
-                className="h-10 w-10 shrink-0 rounded-full bg-gray-100 object-cover"
+                className="h-10 w-10 shrink-0 rounded-full bg-gray-100 object-cover dark:bg-gray-700"
               />
               <div className="min-w-0 flex-1">
-                <p className="font-medium text-gray-900">{speaker.name}</p>
-                <p className="text-sm text-gray-500">{speaker.role}</p>
+                <p className="font-medium text-gray-900 dark:text-white">
+                  {speaker.name}
+                </p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {speaker.role}
+                </p>
                 {speaker.company && (
-                  <p className="text-sm text-gray-400">{speaker.company}</p>
+                  <p className="text-sm text-gray-400 dark:text-gray-500">
+                    {speaker.company}
+                  </p>
                 )}
                 {speaker.topics.length > 0 && (
                   <div className="mt-2 flex flex-wrap gap-1">
                     {speaker.topics.slice(0, 3).map((t, i) => (
                       <span
                         key={i}
-                        className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600"
+                        className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-400"
                       >
                         {t}
                       </span>
                     ))}
                     {speaker.topics.length > 3 && (
-                      <span className="text-xs text-gray-400">
+                      <span className="text-xs text-gray-400 dark:text-gray-500">
                         +{speaker.topics.length - 3}
                       </span>
                     )}
@@ -459,17 +474,17 @@ export function SpeakerList() {
                 )}
               </div>
             </div>
-            <div className="mt-3 flex justify-end gap-2 border-t border-gray-100 pt-3">
+            <div className="mt-3 flex justify-end gap-2 border-t border-gray-100 pt-3 dark:border-gray-700">
               <button
                 onClick={() => setEditing(speaker)}
-                className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
               >
                 Editar
               </button>
               <button
                 onClick={() => handleDelete(speaker.id)}
                 disabled={deleting === speaker.id}
-                className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+                className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
               >
                 {deleting === speaker.id ? "..." : "Eliminar"}
               </button>
@@ -479,7 +494,7 @@ export function SpeakerList() {
       </div>
 
       {paginated.length === 0 && (
-        <p className="py-8 text-center text-gray-500">
+        <p className="py-8 text-center text-gray-500 dark:text-gray-400">
           {search ? "Sin resultados" : "No hay speakers."}
         </p>
       )}
@@ -487,7 +502,7 @@ export function SpeakerList() {
       {/* Pagination */}
       {totalPages > 1 && (
         <div className="mt-6 flex items-center justify-between">
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
             Mostrando {(page - 1) * PAGE_SIZE + 1}-
             {Math.min(page * PAGE_SIZE, filtered.length)} de {filtered.length}
           </p>
@@ -495,7 +510,7 @@ export function SpeakerList() {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-40"
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-40 dark:border-gray-600 dark:text-gray-300"
             >
               Anterior
             </button>
@@ -506,7 +521,7 @@ export function SpeakerList() {
                 className={`rounded-lg px-3 py-1.5 text-sm ${
                   p === page
                     ? "bg-blue-600 text-white"
-                    : "border border-gray-300 hover:bg-gray-50"
+                    : "border border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
                 }`}
               >
                 {p}
@@ -515,7 +530,7 @@ export function SpeakerList() {
             <button
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={page === totalPages}
-              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-40"
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-40 dark:border-gray-600 dark:text-gray-300"
             >
               Siguiente
             </button>

--- a/src/components/react/admin/sponsors/SponsorList.tsx
+++ b/src/components/react/admin/sponsors/SponsorList.tsx
@@ -101,14 +101,14 @@ export function SponsorList() {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
         {error}
       </div>
     );
   }
 
   const inputClass =
-    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500";
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400";
 
   if (form) {
     return (
@@ -118,15 +118,15 @@ export function SponsorList() {
             setEditing(null);
             setCreating(false);
           }}
-          className="mb-4 text-sm text-gray-500 hover:text-gray-700"
+          className="mb-4 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
         >
           ← Volver a sponsors
         </button>
-        <h2 className="mb-6 text-xl font-bold text-gray-900">
+        <h2 className="mb-6 text-xl font-bold text-gray-900 dark:text-white">
           {creating ? "Agregar sponsor" : `Editar: ${form.name}`}
         </h2>
         <form onSubmit={handleSave} className="space-y-6">
-          <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
             <div className="grid gap-4 sm:grid-cols-2">
               <FormField label="Nombre" required>
                 <input
@@ -171,7 +171,7 @@ export function SponsorList() {
                   className={inputClass}
                 />
               </FormField>
-              <label className="flex items-center gap-2 text-sm">
+              <label className="flex items-center gap-2 text-sm dark:text-gray-300">
                 <input
                   type="checkbox"
                   checked={form.featured}
@@ -189,7 +189,7 @@ export function SponsorList() {
                 setEditing(null);
                 setCreating(false);
               }}
-              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
             >
               Cancelar
             </button>
@@ -216,7 +216,9 @@ export function SponsorList() {
         />
       )}
       <div className="mb-6 flex items-center justify-between">
-        <p className="text-sm text-gray-500">{sponsors.length} sponsors</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {sponsors.length} sponsors
+        </p>
         <button
           onClick={() => {
             setCreating(true);
@@ -227,36 +229,41 @@ export function SponsorList() {
           + Agregar sponsor
         </button>
       </div>
-      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Sponsor
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Sector
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Estado
               </th>
-              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Acciones
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
             {sponsors.map((sponsor) => (
-              <tr key={sponsor.name} className="hover:bg-gray-50">
+              <tr
+                key={sponsor.name}
+                className="hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
                 <td className="px-6 py-4">
-                  <p className="font-medium text-gray-900">{sponsor.name}</p>
+                  <p className="font-medium text-gray-900 dark:text-white">
+                    {sponsor.name}
+                  </p>
                 </td>
-                <td className="px-6 py-4 text-sm text-gray-500">
+                <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                   {sponsor.sector}
                 </td>
                 <td className="px-6 py-4">
                   {sponsor.featured && (
-                    <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800">
+                    <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
                       Destacado
                     </span>
                   )}
@@ -265,14 +272,14 @@ export function SponsorList() {
                   <div className="flex justify-end gap-2">
                     <button
                       onClick={() => setEditing(sponsor)}
-                      className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                      className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
                     >
                       Editar
                     </button>
                     <button
                       onClick={() => handleDelete(sponsor.name)}
                       disabled={deleting === sponsor.name}
-                      className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+                      className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
                     >
                       {deleting === sponsor.name ? "..." : "Eliminar"}
                     </button>

--- a/src/components/react/admin/stats/StatsEditor.tsx
+++ b/src/components/react/admin/stats/StatsEditor.tsx
@@ -83,7 +83,7 @@ export function StatsEditor() {
   }
 
   const inputClass =
-    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500";
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400";
 
   return (
     <div className="mx-auto max-w-3xl">
@@ -95,13 +95,13 @@ export function StatsEditor() {
         />
       )}
 
-      <p className="mb-6 text-sm text-gray-500">
+      <p className="mb-6 text-sm text-gray-500 dark:text-gray-400">
         Estos valores se muestran en las paginas publicas del sitio. Ultima
         actualizacion: {new Date(stats.updated_at).toLocaleDateString("es-PE")}
       </p>
 
       <form onSubmit={handleSave} className="space-y-6">
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
           <div className="grid gap-4 sm:grid-cols-3">
             {FIELDS.map(({ key, label, type }) => (
               <FormField key={key} label={label}>

--- a/src/components/react/admin/team/TeamList.tsx
+++ b/src/components/react/admin/team/TeamList.tsx
@@ -83,7 +83,7 @@ export function TeamList() {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
         {error}
       </div>
     );
@@ -116,7 +116,9 @@ export function TeamList() {
       )}
 
       <div className="mb-6 flex items-center justify-between">
-        <p className="text-sm text-gray-500">{members.length} miembros</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {members.length} miembros
+        </p>
         <button
           onClick={() => setCreating(true)}
           className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
@@ -130,30 +132,33 @@ export function TeamList() {
         { title: "Miembros", items: teamMembers },
       ].map((group) => (
         <div key={group.title} className="mb-8">
-          <h3 className="mb-3 text-lg font-semibold text-gray-900">
+          <h3 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
             {group.title} ({group.items.length})
           </h3>
-          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-50 dark:bg-gray-900">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                  <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                     Nombre
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                  <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                     Rol
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                  <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                     Bio
                   </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase">
+                  <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                     Acciones
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200">
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                 {group.items.map((member) => (
-                  <tr key={member.id} className="hover:bg-gray-50">
+                  <tr
+                    key={member.id}
+                    className="hover:bg-gray-50 dark:hover:bg-gray-700"
+                  >
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-3">
                         <img
@@ -161,29 +166,29 @@ export function TeamList() {
                           alt=""
                           className="h-8 w-8 rounded-full object-cover"
                         />
-                        <span className="font-medium text-gray-900">
+                        <span className="font-medium text-gray-900 dark:text-white">
                           {member.name}
                         </span>
                       </div>
                     </td>
-                    <td className="px-6 py-4 text-sm text-gray-500">
+                    <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                       {member.role}
                     </td>
-                    <td className="max-w-xs truncate px-6 py-4 text-sm text-gray-500">
+                    <td className="max-w-xs truncate px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                       {member.bio}
                     </td>
                     <td className="px-6 py-4 text-right">
                       <div className="flex justify-end gap-2">
                         <button
                           onClick={() => setEditing(member)}
-                          className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50"
+                          className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
                         >
                           Editar
                         </button>
                         <button
                           onClick={() => handleDelete(member.id)}
                           disabled={deleting === member.id}
-                          className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50"
+                          className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
                         >
                           {deleting === member.id ? "..." : "Eliminar"}
                         </button>

--- a/src/components/react/admin/team/TeamMemberForm.tsx
+++ b/src/components/react/admin/team/TeamMemberForm.tsx
@@ -54,23 +54,23 @@ export function TeamMemberForm({ member, onSave, onCancel }: Props) {
   }
 
   const inputClass =
-    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500";
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400";
 
   return (
     <div className="mx-auto max-w-2xl">
       <button
         onClick={onCancel}
-        className="mb-4 text-sm text-gray-500 hover:text-gray-700"
+        className="mb-4 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
       >
         ← Volver a equipo
       </button>
 
-      <h2 className="mb-6 text-xl font-bold text-gray-900">
+      <h2 className="mb-6 text-xl font-bold text-gray-900 dark:text-white">
         {isNew ? "Agregar miembro" : `Editar: ${member?.name}`}
       </h2>
 
       <form onSubmit={handleSubmit} className="space-y-6">
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
           <div className="grid gap-4 sm:grid-cols-2">
             <FormField label="ID (slug)" required>
               <input
@@ -134,8 +134,10 @@ export function TeamMemberForm({ member, onSave, onCancel }: Props) {
           </div>
         </div>
 
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
-          <h3 className="mb-4 font-semibold text-gray-900">Redes sociales</h3>
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-4 font-semibold text-gray-900 dark:text-white">
+            Redes sociales
+          </h3>
           <div className="grid gap-4 sm:grid-cols-2">
             {["linkedin", "github", "twitter", "web"].map((key) => (
               <FormField key={key} label={key}>
@@ -150,8 +152,10 @@ export function TeamMemberForm({ member, onSave, onCancel }: Props) {
           </div>
         </div>
 
-        <div className="rounded-xl border border-gray-200 bg-white p-6">
-          <h3 className="mb-4 font-semibold text-gray-900">Tags</h3>
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-4 font-semibold text-gray-900 dark:text-white">
+            Tags
+          </h3>
           <div className="flex gap-2">
             <input
               type="text"
@@ -177,7 +181,7 @@ export function TeamMemberForm({ member, onSave, onCancel }: Props) {
             {(form.tags || []).map((tag, i) => (
               <span
                 key={i}
-                className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800"
+                className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
               >
                 {tag}
                 <button
@@ -188,7 +192,7 @@ export function TeamMemberForm({ member, onSave, onCancel }: Props) {
                       (form.tags || []).filter((_, idx) => idx !== i)
                     )
                   }
-                  className="text-blue-600 hover:text-blue-800"
+                  className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
                 >
                   ×
                 </button>
@@ -201,7 +205,7 @@ export function TeamMemberForm({ member, onSave, onCancel }: Props) {
           <button
             type="button"
             onClick={onCancel}
-            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             Cancelar
           </button>

--- a/src/components/react/admin/ui/FormField.tsx
+++ b/src/components/react/admin/ui/FormField.tsx
@@ -8,12 +8,14 @@ interface Props {
 export function FormField({ label, error, required, children }: Props) {
   return (
     <div>
-      <label className="mb-1 block text-sm font-medium text-gray-700">
+      <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
         {label}
         {required && <span className="text-red-500"> *</span>}
       </label>
       {children}
-      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+      {error && (
+        <p className="mt-1 text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
     </div>
   );
 }

--- a/src/components/react/admin/users/UserDirectory.tsx
+++ b/src/components/react/admin/users/UserDirectory.tsx
@@ -76,7 +76,7 @@ export function UserDirectory() {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
         {error}
       </div>
     );
@@ -92,31 +92,34 @@ export function UserDirectory() {
         />
       )}
 
-      <p className="mb-6 text-sm text-gray-500">
+      <p className="mb-6 text-sm text-gray-500 dark:text-gray-400">
         {users.length} usuarios registrados
       </p>
 
-      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Usuario
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Email
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Rol
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
                 Ultimo login
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
             {users.map((user) => (
-              <tr key={user.uid} className="hover:bg-gray-50">
+              <tr
+                key={user.uid}
+                className="hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
                 <td className="px-6 py-4">
                   <div className="flex items-center gap-3">
                     {user.photoURL && (
@@ -126,12 +129,12 @@ export function UserDirectory() {
                         className="h-8 w-8 rounded-full"
                       />
                     )}
-                    <span className="font-medium text-gray-900">
+                    <span className="font-medium text-gray-900 dark:text-white">
                       {user.displayName}
                     </span>
                   </div>
                 </td>
-                <td className="px-6 py-4 text-sm text-gray-500">
+                <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                   {user.email}
                 </td>
                 <td className="px-6 py-4">
@@ -142,7 +145,7 @@ export function UserDirectory() {
                         handleRoleChange(user.uid, e.target.value)
                       }
                       disabled={changingRole === user.uid}
-                      className="rounded border border-gray-300 px-2 py-1 text-sm disabled:opacity-50"
+                      className="rounded border border-gray-300 px-2 py-1 text-sm disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
                     >
                       {ROLES.map((r) => (
                         <option key={r} value={r}>
@@ -151,12 +154,12 @@ export function UserDirectory() {
                       ))}
                     </select>
                   ) : (
-                    <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                    <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300">
                       {user.role}
                     </span>
                   )}
                 </td>
-                <td className="px-6 py-4 text-sm text-gray-500">
+                <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                   {formatDate(user.lastLoginAt)}
                 </td>
               </tr>

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -16,6 +16,11 @@ const { title } = Astro.props;
     <meta name="robots" content="noindex, nofollow" />
     <title>{title} | Admin GDG ICA</title>
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <script is:inline>
+      if (localStorage.getItem("admin-theme") === "dark") {
+        document.documentElement.classList.add("dark");
+      }
+    </script>
   </head>
   <body>
     <slot />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
 @import "@fontsource-variable/geist";
 @plugin "@tailwindcss/typography";
 


### PR DESCRIPTION
## ✨ What this PR does

Agrega modo oscuro al panel de administracion.

- Toggle en el sidebar (desktop) y header (mobile)
- Preferencia guardada en localStorage
- 15 componentes actualizados con variantes `dark:`
- Solo afecta `/admin/*` — el sitio publico no cambia
- Sin flash de tema incorrecto (script inline en AdminLayout)

## 🔗 Related issue

None

## ✅ Checklist

- [x] Build + lint passing
- [x] Visual verification on light and dark mode
