### PR TITLE
feat(admin): add Google Forms viewer with Sheets API integration

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,7 +12,8 @@
         "express": "^5.1.0",
         "express-rate-limit": "^8.3.2",
         "firebase-admin": "^13.4.0",
-        "firebase-functions": "^6.3.2"
+        "firebase-functions": "^6.3.2",
+        "googleapis": "^171.4.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -2963,6 +2964,67 @@
         "node": ">=14"
       }
     },
+    "node_modules/googleapis": {
+      "version": "171.4.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-171.4.0.tgz",
+      "integrity": "sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
+      "integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4507,6 +4569,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,8 @@
     "express": "^5.1.0",
     "express-rate-limit": "^8.3.2",
     "firebase-admin": "^13.4.0",
-    "firebase-functions": "^6.3.2"
+    "firebase-functions": "^6.3.2",
+    "googleapis": "^171.4.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/functions/src/handlers/forms.ts
+++ b/functions/src/handlers/forms.ts
@@ -1,0 +1,190 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { GitHubService } from "../services/github";
+import { readSheet } from "../services/sheets";
+import { safeError } from "../middleware/validate";
+import { GITHUB_TOKEN } from "../config";
+
+interface FormEntry {
+  id: string;
+  name: string;
+  spreadsheet_id: string;
+  sheet_name: string;
+  is_public: boolean;
+  created_at: string;
+}
+
+export async function listForms(req: Request, res: Response) {
+  try {
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const { data } =
+      await github.getFileContent<FormEntry[]>("about/forms.json");
+
+    const user = (req as AuthenticatedRequest).user;
+    const isAdmin = user.role === "admin";
+
+    const visible = isAdmin ? data : data.filter((f) => f.is_public);
+    res.json({ success: true, data: visible });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+export async function addForm(req: Request, res: Response) {
+  try {
+    const form = req.body as FormEntry;
+    if (!form.id || !form.name || !form.spreadsheet_id) {
+      res.status(400).json({
+        success: false,
+        error: "Missing required fields: id, name, spreadsheet_id",
+      });
+      return;
+    }
+
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    const entry: FormEntry = {
+      id: form.id,
+      name: form.name,
+      spreadsheet_id: form.spreadsheet_id,
+      sheet_name: form.sheet_name || "Form Responses 1",
+      is_public: form.is_public ?? true,
+      created_at: new Date().toISOString(),
+    };
+
+    const { data: forms, sha } =
+      await github.getFileContent<FormEntry[]>("about/forms.json");
+    forms.push(entry);
+
+    await github.putFile(
+      "about/forms.json",
+      JSON.stringify(forms, null, 2),
+      `feat(forms): add ${entry.name}`,
+      sha
+    );
+
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add({
+        action: "form.create",
+        performedBy: user.uid,
+        targetId: entry.id,
+        targetType: "form",
+        details: { name: entry.name },
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+    res.status(201).json({ success: true, data: entry });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+export async function updateForm(req: Request, res: Response) {
+  try {
+    const formId = req.params.id as string;
+    const updates = req.body as Partial<FormEntry>;
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    const { data: forms, sha } =
+      await github.getFileContent<FormEntry[]>("about/forms.json");
+    const index = forms.findIndex((f) => f.id === formId);
+
+    if (index === -1) {
+      res.status(404).json({ success: false, error: "Form not found" });
+      return;
+    }
+
+    forms[index] = { ...forms[index], ...updates, id: formId };
+
+    await github.putFile(
+      "about/forms.json",
+      JSON.stringify(forms, null, 2),
+      `fix(forms): update ${formId}`,
+      sha
+    );
+
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add({
+        action: "form.update",
+        performedBy: user.uid,
+        targetId: formId,
+        targetType: "form",
+        details: { name: forms[index].name },
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+    res.json({ success: true, data: forms[index] });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+export async function deleteForm(req: Request, res: Response) {
+  try {
+    const formId = req.params.id as string;
+    const github = new GitHubService(GITHUB_TOKEN.value());
+    const user = (req as AuthenticatedRequest).user;
+
+    const { data: forms, sha } =
+      await github.getFileContent<FormEntry[]>("about/forms.json");
+    const filtered = forms.filter((f) => f.id !== formId);
+
+    if (filtered.length === forms.length) {
+      res.status(404).json({ success: false, error: "Form not found" });
+      return;
+    }
+
+    await github.putFile(
+      "about/forms.json",
+      JSON.stringify(filtered, null, 2),
+      `chore(forms): remove ${formId}`,
+      sha
+    );
+
+    admin.firestore().collection("audit_log").add({
+      action: "form.delete",
+      performedBy: user.uid,
+      targetId: formId,
+      targetType: "form",
+      details: {},
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+export async function getFormResponses(req: Request, res: Response) {
+  try {
+    const formId = req.params.id as string;
+    const github = new GitHubService(GITHUB_TOKEN.value());
+
+    const { data: forms } =
+      await github.getFileContent<FormEntry[]>("about/forms.json");
+    const form = forms.find((f) => f.id === formId);
+
+    if (!form) {
+      res.status(404).json({ success: false, error: "Form not found" });
+      return;
+    }
+
+    if (!form.is_public) {
+      res.status(403).json({ success: false, error: "This form is private" });
+      return;
+    }
+
+    const data = await readSheet(form.spreadsheet_id, form.sheet_name);
+    res.json({ success: true, data });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,6 +13,7 @@ import * as speakers from "./handlers/speakers";
 import * as sponsors from "./handlers/sponsors";
 import * as stats from "./handlers/stats";
 import * as users from "./handlers/users";
+import * as forms from "./handlers/forms";
 import { triggerRebuild } from "./handlers/rebuild";
 
 admin.initializeApp();
@@ -102,6 +103,18 @@ app.put("/api/stats", requireRole("admin"), stats.updateStats);
 // Users
 app.get("/api/users", requireRole("admin"), users.listUsers);
 app.patch("/api/users/:uid/role", requireRole("admin"), vuid, users.updateRole);
+
+// Forms
+app.get("/api/forms", requireRole("organizer"), forms.listForms);
+app.post("/api/forms", requireRole("admin"), forms.addForm);
+app.put("/api/forms/:id", requireRole("admin"), vid, forms.updateForm);
+app.delete("/api/forms/:id", requireRole("admin"), vid, forms.deleteForm);
+app.get(
+  "/api/forms/:id/responses",
+  requireRole("organizer"),
+  vid,
+  forms.getFormResponses
+);
 
 // Rebuild
 app.post("/api/rebuild", requireRole("admin"), triggerRebuild);

--- a/functions/src/services/sheets.ts
+++ b/functions/src/services/sheets.ts
@@ -1,0 +1,26 @@
+import { google } from "googleapis";
+
+export async function readSheet(
+  spreadsheetId: string,
+  sheetName: string
+): Promise<{ headers: string[]; rows: string[][] }> {
+  const auth = new google.auth.GoogleAuth({
+    scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+  });
+
+  const sheets = google.sheets({ version: "v4", auth });
+  const response = await sheets.spreadsheets.values.get({
+    spreadsheetId,
+    range: sheetName,
+  });
+
+  const values = response.data.values || [];
+  if (values.length === 0) {
+    return { headers: [], rows: [] };
+  }
+
+  const headers = values[0].map(String);
+  const rows = values.slice(1).map((row) => row.map(String));
+
+  return { headers, rows };
+}

--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -9,6 +9,8 @@ import { SpeakerList } from "./speakers/SpeakerList";
 import { SponsorList } from "./sponsors/SponsorList";
 import { StatsEditor } from "./stats/StatsEditor";
 import { UserDirectory } from "./users/UserDirectory";
+import { FormRegistry } from "./forms/FormRegistry";
+import { FormViewer } from "./forms/FormViewer";
 
 interface Props {
   page: string;
@@ -82,6 +84,10 @@ function AdminContent({ page, currentPath }: Props) {
         return <StatsEditor />;
       case "users":
         return <UserDirectory />;
+      case "forms":
+        return <FormRegistry />;
+      case "form-viewer":
+        return <FormViewer />;
       default:
         return (
           <p className="text-gray-500 dark:text-gray-400">

--- a/src/components/react/admin/AdminShell.tsx
+++ b/src/components/react/admin/AdminShell.tsx
@@ -9,6 +9,7 @@ const NAV_ITEMS = [
   { label: "Sponsors", href: "/admin/sponsors", icon: "🤝", adminOnly: true },
   { label: "Usuarios", href: "/admin/usuarios", icon: "👤", adminOnly: true },
   { label: "Stats", href: "/admin/stats", icon: "📈", adminOnly: true },
+  { label: "Formularios", href: "/admin/forms", icon: "📋" },
 ];
 
 interface Props {

--- a/src/components/react/admin/forms/FormRegistry.tsx
+++ b/src/components/react/admin/forms/FormRegistry.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { useAuth } from "../AuthProvider";
+import { Toast } from "../ui/Toast";
+import { FormField } from "../ui/FormField";
+
+interface FormEntry {
+  id: string;
+  name: string;
+  spreadsheet_id: string;
+  sheet_name: string;
+  is_public: boolean;
+  created_at: string;
+}
+
+const EMPTY_FORM: FormEntry = {
+  id: "",
+  name: "",
+  spreadsheet_id: "",
+  sheet_name: "Form Responses 1",
+  is_public: true,
+  created_at: "",
+};
+
+export function FormRegistry() {
+  const { isAdmin } = useAuth();
+  const [forms, setForms] = useState<FormEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [form, setForm] = useState<FormEntry>(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadForms();
+  }, []);
+
+  async function loadForms() {
+    setLoading(true);
+    const res = await api.listForms();
+    if (res.success && res.data) {
+      setForms(res.data as FormEntry[]);
+    } else {
+      setError(res.error || "Error al cargar formularios");
+    }
+    setLoading(false);
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.id || !form.name || !form.spreadsheet_id) {
+      setToast({
+        message: "ID, nombre y spreadsheet ID son obligatorios",
+        type: "error",
+      });
+      return;
+    }
+    setSaving(true);
+    const res = await api.addForm(form);
+    if (res.success) {
+      setToast({ message: "Formulario registrado", type: "success" });
+      setCreating(false);
+      setForm(EMPTY_FORM);
+      loadForms();
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setSaving(false);
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm(`Eliminar formulario "${id}"?`)) return;
+    setDeleting(id);
+    const res = await api.deleteForm(id);
+    if (res.success) {
+      setForms((prev) => prev.filter((f) => f.id !== id));
+      setToast({ message: "Formulario eliminado", type: "success" });
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setDeleting(null);
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+        {error}
+      </div>
+    );
+  }
+
+  const inputClass =
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400";
+
+  if (creating) {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <button
+          onClick={() => setCreating(false)}
+          className="mb-4 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          ← Volver a formularios
+        </button>
+        <h2 className="mb-6 text-xl font-bold text-gray-900 dark:text-white">
+          Registrar formulario
+        </h2>
+        <form onSubmit={handleSave} className="space-y-6">
+          <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormField label="ID (slug)" required>
+                <input
+                  type="text"
+                  value={form.id}
+                  onChange={(e) => setForm({ ...form, id: e.target.value })}
+                  placeholder="speakers-bwai-2026"
+                  className={inputClass}
+                />
+              </FormField>
+              <FormField label="Nombre" required>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  placeholder="Convocatoria Speakers"
+                  className={inputClass}
+                />
+              </FormField>
+              <FormField label="Spreadsheet ID" required>
+                <input
+                  type="text"
+                  value={form.spreadsheet_id}
+                  onChange={(e) =>
+                    setForm({ ...form, spreadsheet_id: e.target.value })
+                  }
+                  placeholder="1BxiMVs0XRA5nFMd..."
+                  className={inputClass}
+                />
+              </FormField>
+              <FormField label="Nombre de la hoja">
+                <input
+                  type="text"
+                  value={form.sheet_name}
+                  onChange={(e) =>
+                    setForm({ ...form, sheet_name: e.target.value })
+                  }
+                  className={inputClass}
+                />
+              </FormField>
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                <input
+                  type="checkbox"
+                  checked={form.is_public}
+                  onChange={(e) =>
+                    setForm({ ...form, is_public: e.target.checked })
+                  }
+                  className="rounded"
+                />
+                Publico (visible para organizers)
+              </label>
+            </div>
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Recuerda compartir el Google Sheet con{" "}
+            <code className="rounded bg-gray-100 px-1 text-xs dark:bg-gray-700">
+              647264238138-compute@developer.gserviceaccount.com
+            </code>{" "}
+            como Lector.
+          </p>
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => setCreating(false)}
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {saving ? "Guardando..." : "Registrar"}
+            </button>
+          </div>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+
+      <div className="mb-6 flex items-center justify-between">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {forms.length} formulario{forms.length !== 1 && "s"}
+        </p>
+        {isAdmin && (
+          <button
+            onClick={() => setCreating(true)}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            + Agregar formulario
+          </button>
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {forms.map((f) => (
+          <div
+            key={f.id}
+            className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+          >
+            <div className="mb-3 flex items-start justify-between">
+              <div>
+                <h3 className="font-semibold text-gray-900 dark:text-white">
+                  {f.name}
+                </h3>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {f.id}
+                </p>
+              </div>
+              <span
+                className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
+                  f.is_public
+                    ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                    : "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+                }`}
+              >
+                {f.is_public ? "Publico" : "Privado"}
+              </span>
+            </div>
+            <p className="mb-4 text-xs text-gray-400 dark:text-gray-500">
+              {new Date(f.created_at).toLocaleDateString("es-PE")}
+            </p>
+            <div className="flex gap-2">
+              {f.is_public && (
+                <a
+                  href={`/admin/forms/viewer?id=${f.id}`}
+                  className="rounded-lg bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50"
+                >
+                  Ver respuestas
+                </a>
+              )}
+              {isAdmin && (
+                <button
+                  onClick={() => handleDelete(f.id)}
+                  disabled={deleting === f.id}
+                  className="rounded-lg px-3 py-1.5 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+                >
+                  {deleting === f.id ? "..." : "Eliminar"}
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {forms.length === 0 && (
+        <p className="py-12 text-center text-gray-500 dark:text-gray-400">
+          No hay formularios registrados.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/react/admin/forms/FormViewer.tsx
+++ b/src/components/react/admin/forms/FormViewer.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "@/lib/api";
+
+const PAGE_SIZE = 20;
+const URL_PATTERN = /https?:\/\/[^\s]+/g;
+
+function CellValue({ value }: { value: string }) {
+  if (!value)
+    return <span className="text-gray-400 dark:text-gray-500">-</span>;
+
+  const urls = value.match(URL_PATTERN);
+  if (urls) {
+    const parts = value.split(URL_PATTERN);
+    return (
+      <span>
+        {parts.map((part, i) => (
+          <span key={i}>
+            {part}
+            {urls[i] && (
+              <a
+                href={urls[i]}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                {urls[i].includes("drive.google.com")
+                  ? "Ver archivo"
+                  : urls[i].length > 50
+                    ? urls[i].slice(0, 50) + "..."
+                    : urls[i]}
+              </a>
+            )}
+          </span>
+        ))}
+      </span>
+    );
+  }
+
+  return <span>{value}</span>;
+}
+
+export function FormViewer() {
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [rows, setRows] = useState<string[][]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  const formId =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search).get("id") || ""
+      : "";
+
+  useEffect(() => {
+    if (!formId) return;
+    loadResponses();
+  }, [formId]);
+
+  async function loadResponses() {
+    setLoading(true);
+    const res = await api.getFormResponses(formId);
+    if (res.success && res.data) {
+      const data = res.data as { headers: string[]; rows: string[][] };
+      setHeaders(data.headers);
+      setRows(data.rows);
+    } else {
+      setError(res.error || "Error al cargar respuestas");
+    }
+    setLoading(false);
+  }
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return rows;
+    const q = search.toLowerCase();
+    return rows.filter((row) =>
+      row.some((cell) => cell.toLowerCase().includes(q))
+    );
+  }, [rows, search]);
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  useEffect(() => {
+    setPage(1);
+  }, [search]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <a
+          href="/admin/forms"
+          className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400"
+        >
+          ← Volver a formularios
+        </a>
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <a
+            href="/admin/forms"
+            className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400"
+          >
+            ← Formularios
+          </a>
+          <span className="text-sm text-gray-300 dark:text-gray-600">|</span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            {filtered.length} respuesta{filtered.length !== 1 && "s"}
+          </span>
+        </div>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Buscar en respuestas..."
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none sm:w-64 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+        />
+      </div>
+
+      {/* Desktop table */}
+      <div className="hidden overflow-x-auto rounded-lg border border-gray-200 bg-white md:block dark:border-gray-700 dark:bg-gray-800">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                #
+              </th>
+              {headers.map((h, i) => (
+                <th
+                  key={i}
+                  className="max-w-xs px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {paginated.map((row, ri) => (
+              <tr key={ri} className="hover:bg-gray-50 dark:hover:bg-gray-700">
+                <td className="px-4 py-3 text-xs text-gray-400 dark:text-gray-500">
+                  {(page - 1) * PAGE_SIZE + ri + 1}
+                </td>
+                {headers.map((_, ci) => (
+                  <td
+                    key={ci}
+                    className="max-w-xs truncate px-4 py-3 text-sm text-gray-700 dark:text-gray-300"
+                  >
+                    <CellValue value={row[ci] || ""} />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile cards */}
+      <div className="space-y-3 md:hidden">
+        {paginated.map((row, ri) => (
+          <div
+            key={ri}
+            className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+          >
+            <p className="mb-2 text-xs text-gray-400 dark:text-gray-500">
+              #{(page - 1) * PAGE_SIZE + ri + 1}
+            </p>
+            {headers.map((h, ci) => (
+              <div key={ci} className="mb-2">
+                <p className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                  {h}
+                </p>
+                <p className="text-sm text-gray-900 dark:text-gray-200">
+                  <CellValue value={row[ci] || ""} />
+                </p>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {paginated.length === 0 && (
+        <p className="py-12 text-center text-gray-500 dark:text-gray-400">
+          {search ? "Sin resultados" : "No hay respuestas."}
+        </p>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="mt-6 flex items-center justify-between">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {(page - 1) * PAGE_SIZE + 1}-
+            {Math.min(page * PAGE_SIZE, filtered.length)} de {filtered.length}
+          </p>
+          <div className="flex gap-1">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-40 dark:border-gray-600 dark:text-gray-300"
+            >
+              Anterior
+            </button>
+            {Array.from({ length: Math.min(totalPages, 5) }, (_, i) => {
+              const start = Math.max(1, Math.min(page - 2, totalPages - 4));
+              return start + i;
+            })
+              .filter((p) => p <= totalPages)
+              .map((p) => (
+                <button
+                  key={p}
+                  onClick={() => setPage(p)}
+                  className={`rounded-lg px-3 py-1.5 text-sm ${
+                    p === page
+                      ? "bg-blue-600 text-white"
+                      : "border border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                  }`}
+                >
+                  {p}
+                </button>
+              ))}
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-40 dark:border-gray-600 dark:text-gray-300"
+            >
+              Siguiente
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -74,6 +74,14 @@ export const api = {
   updateUserRole: (uid: string, role: string) =>
     request("PATCH", `/users/${uid}/role`, { role }),
 
+  // Forms
+  listForms: () => request("GET", "/forms"),
+  addForm: (data: unknown) => request("POST", "/forms", data),
+  updateForm: (id: string, data: unknown) =>
+    request("PUT", `/forms/${id}`, data),
+  deleteForm: (id: string) => request("DELETE", `/forms/${id}`),
+  getFormResponses: (id: string) => request("GET", `/forms/${id}/responses`),
+
   // Rebuild
   triggerRebuild: () => request("POST", "/rebuild"),
 };

--- a/src/pages/admin/forms/index.astro
+++ b/src/pages/admin/forms/index.astro
@@ -1,0 +1,8 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Formularios">
+  <AdminApp client:load page="forms" currentPath="/admin/forms" />
+</AdminLayout>

--- a/src/pages/admin/forms/viewer.astro
+++ b/src/pages/admin/forms/viewer.astro
@@ -1,0 +1,8 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Respuestas">
+  <AdminApp client:load page="form-viewer" currentPath="/admin/forms" />
+</AdminLayout>


### PR DESCRIPTION
## ✨ What this PR does

Agrega un visor de Google Forms al admin panel para que el equipo pueda ver respuestas de formularios sin necesitar acceso a Google Sheets.

**Flujo:**
1. Admin registra un formulario (nombre, spreadsheet ID, publico/privado)
2. Admin comparte el Sheet con el service account de Firebase
3. Organizers ven las respuestas en `/admin/forms` → click → tabla read-only

**Backend:**
- Google Sheets API via service account de Firebase (sin secrets adicionales)
- CRUD de formularios en `gdg-ica-data/about/forms.json`
- Endpoint `GET /api/forms/:id/responses` que lee el spreadsheet

**Frontend:**
- `FormRegistry`: lista de formularios con cards, badge publico/privado
- `FormViewer`: tabla read-only con paginacion, busqueda, URLs auto-linkadas
- Responsive + dark mode

**Setup requerido:**
- [x] Google Sheets API habilitada en el proyecto
- [x] Compartir cada Sheet con `647264238138-compute@developer.gserviceaccount.com`

## 🔗 Related issue

None

## ✅ Checklist

- [x] Build + lint passing
- [x] Functions build passing
- [x] Test with real Google Sheet after deploy
