### PR TITLE
fix(events): multi-track schedule rendering and admin track form

### DIFF
--- a/src/components/TrackTabSchedule.astro
+++ b/src/components/TrackTabSchedule.astro
@@ -44,10 +44,10 @@ const trackSessions = schedule.trackSessions;
       {
         tracks.map((track, index) => (
           <button
-            class={`track-tab-btn group relative rounded-t-lg px-5 py-3.5 text-sm font-semibold transition-all duration-300 hover:bg-gray-50 ${
+            class={`track-tab-btn group relative rounded-t-lg px-5 py-3.5 text-sm font-semibold transition-all duration-300 hover:bg-gray-50 dark:hover:bg-gray-800 ${
               index === 0
-                ? "text-gray-900"
-                : "text-gray-500 hover:text-gray-700"
+                ? "text-gray-900 dark:text-white"
+                : "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
             }`}
             data-track={track.id}
           >
@@ -106,7 +106,8 @@ const trackSessions = schedule.trackSessions;
                       class="hidden h-8 w-8 items-center justify-center rounded-xl shadow-md transition-all duration-300 group-hover:scale-110 group-hover:shadow-lg md:flex"
                       style={`background-color: ${track.color}`}
                     >
-                      {session.type === "networking" ? (
+                      {session.type === "networking" ||
+                      session.type === "break" ? (
                         <Coffee size={16} class="text-white" />
                       ) : session.type === "workshop" ? (
                         <Users size={16} class="text-white" />
@@ -128,7 +129,8 @@ const trackSessions = schedule.trackSessions;
                   <div class="w-full flex-grow">
                     <div
                       class={`relative overflow-hidden rounded-2xl border-2 bg-white p-6 transition-all duration-300 ${
-                        session.type === "networking"
+                        session.type === "networking" ||
+                        session.type === "break"
                           ? "border-orange-200 hover:border-orange-300 hover:shadow-orange-100"
                           : "border-gray-100 hover:border-gray-200"
                       } hover:-translate-y-1 hover:shadow-xl`}
@@ -152,7 +154,9 @@ const trackSessions = schedule.trackSessions;
                               ? "🛠️ Taller"
                               : session.type === "networking"
                                 ? "☕ Networking"
-                                : "🎤 Charla"}
+                                : session.type === "break"
+                                  ? "☕ Break"
+                                  : "🎤 Charla"}
                           </span>
                           <span class="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-semibold text-gray-700">
                             <Clock size={13} />
@@ -160,31 +164,33 @@ const trackSessions = schedule.trackSessions;
                           </span>
                         </div>
 
-                        {session.type !== "networking" && (
-                          <div class="flex items-center gap-4 border-t-2 border-gray-50 pt-4">
-                            <div class="relative">
-                              <Image
-                                src={session.image || "/placeholder.svg"}
-                                alt={session.name}
-                                width={48}
-                                height={48}
-                                class="h-12 w-12 rounded-xl bg-gray-100 object-cover ring-2 ring-gray-100"
-                              />
-                              <div
-                                class="absolute -right-1 -bottom-1 h-4 w-4 rounded-full border-2 border-white"
-                                style={`background-color: ${track.color}`}
-                              />
+                        {session.type !== "networking" &&
+                          session.type !== "break" &&
+                          session.name && (
+                            <div class="flex items-center gap-4 border-t-2 border-gray-50 pt-4">
+                              <div class="relative">
+                                <Image
+                                  src={session.image || "/placeholder.svg"}
+                                  alt={session.name}
+                                  width={48}
+                                  height={48}
+                                  class="h-12 w-12 rounded-xl bg-gray-100 object-cover ring-2 ring-gray-100"
+                                />
+                                <div
+                                  class="absolute -right-1 -bottom-1 h-4 w-4 rounded-full border-2 border-white"
+                                  style={`background-color: ${track.color}`}
+                                />
+                              </div>
+                              <div class="flex-grow">
+                                <p class="text-sm font-bold text-gray-900">
+                                  {session.name}
+                                </p>
+                                <p class="mt-0.5 line-clamp-1 text-xs text-gray-600">
+                                  {session.role}
+                                </p>
+                              </div>
                             </div>
-                            <div class="flex-grow">
-                              <p class="text-sm font-bold text-gray-900">
-                                {session.name}
-                              </p>
-                              <p class="mt-0.5 line-clamp-1 text-xs text-gray-600">
-                                {session.role}
-                              </p>
-                            </div>
-                          </div>
-                        )}
+                          )}
                       </div>
                     </div>
                   </div>

--- a/src/components/react/admin/events/EventForm.tsx
+++ b/src/components/react/admin/events/EventForm.tsx
@@ -376,12 +376,21 @@ export function EventForm() {
   function updateTrack(index: number, field: keyof TrackDef, value: string) {
     setForm((prev) => {
       const oldId = prev.tracks[index].id;
+      const updates: Partial<TrackDef> = { [field]: value };
+      if (field === "name") {
+        updates.id =
+          value
+            .toLowerCase()
+            .replace(/\s+/g, "-")
+            .replace(/[^a-z0-9-]/g, "") || `track-${index + 1}`;
+      }
       const newTracks = prev.tracks.map((t, i) =>
-        i === index ? { ...t, [field]: value } : t
+        i === index ? { ...t, ...updates } : t
       );
+      const newId = newTracks[index].id;
       const newSessions = { ...prev.track_sessions };
-      if (field === "id" && oldId !== value) {
-        newSessions[value] = newSessions[oldId] || [];
+      if (oldId !== newId) {
+        newSessions[newId] = newSessions[oldId] || [];
         delete newSessions[oldId];
       }
       return { ...prev, tracks: newTracks, track_sessions: newSessions };
@@ -1169,13 +1178,6 @@ export function EventForm() {
                 </h4>
                 {form.tracks.map((track, i) => (
                   <div key={i} className="mb-2 flex items-center gap-2">
-                    <input
-                      type="text"
-                      value={track.id}
-                      onChange={(e) => updateTrack(i, "id", e.target.value)}
-                      placeholder="ID"
-                      className={`${inputClass} w-24`}
-                    />
                     <input
                       type="text"
                       value={track.name}


### PR DESCRIPTION
## ✨ What this PR does

Fixes several issues in multi-track schedule rendering and admin track form.

- Track tab names are now visible on dark backgrounds
- "break" session type is fully supported (label, icon, border styling)
- Speaker section is hidden for break sessions and when no speaker is assigned
- Removed redundant track ID input from the admin form; ID is now auto-generated from the track name

## 🔗 Related issue

Closes #None

## ✅ Checklist

- [x] `pnpm build` passes
- [x] Visual check on event page with multi-track schedule
- [x] Admin form track creation verified
