### PR TITLE
docs(github): add CODE_OF_CONDUCT, CONTRIBUTING and SECURITY files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Código de Conducta
+
+## Nuestro compromiso
+
+Como miembros, colaboradores y líderes, nos comprometemos a hacer de la participación en nuestra comunidad una experiencia libre de acoso para todos, independientemente de la edad, tamaño corporal, discapacidad visible o invisible, etnia, características sexuales, identidad y expresión de género, nivel de experiencia, educación, estatus socioeconómico, nacionalidad, apariencia personal, raza, religión o identidad y orientación sexual.
+
+Nos comprometemos a actuar e interactuar de maneras que contribuyan a una comunidad abierta, acogedora, diversa, inclusiva y saludable.
+
+## Nuestros estándares
+
+Ejemplos de comportamiento que contribuyen a un ambiente positivo:
+
+- Demostrar empatía y amabilidad hacia otras personas
+- Respetar las opiniones, puntos de vista y experiencias diferentes
+- Dar y aceptar con gracia la retroalimentación constructiva
+- Aceptar la responsabilidad y disculparse con quienes se vean afectados por nuestros errores, aprendiendo de la experiencia
+- Centrarse en lo que es mejor no solo para nosotros como individuos, sino para la comunidad en general
+
+Ejemplos de comportamiento inaceptable:
+
+- El uso de lenguaje o imágenes sexualizadas y la atención o insinuaciones sexuales de cualquier tipo
+- Comentarios insultantes o despectivos (_trolling_) y ataques personales o políticos
+- El acoso público o privado
+- Publicar información privada de otras personas, como direcciones físicas o de correo electrónico, sin su permiso explícito
+- Otras conductas que pudieran considerarse inapropiadas en un entorno profesional
+
+## Responsabilidades de aplicación
+
+Los líderes de la comunidad son responsables de aclarar y hacer cumplir nuestros estándares de comportamiento aceptable y tomarán acciones correctivas apropiadas y justas en respuesta a cualquier comportamiento que consideren inapropiado, amenazante, ofensivo o dañino.
+
+## Alcance
+
+Este Código de Conducta aplica en todos los espacios de la comunidad y también cuando una persona representa oficialmente a la comunidad en espacios públicos.
+
+## Aplicación
+
+Los casos de comportamiento abusivo, acosador o inaceptable pueden reportarse a los líderes de la comunidad responsables a través del correo **gdgica1@gmail.com**. Todas las quejas serán revisadas e investigadas de manera oportuna y justa.
+
+## Atribución
+
+Este Código de Conducta es una adaptación del [Contributor Covenant](https://www.contributor-covenant.org), versión 2.1.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Guía de Contribución
+
+¡Gracias por tu interés en contribuir al sitio web de GDG ICA! Esta guía explica cómo participar en el proyecto.
+
+## Antes de empezar
+
+- Lee el [Código de Conducta](CODE_OF_CONDUCT.md).
+- Revisa los [issues abiertos](https://github.com/GDGXICA/gdgxica.github.io/issues) para ver si alguien ya está trabajando en lo que quieres hacer.
+- Para cambios grandes, abre un issue primero para discutir el enfoque antes de invertir tiempo en código.
+- Consulta con el equipo antes de agregar nuevas dependencias.
+
+## Flujo de trabajo
+
+1. Haz un fork del repositorio y crea tu rama desde `main`.
+2. Nombra tu rama siguiendo la convención:
+   - `feature/NombreFeature` para nuevas funcionalidades
+   - `fix/NombreBug` para correcciones
+   - `docs/NombreDoc` para documentación
+3. Realiza tus cambios y verifica que el proyecto compila sin errores (`pnpm build`).
+4. Asegúrate de que el linter pasa (`pnpm lint`).
+5. Haz commit usando el formato convencional (ver abajo).
+6. Abre un Pull Request hacia `main` con una descripción clara de los cambios.
+
+## Formato de commits
+
+Usa el prefijo adecuado:
+
+```
+feat:     nueva funcionalidad
+fix:      corrección de bug
+docs:     cambios en documentación
+style:    cambios de formato (sin lógica)
+refactor: refactorización de código
+test:     adición o corrección de tests
+chore:    tareas de mantenimiento
+```
+
+Ejemplo: `feat: agregar sección de sponsors en homepage`
+
+## Reglas de código
+
+- Sin `console.log` en código de producción.
+- Sin `!important` en CSS; usa utilidades de Tailwind.
+- Componentes `.astro` para contenido estático; React (`.jsx`/`.tsx`) solo para interactividad en el cliente.
+- El contenido del sitio está en español.
+
+## Configuración local
+
+```bash
+# Instalar dependencias
+pnpm install
+
+# Servidor de desarrollo
+pnpm dev
+
+# Build de producción
+pnpm build
+```
+
+## ¿Tienes preguntas?
+
+Abre un issue o contáctanos en **gdgica1@gmail.com**.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,21 @@
+# Política de Seguridad
+
+## Versiones soportadas
+
+Solo la versión en producción del sitio (rama `main`) recibe actualizaciones de seguridad.
+
+## Reportar una vulnerabilidad
+
+Si descubres una vulnerabilidad de seguridad, **no abras un issue público**. Envía un reporte privado a:
+
+**gdgica1@gmail.com**
+
+Incluye en tu reporte:
+
+- Descripción del problema y su posible impacto
+- Pasos para reproducirlo
+- Cualquier prueba de concepto o capturas relevantes
+
+Nos comprometemos a responder en un plazo de **72 horas** y a mantenerte informado del proceso de resolución. Una vez corregida la vulnerabilidad, la divulgaremos públicamente con el crédito correspondiente si así lo deseas.
+
+Agradecemos el reporte responsable y la colaboración de la comunidad para mantener este proyecto seguro.


### PR DESCRIPTION
## ✨ Qué hace este PR

Agrega los tres archivos requeridos por GitHub Community Standards que faltaban en el repositorio:

- **`CODE_OF_CONDUCT.md`** — Código de conducta basado en Contributor Covenant 2.1, adaptado a GDG ICA
- **`CONTRIBUTING.md`** — Guía de contribución con flujo de trabajo, convenciones de commits y reglas del proyecto
- **`SECURITY.md`** — Política de seguridad con canal de reporte privado y compromiso de respuesta en 72h

Con estos archivos el checklist de Community Standards queda completo.

## 🔗 Issue relacionada

N/A

## ✅ Checklist

- [x] Código probado localmente
- [x] Documentación actualizada (si aplica)
- [ ] Issue enlazada correctamente