### PR TITLE
fix(admin): fix frozen inputs in create location form

### DIFF
--- a/src/components/react/admin/locations/LocationList.tsx
+++ b/src/components/react/admin/locations/LocationList.tsx
@@ -32,13 +32,15 @@ export function LocationList() {
   } | null>(null);
   const [editing, setEditing] = useState<Location | null>(null);
   const [creating, setCreating] = useState(false);
+  const [creatingForm, setCreatingForm] = useState<LocationForm>({
+    ...EMPTY_LOCATION,
+  });
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
 
-  const form: LocationForm | null =
-    editing || (creating ? { ...EMPTY_LOCATION } : null);
+  const form: LocationForm | null = editing || (creating ? creatingForm : null);
 
   useEffect(() => {
     loadLocations();
@@ -93,6 +95,7 @@ export function LocationList() {
       });
       setEditing(null);
       setCreating(false);
+      setCreatingForm({ ...EMPTY_LOCATION });
       loadLocations();
     } else {
       setToast({ message: res.error || "Error", type: "error" });
@@ -115,6 +118,7 @@ export function LocationList() {
 
   function updateForm(field: keyof LocationForm, value: string) {
     if (editing) setEditing({ ...editing, [field]: value });
+    else if (creating) setCreatingForm((prev) => ({ ...prev, [field]: value }));
   }
 
   if (loading) {
@@ -143,6 +147,7 @@ export function LocationList() {
           onClick={() => {
             setEditing(null);
             setCreating(false);
+            setCreatingForm({ ...EMPTY_LOCATION });
           }}
           className="mb-4 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
         >
@@ -252,6 +257,7 @@ export function LocationList() {
         </div>
         <button
           onClick={() => {
+            setCreatingForm({ ...EMPTY_LOCATION });
             setCreating(true);
             setEditing(null);
           }}


### PR DESCRIPTION
## Summary

- `updateForm` en `LocationList.tsx` estaba guardada por `if (editing)`, que es `null` en modo creación, por lo que todos los keystrokes se descartaban silenciosamente
- Se agrega estado separado `creatingForm` que `updateForm` actualiza cuando `creating === true`
- Se resetea `creatingForm` al cancelar o después de guardar exitosamente

## Test plan

- [ ] Ir a `/admin/ubicaciones` → "+ Agregar ubicación"
- [ ] Verificar que los campos Nombre, Dirección, Google Maps URL y Google Maps Embed URL aceptan escritura
- [ ] Guardar una ubicación y verificar que aparece en la lista
- [ ] Editar una ubicación existente y verificar que los campos siguen funcionando