### PR TITLE
feat(team): filter inactive members from public pages

### DIFF
--- a/src/loaders/transform-team.ts
+++ b/src/loaders/transform-team.ts
@@ -13,6 +13,7 @@ interface ExternalTeamMember {
     twitter?: string;
   };
   type: "organizer" | "member";
+  is_active?: boolean;
   tags?: string[];
   joined_date?: string;
   responsibilities?: string[];
@@ -21,7 +22,7 @@ interface ExternalTeamMember {
 export async function loadOrganizers() {
   const team = await fetchGdgData<ExternalTeamMember[]>("about/team.json");
   return team
-    .filter((m) => m.type === "organizer")
+    .filter((m) => m.type === "organizer" && m.is_active !== false)
     .map((m) => ({
       id: m.id,
       name: m.name,
@@ -40,7 +41,7 @@ export async function loadOrganizers() {
 export async function loadMembers() {
   const team = await fetchGdgData<ExternalTeamMember[]>("about/team.json");
   return team
-    .filter((m) => m.type === "member")
+    .filter((m) => m.type === "member" && m.is_active !== false)
     .map((m) => ({
       id: m.id,
       name: m.name,


### PR DESCRIPTION
## ✨ What this PR does

Agrega soporte para miembros inactivos del equipo.

- `gdg-ica-data/about/team.json`: campo `is_active` agregado a todos los miembros (default `true`)
- `transform-team.ts`: filtra miembros con `is_active: false` de las paginas publicas
- Para desactivar un miembro: cambiar `is_active` a `false` en team.json desde el admin

## 🔗 Related issue

None

## ✅ Checklist

- [x] Build + lint passing
- [x] is_active field added to gdg-ica-data
