### PR TITLE
fix(admin): contain table scroll within fixed-height container

### DIFF
--- a/src/components/react/admin/AdminShell.tsx
+++ b/src/components/react/admin/AdminShell.tsx
@@ -35,7 +35,7 @@ export function AdminShell({ currentPage, children }: Props) {
   const visibleItems = NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin);
 
   return (
-    <div className="flex min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="flex h-screen overflow-hidden bg-gray-50 dark:bg-gray-900">
       <aside className="hidden w-64 border-r border-gray-200 bg-white lg:block dark:border-gray-700 dark:bg-gray-800">
         <div className="flex h-16 items-center gap-3 border-b border-gray-200 px-6 dark:border-gray-700">
           <img src="/gdg-logo.png" alt="GDG ICA" className="h-8 w-8" />
@@ -83,7 +83,7 @@ export function AdminShell({ currentPage, children }: Props) {
         </div>
       </aside>
 
-      <div className="flex flex-1 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col">
         <header className="flex h-16 items-center justify-between border-b border-gray-200 bg-white px-6 dark:border-gray-700 dark:bg-gray-800">
           <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
             {currentPage === "/admin"
@@ -120,7 +120,7 @@ export function AdminShell({ currentPage, children }: Props) {
           </div>
         </header>
 
-        <main className="flex-1 p-6">{children}</main>
+        <main className="min-w-0 flex-1 overflow-auto p-6">{children}</main>
       </div>
     </div>
   );

--- a/src/components/react/admin/forms/FormViewer.tsx
+++ b/src/components/react/admin/forms/FormViewer.tsx
@@ -238,7 +238,7 @@ export function FormViewer() {
       )}
 
       {viewMode === "table" && (
-        <div className="max-h-[calc(100vh-280px)] overflow-auto rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
           <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
             <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -22,7 +22,7 @@ const { title } = Astro.props;
       }
     </script>
   </head>
-  <body>
+  <body class="h-screen overflow-hidden">
     <slot />
   </body>
 </html>


### PR DESCRIPTION
## ✨ What this PR does

Corrige el scroll en el admin panel en produccion. Los fixes de scroll del PR anterior no se mergearon correctamente.

- `body`: `h-screen overflow-hidden` (sin scroll de pagina)
- `AdminShell`: `h-screen overflow-hidden` (contenedor fijo)
- `main`: `overflow-auto` (scroll interno del contenido)
- Tabla FormViewer: `overflow-x-auto` (scrollbar horizontal propio)

## 🔗 Related issue

None

## ✅ Checklist

- [x] Build + lint passing
- [x] Verified locally with pnpm dev
