### PR TITLE
fix(ui): add visible background to schedule speaker images

### DIFF
--- a/src/components/IndependentTrackSchedule.astro
+++ b/src/components/IndependentTrackSchedule.astro
@@ -142,7 +142,7 @@ function getSessionTypeLabel(type) {
                                   <img
                                     src={session.image || "/placeholder.svg"}
                                     alt={`Foto de ${session.name}`}
-                                    class="h-8 w-8 rounded-full border-2 border-white object-cover shadow-sm"
+                                    class="h-8 w-8 rounded-full border-2 border-white bg-gray-100 object-cover shadow-sm"
                                   />
                                   <div>
                                     <p class="text-sm font-medium text-gray-800">

--- a/src/components/ScheduleCard.astro
+++ b/src/components/ScheduleCard.astro
@@ -27,7 +27,7 @@ const { time, title, name, image, role, type } = Astro.props;
           alt={`Foto de ${name}`}
           height={48}
           width={48}
-          class="aspect-square h-12 w-12 rounded-md"
+          class="aspect-square h-12 w-12 rounded-md border border-gray-200 bg-gray-100 object-cover"
           loading="lazy"
           decoding="async"
         />

--- a/src/components/TrackTabSchedule.astro
+++ b/src/components/TrackTabSchedule.astro
@@ -168,7 +168,7 @@ const trackSessions = schedule.trackSessions;
                                 alt={session.name}
                                 width={48}
                                 height={48}
-                                class="h-12 w-12 rounded-xl object-cover ring-2 ring-gray-100"
+                                class="h-12 w-12 rounded-xl bg-gray-100 object-cover ring-2 ring-gray-100"
                               />
                               <div
                                 class="absolute -right-1 -bottom-1 h-4 w-4 rounded-full border-2 border-white"


### PR DESCRIPTION
## ✨ What this PR does

Hace visibles las imagenes placeholder en las agendas de eventos. Muchos speakers del DevFest 2024 no tienen foto registrada — el placeholder se renderiza pero era invisible en fondo blanco.

- `ScheduleCard`: agrega `bg-gray-100 border border-gray-200 object-cover`
- `IndependentTrackSchedule`: agrega `bg-gray-100`
- `TrackTabSchedule`: agrega `bg-gray-100`

## 🔗 Related issue

None

## ✅ Checklist

- [x] Build + lint passing
