### PR TITLE
fix(loaders): use enriched agenda fields from gdg-ica-data

### DIFF
--- a/src/loaders/transform-events.ts
+++ b/src/loaders/transform-events.ts
@@ -39,7 +39,14 @@ interface ExternalEvent {
     color: string;
     description: string;
   }[];
-  agenda: { time: string; title: string; speaker: string }[];
+  agenda: {
+    time: string;
+    title: string;
+    speaker: string;
+    image?: string;
+    role?: string;
+    type?: string;
+  }[];
   track_sessions?: Record<
     string,
     {
@@ -167,9 +174,9 @@ function buildSchedule(event: ExternalEvent) {
       time: item.time,
       title: item.title,
       name: item.speaker || "",
-      image: "/placeholder.svg",
-      role: "",
-      type: "event",
+      image: item.image || "/placeholder.svg",
+      role: item.role || "",
+      type: item.type || "event",
     }));
   }
 


### PR DESCRIPTION
## ✨ What this PR does

Restaura las agendas/schedules de eventos que se perdieron durante la migracion a gdg-ica-data.

**En gdg-ica-data (ya pusheado):**
- devfest-2024: 19 agenda items + 7 technologies
- devfest-2025: 3 tracks con track_sessions (17 sessions) + 14 technologies
- google-cloud: 10 agenda items + 3 technologies
- w-avoiding-frankenstein: 2 agenda items + 6 technologies

**En este PR (loader fix):**
- `transform-events.ts`: usa campos `image`, `role`, `type` de la agenda enriquecida en vez de placeholders

## 🔗 Related issue

None

## ✅ Checklist

- [x] Build + lint passing
- [x] Schedule data pushed to gdg-ica-data
