### PR TITLE
fix(loader): read gdg-ica-data from local clone in CI to avoid CDN staleness

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,12 +31,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Fetch content images
+      - name: Fetch gdg-ica-data
         run: |
           git clone --depth 1 https://github.com/GDGXICA/gdg-ica-data.git /tmp/gdg-data
           cp -r /tmp/gdg-data/images/* public/
 
       - name: Build project
+        env:
+          GDG_DATA_LOCAL_PATH: /tmp/gdg-data
         run: pnpm run build
 
       - name: Install Cloud Functions dependencies

--- a/src/loaders/fetch-gdg-data.ts
+++ b/src/loaders/fetch-gdg-data.ts
@@ -1,9 +1,32 @@
+import { readFile } from "node:fs/promises";
+import { resolve, sep } from "node:path";
+
 const BASE_URL = "https://raw.githubusercontent.com/GDGXICA/gdg-ica-data/main";
+
+// In CI we clone gdg-ica-data to a local path before running the build
+// and point the loader at it via GDG_DATA_LOCAL_PATH. This bypasses the
+// raw.githubusercontent.com CDN (which has ~5 minutes of staleness and
+// would otherwise serve pre-commit JSON right after an admin save).
+const LOCAL_PATH = process.env.GDG_DATA_LOCAL_PATH
+  ? resolve(process.env.GDG_DATA_LOCAL_PATH)
+  : undefined;
 
 const cache = new Map<string, { data: unknown; timestamp: number }>();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes for dev
 
 export async function fetchGdgData<T>(path: string): Promise<T> {
+  if (LOCAL_PATH) {
+    // Containment check: ensure the resolved path stays inside LOCAL_PATH
+    // so a compromised index.json with "../" segments can't read files
+    // outside the data repo clone.
+    const filePath = resolve(LOCAL_PATH, path);
+    if (filePath !== LOCAL_PATH && !filePath.startsWith(LOCAL_PATH + sep)) {
+      throw new Error(`Refusing to read path outside data repo: ${path}`);
+    }
+    const contents = await readFile(filePath, "utf-8");
+    return JSON.parse(contents) as T;
+  }
+
   const url = `${BASE_URL}/${path}`;
 
   const cached = cache.get(url);


### PR DESCRIPTION
## ✨ What this PR does

Fixes the "admin save → site rebuilds → change not visible" race reported today.

**Root cause:** `raw.githubusercontent.com` caches files for ~5 minutes. The full timeline for the sponsor update on `taller-cloud-certification-2026`:

| UTC | Event |
|---|---|
| 12:05:19 | Commit with new sponsors lands in `gdg-ica-data` (sha `4ec6c1d`) |
| 12:05:28 | Cloud Function dispatches `data-updated` (9 s after the write) |
| 12:05:47 | Workflow starts, clones `gdg-ica-data` for images |
| 12:05:50 | Astro build calls `fetchGdgData` → HTTPS GET to `raw.githubusercontent.com` → **CDN still serves pre-commit JSON** (only 31 s old) |
| 12:05:57 | HTML built with empty sponsors array |
| 12:06:40 | Hosting publishes stale HTML — deploy reports success |

So the rebuild ran and succeeded; it just read stale data.

**Fix:** Reuse the `gdg-ica-data` git clone the workflow already makes (`/tmp/gdg-data`). When `GDG_DATA_LOCAL_PATH` is set, `fetchGdgData` reads from that directory instead of hitting `raw.githubusercontent.com`. No CDN, no staleness. Local dev (env var unset) keeps fetching over HTTPS — no behavior change.

## 🛡️ Secret-leak review

The user specifically asked for care with env vars. Verified:

- `process.env.GDG_DATA_LOCAL_PATH` is read only inside `src/loaders/fetch-gdg-data.ts`, which is a build-time Node loader consumed by `src/content.config.ts`. It never enters the client bundle.
- Confirmed empirically: `grep -r "GDG_DATA_LOCAL_PATH"` against `dist/_astro` returns nothing after `pnpm build`. `raw.githubusercontent` and `gdg-ica-data` strings are also absent from the client bundle.
- `GDG_DATA_LOCAL_PATH` holds a filesystem path (`/tmp/gdg-data`), not a secret. Even if it leaked the value carries no exploitable info.
- The env var is scoped to the `Build project` step only in `deploy.yml`, not exported at job level.
- `LOCAL_PATH` is `path.resolve()`-d once at import time, and each `fetchGdgData(path)` call runs a containment check to ensure the resolved file stays inside `LOCAL_PATH` — defends against a hypothetical compromised `events/index.json` with `../` segments.

## 📂 Data repo boundary

- No JSON data files added or vendored into this repo. `gdg-ica-data` remains the single source of truth.
- The clone in CI lives at `/tmp/gdg-data`, a GitHub Actions runner temp path that is destroyed when the job ends.

## 🔗 Related issue

Closes #None

## ✅ Checklist

- [x] `pnpm build` passes against the HTTPS path (no env var)
- [x] `GDG_DATA_LOCAL_PATH=/tmp/<clone> pnpm build` passes and produces `/eventos/taller-cloud-certification-2026/index.html` with all 3 sponsors rendered
- [x] `dist/_astro` does not contain `GDG_DATA_LOCAL_PATH`, `raw.githubusercontent`, or `gdg-ica-data`
- [ ] After deploy, a fresh admin save on any event surfaces on the site within the next rebuild window
