### PR TITLE
fix(admin): allow horizontal scroll on events table for mobile

### DIFF
--- a/src/components/react/admin/events/EventList.tsx
+++ b/src/components/react/admin/events/EventList.tsx
@@ -89,7 +89,7 @@ export function EventList() {
         </a>
       </div>
 
-      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
         <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
           <thead className="bg-gray-50 dark:bg-gray-900">
             <tr>


### PR DESCRIPTION
## ✨ What this PR does

Fixes horizontal scroll on the admin events table so the Edit/Delete actions are reachable on narrow viewports. The wrapper was using `overflow-hidden`, which clipped the rightmost columns on mobile; switched to `overflow-x-auto`.

## 🔗 Related issue

Closes #None

## ✅ Checklist

- [ ] Code tested locally
- [ ] Documentation updated (if applicable)
- [ ] Issue linked correctly
