### PR TITLE
fix(admin): prevent signIn race requiring a second attempt

### DIFF
--- a/src/components/react/admin/AuthProvider.tsx
+++ b/src/components/react/admin/AuthProvider.tsx
@@ -119,8 +119,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const signIn = async () => {
-    await firebaseSignIn();
+    // Must be set before the popup: Firebase fires onAuthStateChanged
+    // inside signInWithPopup (before the promise resolves), and the
+    // observer reads SESSION_KEY to decide whether the session is valid.
     localStorage.setItem(SESSION_KEY, Date.now().toString());
+    try {
+      await firebaseSignIn();
+    } catch (err) {
+      localStorage.removeItem(SESSION_KEY);
+      throw err;
+    }
   };
 
   const isOrganizer = role === "organizer" || role === "admin";


### PR DESCRIPTION
## What this PR does

Fixes the admin panel sign-in needing two clicks. Firebase fires `onAuthStateChanged` **inside** `signInWithPopup`, before the popup promise resolves. The observer in `AuthProvider` reads `SESSION_KEY` to validate the session — on a fresh login the key was not set yet (the old code set it *after* the popup resolved), so the observer saw "expired" and force-signed the user out. The popup closed and nothing happened. The second click worked only because the key had been seeded by the failed first attempt.

Fix: set `SESSION_KEY` **before** calling `signInWithPopup`, and clean it up if the popup throws/cancels.

### Verification

Traced the Firebase Auth 1.13.0 source to confirm order:
- `AbstractPopupRedirectOperation.onAuthEvent` → `this.resolve(await _signIn(...))`
- `_signIn` → `_signInWithCredential` → `await auth._updateCurrentUser(user)`
- `_updateCurrentUser` calls `notifyAuthListeners()` synchronously, *before* the popup promise resolves

Also reproduced with a standalone script using a fake `Auth` that mirrors this order: original code ends with `currentUser = null`, fixed code keeps the user signed in on the first attempt.

## Related issue

None

## Checklist

- [x] Root cause verified against Firebase SDK source
- [x] Reproduced in isolation before fixing
- [x] Tested live at `https://gdgica.com/admin/` after deploy
