### PR TITLE
fix(functions): use ipKeyGenerator in writeLimiter for IPv6 safety

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,7 +2,7 @@ import * as admin from "firebase-admin";
 import { onRequest } from "firebase-functions/v2/https";
 import express from "express";
 import cors from "cors";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { GITHUB_TOKEN } from "./config";
 import { requireRole, requireAuth } from "./middleware/auth";
 import { validateParamId } from "./middleware/validate";
@@ -72,7 +72,11 @@ const writeLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: (req) => {
     const uid = (req as { user?: { uid?: string } }).user?.uid;
-    return uid ? `u:${uid}` : `ip:${req.ip ?? "unknown"}`;
+    if (uid) return `u:${uid}`;
+    // express-rate-limit v8 requires routing IP-based keys through
+    // ipKeyGenerator() so IPv6 addresses are normalized and can't be
+    // used to bypass the limit by rotating the suffix.
+    return `ip:${ipKeyGenerator(req.ip ?? "unknown")}`;
   },
   message: {
     success: false,


### PR DESCRIPTION
## ✨ What this PR does

Fixes a production outage on admin writes.

**Symptom:** Cloud Run logs showed `ValidationError: Custom keyGenerator appears to use request IP without calling the ipKeyGenerator helper function for IPv6 addresses` at module load, and the admin panel silently failed to persist sponsor/event/team updates (no change in `gdg-ica-data`, site not rebuilt).

**Root cause:** `express-rate-limit` v8 validates at setup time that any custom `keyGenerator` using `req.ip` routes it through the exported `ipKeyGenerator()` helper (prevents IPv6 suffix rotation bypass). Our `writeLimiter` returned `` `ip:${req.ip}` `` directly on the unauthenticated fallback branch, so the `rateLimit()` call threw during module init and crashed the Cloud Function before any route was registered.

**Fix:** Import `ipKeyGenerator` from `express-rate-limit` and wrap `req.ip` with it in the fallback branch. The UID branch is unchanged.

## 🔗 Related issue

Closes #None

## ✅ Checklist

- [x] `functions/` tsc compiles clean
- [ ] After deploy: re-apply the sponsor update from the admin panel (previous save never reached the data repo)
- [ ] Verify Cloud Run logs no longer show `ERR_ERL_KEY_GEN_IPV6`
- [ ] Verify a write from admin lands in `gdg-ica-data` and triggers a rebuild
