### PR TITLE
feat(footer): add GitHub repo link with icon

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -115,7 +115,29 @@ const data = {
     <hr class="my-6 text-[#1F2937]" />
     <div class="flex flex-col items-center justify-between gap-4 md:flex-row">
       <p class="text-center text-[#9CA3AF]">{data.copyright}</p>
-      <div class="flex gap-4 text-[#9CA3AF]">
+      <div
+        class="flex flex-wrap items-center justify-center gap-4 text-[#9CA3AF]"
+      >
+        <a
+          href="https://github.com/GDGXICA/gdgxica.github.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Contribuye en GitHub"
+          class="inline-flex items-center gap-2 text-sm hover:text-white"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+            class="h-4 w-4"
+          >
+            <path
+              d="M12 .5C5.73.5.5 5.73.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.11.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.33-1.28-1.68-1.28-1.68-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.71 1.26 3.37.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.21-1.49 3.18-1.18 3.18-1.18.62 1.59.23 2.76.11 3.05.73.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.41-5.27 5.69.41.36.77 1.06.77 2.14v3.17c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5Z"
+            ></path>
+          </svg>
+          Contribuye en GitHub
+        </a>
         <a href="/terminos-y-condiciones" class="text-sm underline"
           >Términos y Condiciones</a
         >


### PR DESCRIPTION
## ✨ What this PR does

Adds a "Contribuye en GitHub" link with the GitHub icon to the footer's bottom row, alongside the legal links. Surfaces the project repository from every page so visitors can discover it's open source and contribute.

## 🔗 Related issue

Closes #None

## ✅ Checklist

- [ ] Code tested locally
- [ ] Documentation updated (if applicable)
- [ ] Issue linked correctly
