### PR TITLE
fix(loaders): strip domain from agenda images and render sponsors

### DIFF
--- a/src/loaders/transform-events.ts
+++ b/src/loaders/transform-events.ts
@@ -165,7 +165,15 @@ function transformEvent(
 
 function buildSchedule(event: ExternalEvent) {
   if (event.track_sessions) {
-    return { trackSessions: event.track_sessions };
+    const trackSessions: Record<string, (typeof event.track_sessions)[string]> =
+      {};
+    for (const [track, sessions] of Object.entries(event.track_sessions)) {
+      trackSessions[track] = sessions.map((s) => ({
+        ...s,
+        image: stripDomain(s.image),
+      }));
+    }
+    return { trackSessions };
   }
 
   if (event.agenda && event.agenda.length > 0) {
@@ -174,7 +182,7 @@ function buildSchedule(event: ExternalEvent) {
       time: item.time,
       title: item.title,
       name: item.speaker || "",
-      image: item.image || "/placeholder.svg",
+      image: stripDomain(item.image),
       role: item.role || "",
       type: item.type || "event",
     }));


### PR DESCRIPTION
## ✨ What this PR does

Corrige dos problemas en las paginas de eventos:

1. **Imagenes de speakers en agenda/schedule**: aplica `stripDomain()` a las URLs de imagenes en agenda items y track_sessions
2. **Sponsors por evento**: datos migrados a gdg-ica-data (ya pusheado)

## 🔗 Related issue

None

## ✅ Checklist

- [x] Build + lint passing
- [x] Data pushed to gdg-ica-data
