### PR TITLE
feat(admin): saved locations catalog

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -13,6 +13,10 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    match /locations/{locationId} {
+      allow read, write: if false;
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }

--- a/functions/src/handlers/locations.ts
+++ b/functions/src/handlers/locations.ts
@@ -1,0 +1,117 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import {
+  safeError,
+  validateUrl,
+  validateMapEmbedUrl,
+} from "../middleware/validate";
+
+export async function list(_req: Request, res: Response) {
+  try {
+    const snap = await admin
+      .firestore()
+      .collection("locations")
+      .orderBy("createdAt", "desc")
+      .get();
+    res.json({
+      success: true,
+      data: snap.docs.map((d) => ({ id: d.id, ...d.data() })),
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+export async function create(req: Request, res: Response) {
+  try {
+    const user = (req as AuthenticatedRequest).user;
+    const { name, address, map_url, map_embed } = req.body;
+    if (map_url && !validateUrl(map_url)) {
+      res.status(400).json({ success: false, error: "Invalid map_url" });
+      return;
+    }
+    if (map_embed && !validateMapEmbedUrl(map_embed)) {
+      res.status(400).json({ success: false, error: "Invalid map_embed URL" });
+      return;
+    }
+    const ref = await admin.firestore().collection("locations").add({
+      name,
+      address,
+      map_url,
+      map_embed,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdBy: user.uid,
+    });
+    admin.firestore().collection("audit_log").add({
+      action: "location.create",
+      performedBy: user.uid,
+      targetId: ref.id,
+      targetType: "location",
+      details: { name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    res.status(201).json({ success: true, data: { id: ref.id } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+export async function update(req: Request, res: Response) {
+  try {
+    const id = req.params.id as string;
+    const user = (req as AuthenticatedRequest).user;
+    const { name, address, map_url, map_embed } = req.body;
+    if (map_url && !validateUrl(map_url)) {
+      res.status(400).json({ success: false, error: "Invalid map_url" });
+      return;
+    }
+    if (map_embed && !validateMapEmbedUrl(map_embed)) {
+      res.status(400).json({ success: false, error: "Invalid map_embed URL" });
+      return;
+    }
+    const ref = admin.firestore().collection("locations").doc(id);
+    if (!(await ref.get()).exists) {
+      res.status(404).json({ success: false, error: "Location not found" });
+      return;
+    }
+    await ref.update({ name, address, map_url, map_embed });
+    admin.firestore().collection("audit_log").add({
+      action: "location.update",
+      performedBy: user.uid,
+      targetId: id,
+      targetType: "location",
+      details: { name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    res.json({ success: true, data: { id } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+export async function remove(req: Request, res: Response) {
+  try {
+    const id = req.params.id as string;
+    const user = (req as AuthenticatedRequest).user;
+    const ref = admin.firestore().collection("locations").doc(id);
+    const doc = await ref.get();
+    if (!doc.exists) {
+      res.status(404).json({ success: false, error: "Location not found" });
+      return;
+    }
+    const name = (doc.data()?.name as string) || id;
+    await ref.delete();
+    admin.firestore().collection("audit_log").add({
+      action: "location.delete",
+      performedBy: user.uid,
+      targetId: id,
+      targetType: "location",
+      details: { name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,6 +12,7 @@ import {
   speakerSchema,
   sponsorSchema,
   teamMemberSchema,
+  locationSchema,
 } from "./schemas";
 import { register } from "./handlers/auth";
 import * as events from "./handlers/events";
@@ -22,6 +23,7 @@ import * as stats from "./handlers/stats";
 import * as users from "./handlers/users";
 import * as forms from "./handlers/forms";
 import { triggerRebuild } from "./handlers/rebuild";
+import * as locations from "./handlers/locations";
 
 admin.initializeApp();
 
@@ -227,6 +229,31 @@ app.get(
   requireRole("organizer"),
   vid,
   forms.getFormResponses
+);
+
+// Locations
+app.get("/api/locations", requireRole("organizer"), locations.list);
+app.post(
+  "/api/locations",
+  requireRole("organizer"),
+  writeLimiter,
+  validateBody(locationSchema),
+  locations.create
+);
+app.put(
+  "/api/locations/:id",
+  requireRole("organizer"),
+  vid,
+  writeLimiter,
+  validateBody(locationSchema),
+  locations.update
+);
+app.delete(
+  "/api/locations/:id",
+  requireRole("admin"),
+  vid,
+  writeLimiter,
+  locations.remove
 );
 
 // Rebuild

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -130,3 +130,12 @@ export const teamMemberSchema = z
     responsibilities: z.array(shortText(500)).max(50).optional(),
   })
   .strict();
+
+export const locationSchema = z
+  .object({
+    name: shortText(500).min(1),
+    address: shortText(1000).default(""),
+    map_url: shortText(2000).default(""),
+    map_embed: shortText(2000).default(""),
+  })
+  .strict();

--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -12,6 +12,7 @@ import { StatsEditor } from "./stats/StatsEditor";
 import { UserDirectory } from "./users/UserDirectory";
 import { FormRegistry } from "./forms/FormRegistry";
 import { FormViewer } from "./forms/FormViewer";
+import { LocationList } from "./locations/LocationList";
 
 interface Props {
   page: string;
@@ -89,6 +90,8 @@ function AdminContent({ page, currentPath }: Props) {
         return <FormRegistry />;
       case "form-viewer":
         return <FormViewer />;
+      case "ubicaciones":
+        return <LocationList />;
       default:
         return (
           <p className="text-gray-500 dark:text-gray-400">
@@ -124,6 +127,8 @@ function DevContent({ page, currentPath }: Props) {
         return <FormRegistry />;
       case "form-viewer":
         return <FormViewer />;
+      case "ubicaciones":
+        return <LocationList />;
       default:
         return (
           <p className="text-gray-500 dark:text-gray-400">

--- a/src/components/react/admin/AdminShell.tsx
+++ b/src/components/react/admin/AdminShell.tsx
@@ -6,6 +6,7 @@ const NAV_ITEMS = [
   { label: "Eventos", href: "/admin/eventos", icon: "📅" },
   { label: "Equipo", href: "/admin/equipo", icon: "👥", adminOnly: true },
   { label: "Speakers", href: "/admin/speakers", icon: "🎤" },
+  { label: "Ubicaciones", href: "/admin/ubicaciones", icon: "📍" },
   { label: "Sponsors", href: "/admin/sponsors", icon: "🤝", adminOnly: true },
   { label: "Usuarios", href: "/admin/usuarios", icon: "👤", adminOnly: true },
   { label: "Stats", href: "/admin/stats", icon: "📈", adminOnly: true },

--- a/src/components/react/admin/events/EventForm.tsx
+++ b/src/components/react/admin/events/EventForm.tsx
@@ -71,6 +71,14 @@ interface RegisteredSponsor {
   sector: string;
 }
 
+interface Location {
+  id: string;
+  name: string;
+  address: string;
+  map_url: string;
+  map_embed: string;
+}
+
 interface EventData {
   id: string;
   title: string;
@@ -161,6 +169,8 @@ export function EventForm() {
   const [availableSponsors, setAvailableSponsors] = useState<
     RegisteredSponsor[]
   >([]);
+  const [availableLocations, setAvailableLocations] = useState<Location[]>([]);
+  const [savingLocation, setSavingLocation] = useState(false);
   const [scheduleMode, setScheduleMode] = useState<"simple" | "multitrack">(
     "simple"
   );
@@ -176,6 +186,11 @@ export function EventForm() {
     api.listSpeakers().then((res) => {
       if (res.success && res.data) {
         setAvailableSpeakers(res.data as Speaker[]);
+      }
+    });
+    api.listLocations().then((res) => {
+      if (res.success && res.data) {
+        setAvailableLocations(res.data as Location[]);
       }
     });
   }, []);
@@ -208,6 +223,47 @@ export function EventForm() {
 
   function updateField(field: keyof EventData, value: unknown) {
     setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function applyLocation(locationId: string) {
+    const loc = availableLocations.find((l) => l.id === locationId);
+    if (!loc) return;
+    setForm((prev) => ({
+      ...prev,
+      venue: loc.name,
+      venue_address: loc.address,
+      venue_map_url: loc.map_url,
+      venue_map_embed: loc.map_embed,
+    }));
+  }
+
+  async function handleSaveLocation() {
+    if (!form.venue) {
+      setToast({
+        message: "El nombre de la sede es obligatorio",
+        type: "error",
+      });
+      return;
+    }
+    setSavingLocation(true);
+    const res = await api.addLocation({
+      name: form.venue,
+      address: form.venue_address,
+      map_url: form.venue_map_url,
+      map_embed: form.venue_map_embed,
+    });
+    if (res.success) {
+      setToast({ message: "Ubicación guardada", type: "success" });
+      api.listLocations().then((r) => {
+        if (r.success && r.data) setAvailableLocations(r.data as Location[]);
+      });
+    } else {
+      setToast({
+        message: res.error || "Error al guardar ubicación",
+        type: "error",
+      });
+    }
+    setSavingLocation(false);
   }
 
   function addToList(
@@ -660,6 +716,24 @@ export function EventForm() {
                 className={inputClass}
               />
             </FormField>
+            {availableLocations.length > 0 && (
+              <div className="sm:col-span-2">
+                <FormField label="Cargar ubicación guardada">
+                  <select
+                    className={inputClass}
+                    value=""
+                    onChange={(e) => applyLocation(e.target.value)}
+                  >
+                    <option value="">Seleccionar ubicación guardada...</option>
+                    {availableLocations.map((loc) => (
+                      <option key={loc.id} value={loc.id}>
+                        {loc.name}
+                      </option>
+                    ))}
+                  </select>
+                </FormField>
+              </div>
+            )}
             <FormField label="Sede">
               <input
                 type="text"
@@ -693,6 +767,18 @@ export function EventForm() {
                 className={inputClass}
               />
             </FormField>
+            <div className="flex justify-end sm:col-span-2">
+              <button
+                type="button"
+                onClick={handleSaveLocation}
+                disabled={savingLocation || !form.venue}
+                className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                {savingLocation
+                  ? "Guardando..."
+                  : "Guardar como nueva ubicación"}
+              </button>
+            </div>
             <FormField label="URL imagen">
               <input
                 type="url"

--- a/src/components/react/admin/locations/LocationList.tsx
+++ b/src/components/react/admin/locations/LocationList.tsx
@@ -1,0 +1,396 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "@/lib/api";
+import { Toast } from "../ui/Toast";
+import { FormField } from "../ui/FormField";
+
+interface Location {
+  id: string;
+  name: string;
+  address: string;
+  map_url: string;
+  map_embed: string;
+}
+
+type LocationForm = Omit<Location, "id"> & { id?: string };
+
+const EMPTY_LOCATION: LocationForm = {
+  name: "",
+  address: "",
+  map_url: "",
+  map_embed: "",
+};
+
+const PAGE_SIZE = 10;
+
+export function LocationList() {
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+  const [editing, setEditing] = useState<Location | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+
+  const form: LocationForm | null =
+    editing || (creating ? { ...EMPTY_LOCATION } : null);
+
+  useEffect(() => {
+    loadLocations();
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return locations;
+    const q = search.toLowerCase();
+    return locations.filter(
+      (l) =>
+        l.name.toLowerCase().includes(q) || l.address.toLowerCase().includes(q)
+    );
+  }, [locations, search]);
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  useEffect(() => {
+    setPage(1);
+  }, [search]);
+
+  async function loadLocations() {
+    setLoading(true);
+    const res = await api.listLocations();
+    if (res.success && res.data) {
+      setLocations(res.data as Location[]);
+    } else {
+      setError(res.error || "Error al cargar ubicaciones");
+    }
+    setLoading(false);
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form) return;
+    setSaving(true);
+    const isNew = creating;
+    const payload = {
+      name: form.name,
+      address: form.address,
+      map_url: form.map_url,
+      map_embed: form.map_embed,
+    };
+    const res = isNew
+      ? await api.addLocation(payload)
+      : await api.updateLocation((form as Location).id, payload);
+
+    if (res.success) {
+      setToast({
+        message: `Ubicación ${isNew ? "agregada" : "actualizada"}`,
+        type: "success",
+      });
+      setEditing(null);
+      setCreating(false);
+      loadLocations();
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setSaving(false);
+  }
+
+  async function handleDelete(id: string, name: string) {
+    if (!confirm(`Eliminar ubicación "${name}"?`)) return;
+    setDeleting(id);
+    const res = await api.deleteLocation(id);
+    if (res.success) {
+      setLocations((prev) => prev.filter((l) => l.id !== id));
+      setToast({ message: "Ubicación eliminada", type: "success" });
+    } else {
+      setToast({ message: res.error || "Error", type: "error" });
+    }
+    setDeleting(null);
+  }
+
+  function updateForm(field: keyof LocationForm, value: string) {
+    if (editing) setEditing({ ...editing, [field]: value });
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+        {error}
+      </div>
+    );
+  }
+
+  const inputClass =
+    "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400";
+
+  if (form) {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <button
+          onClick={() => {
+            setEditing(null);
+            setCreating(false);
+          }}
+          className="mb-4 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+        >
+          ← Volver a ubicaciones
+        </button>
+        <h2 className="mb-6 text-xl font-bold text-gray-900 dark:text-white">
+          {creating
+            ? "Agregar ubicación"
+            : `Editar: ${(form as Location).name}`}
+        </h2>
+        <form onSubmit={handleSave} className="space-y-6">
+          <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="sm:col-span-2">
+                <FormField label="Nombre" required>
+                  <input
+                    type="text"
+                    value={form.name}
+                    onChange={(e) => updateForm("name", e.target.value)}
+                    placeholder="Universidad Tecnológica Del Perú (UTP) - Sede Ica"
+                    className={inputClass}
+                  />
+                </FormField>
+              </div>
+              <div className="sm:col-span-2">
+                <FormField label="Dirección">
+                  <input
+                    type="text"
+                    value={form.address}
+                    onChange={(e) => updateForm("address", e.target.value)}
+                    placeholder="Av. Ayabaca S/N, Ica 11001"
+                    className={inputClass}
+                  />
+                </FormField>
+              </div>
+              <div className="sm:col-span-2">
+                <FormField label="Google Maps URL">
+                  <input
+                    type="url"
+                    value={form.map_url}
+                    onChange={(e) => updateForm("map_url", e.target.value)}
+                    placeholder="https://maps.app.goo.gl/..."
+                    className={inputClass}
+                  />
+                </FormField>
+              </div>
+              <div className="sm:col-span-2">
+                <FormField label="Google Maps Embed URL">
+                  <input
+                    type="url"
+                    value={form.map_embed}
+                    onChange={(e) => updateForm("map_embed", e.target.value)}
+                    placeholder="https://www.google.com/maps/embed?pb=..."
+                    className={inputClass}
+                  />
+                </FormField>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                setEditing(null);
+                setCreating(false);
+              }}
+              className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {saving ? "Guardando..." : creating ? "Agregar" : "Actualizar"}
+            </button>
+          </div>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar ubicación..."
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none sm:w-64 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+          />
+          <span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
+            {filtered.length} ubicación{filtered.length !== 1 && "es"}
+          </span>
+        </div>
+        <button
+          onClick={() => {
+            setCreating(true);
+            setEditing(null);
+          }}
+          className="shrink-0 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          + Agregar ubicación
+        </button>
+      </div>
+
+      {/* Desktop table */}
+      <div className="hidden overflow-hidden rounded-lg border border-gray-200 bg-white md:block dark:border-gray-700 dark:bg-gray-800">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                Nombre
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                Dirección
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                Acciones
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {paginated.map((loc) => (
+              <tr
+                key={loc.id}
+                className="hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                <td className="px-6 py-4">
+                  <p className="font-medium text-gray-900 dark:text-white">
+                    {loc.name}
+                  </p>
+                </td>
+                <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+                  {loc.address || "—"}
+                </td>
+                <td className="px-6 py-4 text-right">
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => setEditing(loc)}
+                      className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      onClick={() => handleDelete(loc.id, loc.name)}
+                      disabled={deleting === loc.id}
+                      className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+                    >
+                      {deleting === loc.id ? "..." : "Eliminar"}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile cards */}
+      <div className="space-y-3 md:hidden">
+        {paginated.map((loc) => (
+          <div
+            key={loc.id}
+            className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+          >
+            <p className="font-medium text-gray-900 dark:text-white">
+              {loc.name}
+            </p>
+            {loc.address && (
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {loc.address}
+              </p>
+            )}
+            <div className="mt-3 flex justify-end gap-2 border-t border-gray-100 pt-3 dark:border-gray-700">
+              <button
+                onClick={() => setEditing(loc)}
+                className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+              >
+                Editar
+              </button>
+              <button
+                onClick={() => handleDelete(loc.id, loc.name)}
+                disabled={deleting === loc.id}
+                className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+              >
+                {deleting === loc.id ? "..." : "Eliminar"}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {paginated.length === 0 && (
+        <p className="py-8 text-center text-gray-500 dark:text-gray-400">
+          {search ? "Sin resultados" : "No hay ubicaciones guardadas."}
+        </p>
+      )}
+
+      {totalPages > 1 && (
+        <div className="mt-6 flex items-center justify-between">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Mostrando {(page - 1) * PAGE_SIZE + 1}-
+            {Math.min(page * PAGE_SIZE, filtered.length)} de {filtered.length}
+          </p>
+          <div className="flex gap-1">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-40 dark:border-gray-600 dark:text-gray-300"
+            >
+              Anterior
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+              <button
+                key={p}
+                onClick={() => setPage(p)}
+                className={`rounded-lg px-3 py-1.5 text-sm ${
+                  p === page
+                    ? "bg-blue-600 text-white"
+                    : "border border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                }`}
+              >
+                {p}
+              </button>
+            ))}
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-40 dark:border-gray-600 dark:text-gray-300"
+            >
+              Siguiente
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -86,6 +86,13 @@ const realApi = {
   deleteForm: (id: string) => request("DELETE", `/forms/${id}`),
   getFormResponses: (id: string) => request("GET", `/forms/${id}/responses`),
 
+  // Locations
+  listLocations: () => request("GET", "/locations"),
+  addLocation: (data: unknown) => request("POST", "/locations", data),
+  updateLocation: (id: string, data: unknown) =>
+    request("PUT", `/locations/${id}`, data),
+  deleteLocation: (id: string) => request("DELETE", `/locations/${id}`),
+
   // Rebuild
   triggerRebuild: () => request("POST", "/rebuild"),
 };

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -7,6 +7,7 @@ import {
   MOCK_USERS,
   MOCK_FORMS,
   MOCK_FORM_RESPONSES,
+  MOCK_LOCATIONS,
 } from "./mock-data";
 
 function ok<T>(data: T) {
@@ -49,6 +50,11 @@ export const mockApi = {
   updateForm: () => ok({ id: "updated" }),
   deleteForm: () => ok(null),
   getFormResponses: () => ok(MOCK_FORM_RESPONSES),
+
+  listLocations: () => ok(MOCK_LOCATIONS),
+  addLocation: () => ok({ id: "new-location" }),
+  updateLocation: () => ok({ id: "updated" }),
+  deleteLocation: () => ok(null),
 
   triggerRebuild: () => ok(null),
 };

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -144,3 +144,15 @@ export const MOCK_FORM_RESPONSES = {
     ["Ana Torres", "ana@example.com", "Meta", "ML Engineer", "+51 777777"],
   ],
 };
+
+export const MOCK_LOCATIONS = [
+  {
+    id: "loc-utp-ica",
+    name: "Universidad Tecnológica Del Perú (UTP) - Sede Ica",
+    address: "Av. Ayabaca S/N, Ica 11001",
+    map_url: "https://www.google.com/maps/place/UTP+Ica",
+    map_embed: "",
+    createdAt: { _seconds: Math.floor(Date.now() / 1000) },
+    createdBy: "dev-admin",
+  },
+];

--- a/src/pages/admin/ubicaciones/index.astro
+++ b/src/pages/admin/ubicaciones/index.astro
@@ -1,0 +1,8 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Ubicaciones">
+  <AdminApp client:load page="ubicaciones" currentPath="/admin/ubicaciones" />
+</AdminLayout>


### PR DESCRIPTION
## Summary

- New Firestore collection `locations` for storing reusable venue details (name, address, Google Maps URL, embed URL)
- Cloud Functions API: `GET/POST/PUT/DELETE /api/locations` (organizer+ for CRUD, admin for delete)
- New admin page `/admin/ubicaciones` to list, create, edit and delete saved locations
- EventForm: dropdown to load a saved location into all 4 venue fields at once; button to save current venue as a new location
- Firestore rules: explicit client-side deny for `locations` collection (all access via Cloud Functions admin SDK)

## Test plan

- [x] `cd functions && npm run build` — no TypeScript errors
- [x] Dev preview (`npm run dev`): navigate to `/admin/ubicaciones`, create a location using mock data, verify it appears in the list and can be edited/deleted
- [x] Dev preview: open `/admin/eventos/nuevo`, verify the "Cargar ubicación guardada" dropdown appears and fills the 4 venue fields on selection
- [x] Dev preview: fill venue fields and click "Guardar como nueva ubicación", verify success toast
- [x] After deploy: `firebase deploy --only functions,firestore:rules` — smoke test creating a real location and loading it from the event form