### PR TITLE
fix(admin): show navigation menu on mobile devices

### DIFF
--- a/src/components/react/admin/AdminShell.tsx
+++ b/src/components/react/admin/AdminShell.tsx
@@ -20,6 +20,7 @@ interface Props {
 export function AdminShell({ currentPage, children }: Props) {
   const { user, role, signOut, isAdmin } = useAuth();
   const [dark, setDark] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   useEffect(() => {
     setDark(document.documentElement.classList.contains("dark"));
@@ -34,70 +35,111 @@ export function AdminShell({ currentPage, children }: Props) {
 
   const visibleItems = NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin);
 
+  const sidebarContent = (
+    <>
+      <div className="flex h-16 items-center gap-3 border-b border-gray-200 px-6 dark:border-gray-700">
+        <img src="/gdg-logo.png" alt="GDG ICA" className="h-8 w-8" />
+        <div className="flex-1">
+          <p className="text-sm font-bold text-gray-900 dark:text-white">
+            GDG ICA
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Admin Panel
+          </p>
+        </div>
+        <button
+          onClick={() => setMobileMenuOpen(false)}
+          className="rounded-lg p-1 text-gray-500 hover:bg-gray-100 lg:hidden dark:text-gray-400 dark:hover:bg-gray-700"
+        >
+          ✕
+        </button>
+      </div>
+      <nav className="flex-1 overflow-auto p-4">
+        <ul className="space-y-1">
+          {visibleItems.map((item) => (
+            <li key={item.href}>
+              <a
+                href={item.href}
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  currentPage === item.href
+                    ? "bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                    : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+                }`}
+              >
+                <span>{item.icon}</span>
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div className="space-y-3 border-t border-gray-200 p-4 dark:border-gray-700">
+        <button
+          onClick={toggleTheme}
+          className="flex w-full items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          {dark ? "☀️ Modo claro" : "🌙 Modo oscuro"}
+        </button>
+        <a
+          href="/"
+          className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          ← Volver al sitio
+        </a>
+      </div>
+    </>
+  );
+
   return (
     <div className="flex h-screen overflow-hidden bg-gray-50 dark:bg-gray-900">
-      <aside className="hidden w-64 border-r border-gray-200 bg-white lg:block dark:border-gray-700 dark:bg-gray-800">
-        <div className="flex h-16 items-center gap-3 border-b border-gray-200 px-6 dark:border-gray-700">
-          <img src="/gdg-logo.png" alt="GDG ICA" className="h-8 w-8" />
-          <div>
-            <p className="text-sm font-bold text-gray-900 dark:text-white">
-              GDG ICA
-            </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Admin Panel
-            </p>
-          </div>
-        </div>
-        <nav className="p-4">
-          <ul className="space-y-1">
-            {visibleItems.map((item) => (
-              <li key={item.href}>
-                <a
-                  href={item.href}
-                  className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                    currentPage === item.href
-                      ? "bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
-                      : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
-                  }`}
-                >
-                  <span>{item.icon}</span>
-                  {item.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
-        <div className="absolute bottom-0 w-64 space-y-3 border-t border-gray-200 p-4 dark:border-gray-700">
-          <button
-            onClick={toggleTheme}
-            className="flex w-full items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-          >
-            {dark ? "☀️ Modo claro" : "🌙 Modo oscuro"}
-          </button>
-          <a
-            href="/"
-            className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-          >
-            ← Volver al sitio
-          </a>
-        </div>
+      {/* Desktop sidebar */}
+      <aside className="hidden w-64 flex-col border-r border-gray-200 bg-white lg:flex dark:border-gray-700 dark:bg-gray-800">
+        {sidebarContent}
       </aside>
 
+      {/* Mobile sidebar overlay */}
+      {mobileMenuOpen && (
+        <div className="fixed inset-0 z-40 lg:hidden">
+          <div
+            className="fixed inset-0 bg-black/50"
+            onClick={() => setMobileMenuOpen(false)}
+          />
+          <aside className="fixed inset-y-0 left-0 z-50 flex w-64 flex-col bg-white dark:bg-gray-800">
+            {sidebarContent}
+          </aside>
+        </div>
+      )}
+
       <div className="flex min-w-0 flex-1 flex-col">
-        <header className="flex h-16 items-center justify-between border-b border-gray-200 bg-white px-6 dark:border-gray-700 dark:bg-gray-800">
-          <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
-            {currentPage === "/admin"
-              ? "Dashboard"
-              : visibleItems.find((i) => i.href === currentPage)?.label ||
-                "Admin"}
-          </h1>
-          <div className="flex items-center gap-4">
+        <header className="flex h-16 items-center justify-between border-b border-gray-200 bg-white px-4 sm:px-6 dark:border-gray-700 dark:bg-gray-800">
+          <div className="flex items-center gap-3">
             <button
-              onClick={toggleTheme}
-              className="rounded-lg px-2 py-1.5 text-sm text-gray-600 transition-colors hover:bg-gray-100 lg:hidden dark:text-gray-400 dark:hover:bg-gray-700"
+              onClick={() => setMobileMenuOpen(true)}
+              className="rounded-lg p-1.5 text-gray-600 hover:bg-gray-100 lg:hidden dark:text-gray-400 dark:hover:bg-gray-700"
+              aria-label="Abrir menú"
             >
-              {dark ? "☀️" : "🌙"}
+              <svg
+                className="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth="1.5"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+                />
+              </svg>
             </button>
+            <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
+              {currentPage === "/admin"
+                ? "Dashboard"
+                : visibleItems.find((i) => i.href === currentPage)?.label ||
+                  "Admin"}
+            </h1>
+          </div>
+          <div className="flex items-center gap-4">
             <div className="hidden text-right sm:block">
               <p className="text-sm font-medium text-gray-900 dark:text-white">
                 {user?.displayName}


### PR DESCRIPTION
## ✨ What this PR does

Adds a mobile-friendly navigation menu to the admin panel. Previously the sidebar was hidden on screens below `lg` (1024px) with no way to access navigation items, making the admin panel unusable on mobile devices.

- Added hamburger button in the header (visible only on mobile) to toggle the navigation drawer
- Added mobile slide-out drawer with backdrop that closes on outside tap
- Extracted sidebar content into a shared block so desktop and mobile render the same items
- Desktop sidebar switched from `lg:block` to `lg:flex` for proper layout of the bottom section

## 🔗 Related issue

Closes #None

## ✅ Checklist

- [x] `pnpm build` passes
- [ ] Admin panel navigation is accessible on mobile
- [ ] Desktop layout unchanged
- [ ] Dark mode styling preserved in mobile drawer
