### PR TITLE
fix(events): show placeholder when track schedule is empty

### DIFF
--- a/src/loaders/transform-events.ts
+++ b/src/loaders/transform-events.ts
@@ -166,7 +166,7 @@ function transformEvent(
 }
 
 function buildSchedule(event: ExternalEvent) {
-  if (event.track_sessions) {
+  if (event.track_sessions && Object.keys(event.track_sessions).length > 0) {
     const trackSessions: Record<string, (typeof event.track_sessions)[string]> =
       {};
     for (const [track, sessions] of Object.entries(event.track_sessions)) {

--- a/src/pages/eventos/[slug].astro
+++ b/src/pages/eventos/[slug].astro
@@ -132,7 +132,13 @@ const schedule = event.data.schedule;
 const isArraySchedule = Array.isArray(schedule);
 const isTrackSchedule =
   !isArraySchedule && "trackSessions" in (schedule as object);
-const hasSchedule = isArraySchedule ? (schedule as unknown[]).length > 0 : true;
+const hasSchedule = isArraySchedule
+  ? (schedule as unknown[]).length > 0
+  : isTrackSchedule
+    ? Object.keys(
+        (schedule as { trackSessions: Record<string, unknown[]> }).trackSessions
+      ).length > 0
+    : false;
 
 const whatsappGroupLink = event.data.whatsappGroupLink;
 const whatsappQrSvg = whatsappGroupLink


### PR DESCRIPTION
## ✨ What this PR does

Events with an empty `track_sessions` object were rendering a blank agenda section instead of the "Nuestra agenda está en construcción" placeholder.

- Loader now skips the track schedule path when `track_sessions` is empty, falling through to the agenda array or the empty array fallback
- Page template now checks that `trackSessions` has entries before considering the schedule as present

## 🔗 Related issue

Closes #None

## ✅ Checklist

- [x] `pnpm build` passes
- [ ] Events with empty agenda show placeholder message
- [ ] Events with tracks still render correctly
