### PR TITLE
feat(admin): add dev preview mode for local development

### DIFF
--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -1,5 +1,6 @@
-import { AuthProvider, useAuth } from "./AuthProvider";
+import { AuthProvider, DevAuthProvider, useAuth } from "./AuthProvider";
 import { LoginScreen } from "./LoginScreen";
+import { isDevPreview } from "@/lib/api";
 import { AdminShell } from "./AdminShell";
 import { Dashboard } from "./Dashboard";
 import { EventList } from "./events/EventList";
@@ -100,7 +101,57 @@ function AdminContent({ page, currentPath }: Props) {
   return <AdminShell currentPage={currentPath}>{pageContent()}</AdminShell>;
 }
 
+function DevContent({ page, currentPath }: Props) {
+  const pageContent = () => {
+    switch (page) {
+      case "dashboard":
+        return <Dashboard />;
+      case "events":
+        return <EventList />;
+      case "event-form":
+        return <EventForm />;
+      case "team":
+        return <TeamList />;
+      case "speakers":
+        return <SpeakerList />;
+      case "sponsors":
+        return <SponsorList />;
+      case "stats":
+        return <StatsEditor />;
+      case "users":
+        return <UserDirectory />;
+      case "forms":
+        return <FormRegistry />;
+      case "form-viewer":
+        return <FormViewer />;
+      default:
+        return (
+          <p className="text-gray-500 dark:text-gray-400">
+            Pagina en construccion
+          </p>
+        );
+    }
+  };
+
+  return (
+    <AdminShell currentPage={currentPath}>
+      <div className="mb-4 rounded-lg border border-yellow-300 bg-yellow-50 px-4 py-2 text-sm text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-400">
+        PREVIEW MODE — datos de ejemplo, sin auth
+      </div>
+      {pageContent()}
+    </AdminShell>
+  );
+}
+
 export function AdminApp({ page, currentPath }: Props) {
+  if (isDevPreview) {
+    return (
+      <DevAuthProvider>
+        <DevContent page={page} currentPath={currentPath} />
+      </DevAuthProvider>
+    );
+  }
+
   return (
     <AuthProvider>
       <AdminContent page={page} currentPath={currentPath} />

--- a/src/components/react/admin/AuthProvider.tsx
+++ b/src/components/react/admin/AuthProvider.tsx
@@ -41,6 +41,26 @@ export function useAuth() {
   return useContext(AuthContext);
 }
 
+export function DevAuthProvider({ children }: { children: React.ReactNode }) {
+  const mockValue: AuthContextType = {
+    user: {
+      displayName: "Dev Preview",
+      email: "dev@preview.local",
+      photoURL: "",
+    } as AuthContextType["user"],
+    role: "admin",
+    loading: false,
+    signIn: async () => {},
+    signOut: async () => {},
+    isOrganizer: true,
+    isAdmin: true,
+  };
+
+  return (
+    <AuthContext.Provider value={mockValue}>{children}</AuthContext.Provider>
+  );
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [role, setRole] = useState<string | null>(null);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,10 @@
 import { getIdToken } from "./auth";
+import { mockApi } from "./mock-api";
 
 const API_BASE = "/api";
+
+export const isDevPreview =
+  typeof window !== "undefined" && window.location.hostname === "localhost";
 
 interface ApiResponse<T> {
   success: boolean;
@@ -31,7 +35,7 @@ async function request<T>(
   return res.json();
 }
 
-export const api = {
+const realApi = {
   // Auth
   register: () => request("POST", "/auth/register"),
 
@@ -85,3 +89,6 @@ export const api = {
   // Rebuild
   triggerRebuild: () => request("POST", "/rebuild"),
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const api: typeof realApi = isDevPreview ? (mockApi as any) : realApi;

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -1,0 +1,54 @@
+import {
+  MOCK_SPEAKERS,
+  MOCK_EVENTS,
+  MOCK_TEAM,
+  MOCK_SPONSORS,
+  MOCK_STATS,
+  MOCK_USERS,
+  MOCK_FORMS,
+  MOCK_FORM_RESPONSES,
+} from "./mock-data";
+
+function ok<T>(data: T) {
+  return Promise.resolve({ success: true as const, data });
+}
+
+export const mockApi = {
+  register: () => ok({ role: "admin" }),
+
+  listEvents: () => ok(MOCK_EVENTS),
+  getEvent: (id: string) =>
+    ok(MOCK_EVENTS.find((e) => e.id === id) || MOCK_EVENTS[0]),
+  createEvent: () => ok({ id: "new-event" }),
+  updateEvent: () => ok({ id: "updated" }),
+  deleteEvent: () => ok(null),
+
+  listTeam: () => ok(MOCK_TEAM),
+  addTeamMember: () => ok({ id: "new-member" }),
+  updateTeamMember: () => ok({ id: "updated" }),
+  deleteTeamMember: () => ok(null),
+
+  listSpeakers: () => ok(MOCK_SPEAKERS),
+  addSpeaker: () => ok({ id: "new-speaker" }),
+  updateSpeaker: () => ok({ id: "updated" }),
+  deleteSpeaker: () => ok(null),
+
+  listSponsors: () => ok(MOCK_SPONSORS),
+  addSponsor: () => ok({ name: "new" }),
+  updateSponsor: () => ok({ name: "updated" }),
+  deleteSponsor: () => ok(null),
+
+  getStats: () => ok(MOCK_STATS),
+  updateStats: () => ok(MOCK_STATS),
+
+  listUsers: () => ok(MOCK_USERS),
+  updateUserRole: () => ok({ uid: "dev", role: "admin" }),
+
+  listForms: () => ok(MOCK_FORMS),
+  addForm: () => ok({ id: "new-form" }),
+  updateForm: () => ok({ id: "updated" }),
+  deleteForm: () => ok(null),
+  getFormResponses: () => ok(MOCK_FORM_RESPONSES),
+
+  triggerRebuild: () => ok(null),
+};

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,0 +1,146 @@
+export const MOCK_SPEAKERS = [
+  {
+    id: "maria-garcia",
+    name: "Maria Garcia",
+    bio: "Senior Frontend Engineer con 8 anos de experiencia",
+    photo_url: "",
+    company: "Google",
+    role: "Staff Engineer",
+    topics: ["Web", "Angular", "TypeScript"],
+    social_links: { linkedin: "https://linkedin.com/in/example" },
+    talk_ids: [],
+  },
+  {
+    id: "carlos-lopez",
+    name: "Carlos Lopez",
+    bio: "Cloud Architect y GDE en Google Cloud",
+    photo_url: "",
+    company: "AWS",
+    role: "Solutions Architect",
+    topics: ["Cloud", "Kubernetes", "DevOps"],
+    social_links: {},
+    talk_ids: [],
+  },
+  {
+    id: "ana-torres",
+    name: "Ana Torres",
+    bio: "ML Engineer especializada en NLP",
+    photo_url: "",
+    company: "Meta",
+    role: "ML Engineer",
+    topics: ["AI", "Machine Learning", "Python"],
+    social_links: { github: "https://github.com/example" },
+    talk_ids: [],
+  },
+];
+
+export const MOCK_EVENTS = [
+  {
+    id: "devfest-preview",
+    title: "DevFest Preview 2026",
+    description: "Evento de preview para desarrollo",
+    date: "2026-06-15T09:00:00",
+    end_time: "05:00 PM",
+    venue: "Universidad Nacional",
+    venue_address: "Av Principal 123",
+    venue_map_url: "",
+    image_url: "",
+    topics: ["AI", "Cloud", "Web"],
+    speaker_ids: ["maria-garcia"],
+    registration_url: "",
+    materials: {},
+    agenda: [],
+  },
+];
+
+export const MOCK_TEAM = [
+  {
+    id: "dev-user-1",
+    name: "Juan Preview",
+    role: "Leadership",
+    photo_url: "",
+    bio: "Organizador de ejemplo",
+    social_links: { linkedin: "https://linkedin.com" },
+    type: "organizer" as const,
+    tags: ["Cloud", "Python"],
+  },
+  {
+    id: "dev-user-2",
+    name: "Laura Preview",
+    role: "Technology",
+    photo_url: "",
+    bio: "Miembro de ejemplo",
+    social_links: {},
+    type: "member" as const,
+    tags: ["React", "TypeScript"],
+  },
+];
+
+export const MOCK_SPONSORS = [
+  {
+    name: "Google",
+    logo_url: "",
+    url: "https://google.com",
+    sector: "Tecnologia",
+    description: "Sponsor principal de ejemplo",
+    featured: true,
+  },
+  {
+    name: "GitHub",
+    logo_url: "",
+    url: "https://github.com",
+    sector: "Software",
+    description: "Sponsor de ejemplo",
+    featured: false,
+  },
+];
+
+export const MOCK_STATS = {
+  total_members: 1000,
+  total_events: 50,
+  total_talks: 32,
+  total_speakers: 25,
+  years_active: 10,
+  total_organizers: 7,
+  developers_mentored: 200,
+  total_sponsors: 15,
+  annual_support: "$50k",
+  sponsored_events: 100,
+  developers_reached: 5000,
+  active_volunteers: 50,
+  volunteer_hours: 1500,
+  events_supported: 100,
+  volunteer_areas: 9,
+  updated_at: new Date().toISOString(),
+};
+
+export const MOCK_USERS = [
+  {
+    uid: "dev-admin",
+    email: "admin@preview.dev",
+    displayName: "Admin Preview",
+    photoURL: "",
+    role: "admin",
+    lastLoginAt: { _seconds: Math.floor(Date.now() / 1000) },
+  },
+];
+
+export const MOCK_FORMS = [
+  {
+    id: "preview-form",
+    name: "Formulario de Preview",
+    spreadsheet_id: "mock",
+    sheet_name: "Sheet1",
+    is_public: true,
+    created_at: new Date().toISOString(),
+  },
+];
+
+export const MOCK_FORM_RESPONSES = {
+  headers: ["Nombre", "Email", "Empresa", "Rol", "Telefono"],
+  rows: [
+    ["Maria Garcia", "maria@example.com", "Google", "Engineer", "+51 999999"],
+    ["Carlos Lopez", "carlos@example.com", "AWS", "Architect", "+51 888888"],
+    ["Ana Torres", "ana@example.com", "Meta", "ML Engineer", "+51 777777"],
+  ],
+};


### PR DESCRIPTION
## ✨ What this PR does

Agrega un modo preview para desarrollo local del admin panel.

En `localhost:4321/admin`:
- No requiere login con Google
- Muestra datos mock en todas las secciones
- Banner amarillo "PREVIEW MODE" para distinguir de produccion
- Permite iterar en frontend sin deployar

En produccion (`gdgica.com/admin`):
- Sin cambios, sigue requiriendo auth + API real

## 🔗 Related issue

None

## ✅ Checklist

- [x] Build + lint passing
- [x] Produccion no afectada (isDevPreview = false en gdgica.com)
- [x] Verificar `pnpm dev` → localhost:4321/admin funciona sin login
