### PR TITLE
feat(admin): mini-game template CRUD (admin-only)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,6 +17,11 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    match /minigame_templates/{templateId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }

--- a/functions/src/handlers/minigameTemplates.test.ts
+++ b/functions/src/handlers/minigameTemplates.test.ts
@@ -1,0 +1,282 @@
+import { Request, Response } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock firebase-admin BEFORE importing the handler so the handler captures
+// the mocked admin. Each test wires the collection() return so we can spy
+// on doc/get/add/set/delete calls.
+const collectionMock = vi.fn();
+const fieldValueServerTimestamp = "__SERVER_TS__";
+
+vi.mock("firebase-admin", () => ({
+  firestore: Object.assign(() => ({ collection: collectionMock }), {
+    FieldValue: {
+      serverTimestamp: () => fieldValueServerTimestamp,
+    },
+  }),
+}));
+
+// Imported after the mock is set up.
+import * as handler from "./minigameTemplates";
+import type { AuthenticatedRequest } from "../middleware/auth";
+
+interface ResMock extends Response {
+  __status: number | undefined;
+  __body: unknown;
+}
+
+function buildRes(): ResMock {
+  const res: Partial<ResMock> = {};
+  res.status = vi.fn(function (this: ResMock, code: number) {
+    this.__status = code;
+    return this;
+  }) as ResMock["status"];
+  res.json = vi.fn(function (this: ResMock, body: unknown) {
+    this.__body = body;
+    return this;
+  }) as ResMock["json"];
+  return res as ResMock;
+}
+
+function buildReq(body: unknown, params: Record<string, string> = {}): Request {
+  const req = {
+    body,
+    params,
+    user: { uid: "admin-uid" },
+  } as unknown as AuthenticatedRequest;
+  return req as unknown as Request;
+}
+
+const samplePoll = {
+  type: "poll" as const,
+  title: "Sample poll",
+  description: "",
+  poll: {
+    question: "What is RAG?",
+    options: [
+      { id: "a", label: "Retrieval Augmented Generation" },
+      { id: "b", label: "Random Access Generator" },
+    ],
+  },
+};
+
+const sampleQuiz = {
+  type: "quiz" as const,
+  title: "Quiz Q1",
+  description: "",
+  quiz: {
+    questions: [
+      {
+        id: "q1",
+        prompt: "Multimodal model from Google?",
+        options: [
+          { id: "a", label: "Gemini" },
+          { id: "b", label: "GPT-4" },
+        ],
+        correctOptionId: "a",
+        timeLimitSec: 30,
+        points: 100,
+      },
+    ],
+  },
+};
+
+const sampleWordcloud = {
+  type: "wordcloud" as const,
+  title: "Hopes for AI",
+  description: "",
+  wordcloud: {
+    prompt: "What do you hope to learn?",
+    maxWordsPerUser: 3,
+    maxLength: 60,
+  },
+};
+
+const sampleBingo = {
+  type: "bingo" as const,
+  title: "Buzzword Bingo",
+  description: "",
+  bingo: {
+    terms: Array.from({ length: 16 }, (_, i) => `term-${i + 1}`),
+    cardSize: 4 as const,
+    freeCenter: false,
+  },
+};
+
+describe("minigameTemplates handler", () => {
+  beforeEach(() => {
+    collectionMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("list", () => {
+    it("returns docs ordered by updatedAt desc", async () => {
+      const docs = [
+        { id: "t1", data: () => ({ ...samplePoll, version: 2 }) },
+        { id: "t2", data: () => ({ ...sampleQuiz, version: 1 }) },
+      ];
+      const orderBy = vi.fn(() => ({ get: vi.fn(async () => ({ docs })) }));
+      collectionMock.mockReturnValue({ orderBy });
+
+      const req = buildReq({});
+      const res = buildRes();
+      await handler.list(req, res);
+
+      expect(collectionMock).toHaveBeenCalledWith("minigame_templates");
+      expect(orderBy).toHaveBeenCalledWith("updatedAt", "desc");
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: [
+          { id: "t1", ...samplePoll, version: 2 },
+          { id: "t2", ...sampleQuiz, version: 1 },
+        ],
+      });
+    });
+  });
+
+  describe("create", () => {
+    it.each([
+      ["poll", samplePoll],
+      ["quiz", sampleQuiz],
+      ["wordcloud", sampleWordcloud],
+      ["bingo", sampleBingo],
+    ])("creates a %s template", async (_label, payload) => {
+      const add = vi.fn(async () => ({ id: "new-id" }));
+      const auditAdd = vi.fn(async () => undefined);
+      collectionMock.mockImplementation((name: string) => {
+        if (name === "minigame_templates") return { add };
+        if (name === "audit_log") return { add: auditAdd };
+        throw new Error("unexpected collection " + name);
+      });
+
+      const res = buildRes();
+      await handler.create(buildReq(payload), res);
+
+      expect(add).toHaveBeenCalledTimes(1);
+      const stored = add.mock.calls[0][0] as Record<string, unknown>;
+      expect(stored).toMatchObject({
+        ...payload,
+        createdBy: "admin-uid",
+        version: 1,
+      });
+      expect(stored.createdAt).toBe(fieldValueServerTimestamp);
+      expect(stored.updatedAt).toBe(fieldValueServerTimestamp);
+      expect(res.__status).toBe(201);
+      expect(res.__body).toEqual({ success: true, data: { id: "new-id" } });
+
+      expect(auditAdd).toHaveBeenCalledTimes(1);
+      const auditPayload = auditAdd.mock.calls[0][0] as Record<string, unknown>;
+      expect(auditPayload).toMatchObject({
+        action: "minigame_template.create",
+        performedBy: "admin-uid",
+        targetId: "new-id",
+        targetType: "minigame_template",
+        details: { type: payload.type, title: payload.title },
+      });
+    });
+
+    it("returns 500 if firestore add throws", async () => {
+      collectionMock.mockReturnValue({
+        add: vi.fn(async () => {
+          throw new Error("write failed");
+        }),
+      });
+      const res = buildRes();
+      await handler.create(buildReq(samplePoll), res);
+      expect(res.__status).toBe(500);
+      expect((res.__body as { success: boolean }).success).toBe(false);
+    });
+  });
+
+  describe("update", () => {
+    it("updates an existing template and increments version", async () => {
+      const existingSnap = {
+        exists: true,
+        data: () => ({ ...samplePoll, version: 3 }),
+      };
+      const get = vi.fn(async () => existingSnap);
+      const set = vi.fn(async () => undefined);
+      const docFn = vi.fn(() => ({ get, set }));
+      const auditAdd = vi.fn(async () => undefined);
+      collectionMock.mockImplementation((name: string) => {
+        if (name === "minigame_templates") return { doc: docFn };
+        if (name === "audit_log") return { add: auditAdd };
+        throw new Error("unexpected collection " + name);
+      });
+
+      const res = buildRes();
+      await handler.update(buildReq(samplePoll, { id: "t1" }), res);
+
+      expect(docFn).toHaveBeenCalledWith("t1");
+      expect(set).toHaveBeenCalledTimes(1);
+      const setArgs = set.mock.calls[0];
+      const stored = setArgs[0] as Record<string, unknown>;
+      expect(stored).toMatchObject({ ...samplePoll, version: 4 });
+      expect(stored.updatedAt).toBe(fieldValueServerTimestamp);
+      expect(setArgs[1]).toEqual({ merge: true });
+      expect(res.__body).toEqual({
+        success: true,
+        data: { id: "t1", version: 4 },
+      });
+      const auditPayload = auditAdd.mock.calls[0][0] as Record<string, unknown>;
+      expect(auditPayload).toMatchObject({
+        action: "minigame_template.update",
+        targetId: "t1",
+        details: { type: "poll", title: samplePoll.title, version: 4 },
+      });
+    });
+
+    it("returns 404 when template does not exist", async () => {
+      const docFn = vi.fn(() => ({
+        get: vi.fn(async () => ({ exists: false })),
+        set: vi.fn(),
+      }));
+      collectionMock.mockReturnValue({ doc: docFn });
+      const res = buildRes();
+      await handler.update(buildReq(samplePoll, { id: "ghost" }), res);
+      expect(res.__status).toBe(404);
+      expect((res.__body as { error: string }).error).toMatch(/not found/i);
+    });
+  });
+
+  describe("remove", () => {
+    it("deletes existing template and writes audit", async () => {
+      const get = vi.fn(async () => ({
+        exists: true,
+        data: () => samplePoll,
+      }));
+      const deleteFn = vi.fn(async () => undefined);
+      const docFn = vi.fn(() => ({ get, delete: deleteFn }));
+      const auditAdd = vi.fn(async () => undefined);
+      collectionMock.mockImplementation((name: string) => {
+        if (name === "minigame_templates") return { doc: docFn };
+        if (name === "audit_log") return { add: auditAdd };
+        throw new Error("unexpected collection " + name);
+      });
+
+      const res = buildRes();
+      await handler.remove(buildReq({}, { id: "t1" }), res);
+      expect(deleteFn).toHaveBeenCalledTimes(1);
+      expect(res.__body).toEqual({ success: true });
+      const auditPayload = auditAdd.mock.calls[0][0] as Record<string, unknown>;
+      expect(auditPayload).toMatchObject({
+        action: "minigame_template.delete",
+        targetId: "t1",
+        details: { type: "poll", title: samplePoll.title },
+      });
+    });
+
+    it("returns 404 when template does not exist", async () => {
+      const docFn = vi.fn(() => ({
+        get: vi.fn(async () => ({ exists: false })),
+        delete: vi.fn(),
+      }));
+      collectionMock.mockReturnValue({ doc: docFn });
+      const res = buildRes();
+      await handler.remove(buildReq({}, { id: "ghost" }), res);
+      expect(res.__status).toBe(404);
+    });
+  });
+});

--- a/functions/src/handlers/minigameTemplates.ts
+++ b/functions/src/handlers/minigameTemplates.ts
@@ -1,0 +1,143 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { safeError } from "../middleware/validate";
+import type { MinigameTemplate } from "../schemas";
+
+const COLLECTION = "minigame_templates";
+
+interface AuditDetails {
+  type: MinigameTemplate["type"];
+  title: string;
+  version?: number;
+}
+
+function auditEntry(
+  action: string,
+  performedBy: string,
+  targetId: string,
+  details: AuditDetails
+) {
+  return {
+    action,
+    performedBy,
+    targetId,
+    targetType: "minigame_template",
+    details,
+    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+  };
+}
+
+export async function list(_req: Request, res: Response) {
+  try {
+    const snap = await admin
+      .firestore()
+      .collection(COLLECTION)
+      .orderBy("updatedAt", "desc")
+      .get();
+    res.json({
+      success: true,
+      data: snap.docs.map((d) => ({ id: d.id, ...d.data() })),
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+export async function create(req: Request, res: Response) {
+  try {
+    const user = (req as AuthenticatedRequest).user;
+    const body = req.body as MinigameTemplate;
+    const now = admin.firestore.FieldValue.serverTimestamp();
+    const ref = await admin
+      .firestore()
+      .collection(COLLECTION)
+      .add({
+        ...body,
+        createdAt: now,
+        createdBy: user.uid,
+        updatedAt: now,
+        version: 1,
+      });
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add(
+        auditEntry("minigame_template.create", user.uid, ref.id, {
+          type: body.type,
+          title: body.title,
+        })
+      );
+    res.status(201).json({ success: true, data: { id: ref.id } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+export async function update(req: Request, res: Response) {
+  try {
+    const id = req.params.id as string;
+    const user = (req as AuthenticatedRequest).user;
+    const body = req.body as MinigameTemplate;
+    const ref = admin.firestore().collection(COLLECTION).doc(id);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      res
+        .status(404)
+        .json({ success: false, error: "Minigame template not found" });
+      return;
+    }
+    const prevVersion = (snap.data()?.version as number | undefined) ?? 0;
+    const nextVersion = prevVersion + 1;
+    await ref.set(
+      {
+        ...body,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        version: nextVersion,
+      },
+      { merge: true }
+    );
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add(
+        auditEntry("minigame_template.update", user.uid, id, {
+          type: body.type,
+          title: body.title,
+          version: nextVersion,
+        })
+      );
+    res.json({ success: true, data: { id, version: nextVersion } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+export async function remove(req: Request, res: Response) {
+  try {
+    const id = req.params.id as string;
+    const user = (req as AuthenticatedRequest).user;
+    const ref = admin.firestore().collection(COLLECTION).doc(id);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      res
+        .status(404)
+        .json({ success: false, error: "Minigame template not found" });
+      return;
+    }
+    const data = snap.data() as Partial<MinigameTemplate> | undefined;
+    await ref.delete();
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add(
+        auditEntry("minigame_template.delete", user.uid, id, {
+          type: data?.type ?? "poll",
+          title: data?.title ?? id,
+        })
+      );
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,6 +13,7 @@ import {
   sponsorSchema,
   teamMemberSchema,
   locationSchema,
+  minigameTemplateSchema,
 } from "./schemas";
 import { register } from "./handlers/auth";
 import * as events from "./handlers/events";
@@ -24,6 +25,7 @@ import * as users from "./handlers/users";
 import * as forms from "./handlers/forms";
 import { triggerRebuild } from "./handlers/rebuild";
 import * as locations from "./handlers/locations";
+import * as minigameTemplates from "./handlers/minigameTemplates";
 
 admin.initializeApp();
 
@@ -254,6 +256,35 @@ app.delete(
   vid,
   writeLimiter,
   locations.remove
+);
+
+// Minigame Templates (admin-only — full CRUD)
+app.get(
+  "/api/minigame-templates",
+  requireRole("admin"),
+  minigameTemplates.list
+);
+app.post(
+  "/api/minigame-templates",
+  requireRole("admin"),
+  writeLimiter,
+  validateBody(minigameTemplateSchema),
+  minigameTemplates.create
+);
+app.put(
+  "/api/minigame-templates/:id",
+  requireRole("admin"),
+  vid,
+  writeLimiter,
+  validateBody(minigameTemplateSchema),
+  minigameTemplates.update
+);
+app.delete(
+  "/api/minigame-templates/:id",
+  requireRole("admin"),
+  vid,
+  writeLimiter,
+  minigameTemplates.remove
 );
 
 // Rebuild

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -139,3 +139,88 @@ export const locationSchema = z
     map_embed: shortText(2000).default(""),
   })
   .strict();
+
+// Mini-game templates ------------------------------------------------------
+//
+// Each template is one of four discriminated types. The schema is the
+// authoritative shape both for create and update — admins always send the
+// full document. Validation is `.strict()` everywhere so unknown fields are
+// rejected and cannot land in Firestore.
+
+const optionItemSchema = z
+  .object({
+    id: shortText(100),
+    label: shortText(500).min(1),
+  })
+  .strict();
+
+const quizQuestionSchema = z
+  .object({
+    id: shortText(100),
+    prompt: shortText(1000).min(1),
+    options: z.array(optionItemSchema).min(2).max(6),
+    correctOptionId: shortText(100),
+    timeLimitSec: z.number().int().min(5).max(300).default(30),
+    points: z.number().int().min(0).max(10000).default(100),
+  })
+  .strict();
+
+const baseTemplate = {
+  title: shortText(500).min(1),
+  description: longText(5000).default(""),
+};
+
+export const minigameTemplateSchema = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("poll"),
+      ...baseTemplate,
+      poll: z
+        .object({
+          question: shortText(1000).min(1),
+          options: z.array(optionItemSchema).min(2).max(6),
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("quiz"),
+      ...baseTemplate,
+      quiz: z
+        .object({
+          questions: z.array(quizQuestionSchema).min(1).max(50),
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("wordcloud"),
+      ...baseTemplate,
+      wordcloud: z
+        .object({
+          prompt: shortText(500).min(1),
+          maxWordsPerUser: z.number().int().min(1).max(10).default(3),
+          maxLength: z.number().int().min(5).max(120).default(60),
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("bingo"),
+      ...baseTemplate,
+      bingo: z
+        .object({
+          terms: z.array(shortText(120).min(1)).min(16).max(200),
+          cardSize: z.literal(4).default(4),
+          freeCenter: z.boolean().default(false),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+export type MinigameTemplate = z.infer<typeof minigameTemplateSchema>;
+export type MinigameTemplateType = MinigameTemplate["type"];

--- a/functions/src/schemas/minigameTemplate.test.ts
+++ b/functions/src/schemas/minigameTemplate.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { minigameTemplateSchema } from "./index";
+
+describe("minigameTemplateSchema", () => {
+  it("accepts a valid poll", () => {
+    const r = minigameTemplateSchema.safeParse({
+      type: "poll",
+      title: "Sample",
+      description: "",
+      poll: {
+        question: "Pick one",
+        options: [
+          { id: "a", label: "A" },
+          { id: "b", label: "B" },
+        ],
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a valid quiz with defaults filled in", () => {
+    const r = minigameTemplateSchema.safeParse({
+      type: "quiz",
+      title: "Q",
+      description: "",
+      quiz: {
+        questions: [
+          {
+            id: "q1",
+            prompt: "P?",
+            options: [
+              { id: "a", label: "A" },
+              { id: "b", label: "B" },
+            ],
+            correctOptionId: "a",
+          },
+        ],
+      },
+    });
+    expect(r.success).toBe(true);
+    if (r.success && r.data.type === "quiz") {
+      expect(r.data.quiz.questions[0].timeLimitSec).toBe(30);
+      expect(r.data.quiz.questions[0].points).toBe(100);
+    }
+  });
+
+  it("accepts a valid wordcloud", () => {
+    const r = minigameTemplateSchema.safeParse({
+      type: "wordcloud",
+      title: "W",
+      description: "",
+      wordcloud: { prompt: "Say a word" },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a valid bingo with 16 terms", () => {
+    const r = minigameTemplateSchema.safeParse({
+      type: "bingo",
+      title: "B",
+      description: "",
+      bingo: {
+        terms: Array.from({ length: 16 }, (_, i) => `t-${i}`),
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects payload without a discriminator", () => {
+    const r = minigameTemplateSchema.safeParse({
+      title: "X",
+      description: "",
+      poll: { question: "?", options: [{ id: "a", label: "A" }] },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects unknown fields (.strict)", () => {
+    const r = minigameTemplateSchema.safeParse({
+      type: "poll",
+      title: "X",
+      description: "",
+      poll: {
+        question: "?",
+        options: [
+          { id: "a", label: "A" },
+          { id: "b", label: "B" },
+        ],
+      },
+      extra: "leak",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects poll with only one option", () => {
+    const r = minigameTemplateSchema.safeParse({
+      type: "poll",
+      title: "X",
+      description: "",
+      poll: {
+        question: "?",
+        options: [{ id: "a", label: "A" }],
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects bingo with fewer than 16 terms", () => {
+    const r = minigameTemplateSchema.safeParse({
+      type: "bingo",
+      title: "X",
+      description: "",
+      bingo: { terms: ["only-one"] },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects empty title", () => {
+    const r = minigameTemplateSchema.safeParse({
+      type: "poll",
+      title: "",
+      description: "",
+      poll: {
+        question: "?",
+        options: [
+          { id: "a", label: "A" },
+          { id: "b", label: "B" },
+        ],
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects quiz with empty questions array", () => {
+    const r = minigameTemplateSchema.safeParse({
+      type: "quiz",
+      title: "Q",
+      description: "",
+      quiz: { questions: [] },
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -13,6 +13,7 @@ import { UserDirectory } from "./users/UserDirectory";
 import { FormRegistry } from "./forms/FormRegistry";
 import { FormViewer } from "./forms/FormViewer";
 import { LocationList } from "./locations/LocationList";
+import { MinigameTemplateList } from "./minigame-templates/MinigameTemplateList";
 
 interface Props {
   page: string;
@@ -92,6 +93,8 @@ function AdminContent({ page, currentPath }: Props) {
         return <FormViewer />;
       case "ubicaciones":
         return <LocationList />;
+      case "minigame-templates":
+        return <MinigameTemplateList />;
       default:
         return (
           <p className="text-gray-500 dark:text-gray-400">
@@ -129,6 +132,8 @@ function DevContent({ page, currentPath }: Props) {
         return <FormViewer />;
       case "ubicaciones":
         return <LocationList />;
+      case "minigame-templates":
+        return <MinigameTemplateList />;
       default:
         return (
           <p className="text-gray-500 dark:text-gray-400">

--- a/src/components/react/admin/AdminShell.tsx
+++ b/src/components/react/admin/AdminShell.tsx
@@ -11,6 +11,12 @@ const NAV_ITEMS = [
   { label: "Usuarios", href: "/admin/usuarios", icon: "👤", adminOnly: true },
   { label: "Stats", href: "/admin/stats", icon: "📈", adminOnly: true },
   { label: "Formularios", href: "/admin/forms", icon: "📋" },
+  {
+    label: "Minijuegos",
+    href: "/admin/minigame-templates",
+    icon: "🎮",
+    adminOnly: true,
+  },
 ];
 
 interface Props {

--- a/src/components/react/admin/minigame-templates/MinigameTemplateForm.tsx
+++ b/src/components/react/admin/minigame-templates/MinigameTemplateForm.tsx
@@ -1,0 +1,230 @@
+import { useMemo, useState } from "react";
+import { FormField } from "../ui/FormField";
+import {
+  TYPE_LABELS,
+  emptyForType,
+  inputClass,
+  type MinigameType,
+  type Template,
+} from "./types";
+import { PollFields } from "./forms/PollFields";
+import { QuizFields } from "./forms/QuizFields";
+import { WordCloudFields } from "./forms/WordCloudFields";
+import { BingoFields } from "./forms/BingoFields";
+
+interface Props {
+  initial: Template;
+  isEdit: boolean;
+  saving: boolean;
+  onCancel: () => void;
+  onSubmit: (template: Template) => void;
+}
+
+interface FormErrors {
+  title?: string;
+  config?: string;
+}
+
+function validate(template: Template): FormErrors {
+  const errors: FormErrors = {};
+  if (!template.title.trim()) {
+    errors.title = "El título es obligatorio";
+  }
+  switch (template.type) {
+    case "poll":
+      if (!template.poll.question.trim()) {
+        errors.config = "Falta la pregunta";
+      } else if (template.poll.options.some((o) => !o.label.trim())) {
+        errors.config = "Todas las opciones deben tener texto";
+      }
+      break;
+    case "quiz":
+      for (const q of template.quiz.questions) {
+        if (!q.prompt.trim()) {
+          errors.config = "Cada pregunta necesita un enunciado";
+          break;
+        }
+        if (q.options.some((o) => !o.label.trim())) {
+          errors.config =
+            "Todas las opciones de cada pregunta deben tener texto";
+          break;
+        }
+        if (!q.options.some((o) => o.id === q.correctOptionId)) {
+          errors.config = "Cada pregunta debe marcar una opción correcta";
+          break;
+        }
+      }
+      break;
+    case "wordcloud":
+      if (!template.wordcloud.prompt.trim()) {
+        errors.config = "Falta el prompt para los participantes";
+      }
+      break;
+    case "bingo":
+      if (template.bingo.terms.length < 16) {
+        errors.config = "El bingo necesita al menos 16 términos";
+      }
+      break;
+  }
+  return errors;
+}
+
+export function MinigameTemplateForm({
+  initial,
+  isEdit,
+  saving,
+  onCancel,
+  onSubmit,
+}: Props) {
+  const [template, setTemplate] = useState<Template>(initial);
+  const [submitted, setSubmitted] = useState(false);
+
+  const errors = useMemo(() => validate(template), [template]);
+  const hasErrors = Boolean(errors.title || errors.config);
+
+  function setBase<K extends "title" | "description">(key: K, next: string) {
+    setTemplate({ ...template, [key]: next });
+  }
+
+  function changeType(nextType: MinigameType) {
+    if (nextType === template.type) return;
+    setTemplate({
+      ...emptyForType(nextType),
+      title: template.title,
+      description: template.description,
+    });
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitted(true);
+    if (hasErrors) return;
+    onSubmit(template);
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <button
+        type="button"
+        onClick={onCancel}
+        className="mb-4 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+      >
+        ← Volver a plantillas
+      </button>
+      <h2 className="mb-6 text-xl font-bold text-gray-900 dark:text-white">
+        {isEdit
+          ? `Editar: ${template.title || "(sin título)"}`
+          : "Nueva plantilla"}
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField label="Tipo" required>
+              <select
+                value={template.type}
+                onChange={(e) => changeType(e.target.value as MinigameType)}
+                disabled={isEdit}
+                className={inputClass}
+                aria-label="Tipo de minijuego"
+              >
+                {(Object.keys(TYPE_LABELS) as MinigameType[]).map((t) => (
+                  <option key={t} value={t}>
+                    {TYPE_LABELS[t]}
+                  </option>
+                ))}
+              </select>
+              {isEdit && (
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  El tipo no se puede cambiar al editar.
+                </p>
+              )}
+            </FormField>
+
+            <FormField
+              label="Título"
+              required
+              error={submitted ? errors.title : undefined}
+            >
+              <input
+                type="text"
+                value={template.title}
+                onChange={(e) => setBase("title", e.target.value)}
+                placeholder="Quiz de bienvenida"
+                className={inputClass}
+              />
+            </FormField>
+
+            <div className="sm:col-span-2">
+              <FormField label="Descripción (interna, opcional)">
+                <textarea
+                  value={template.description}
+                  onChange={(e) => setBase("description", e.target.value)}
+                  rows={2}
+                  placeholder="Notas para el equipo organizador"
+                  className={inputClass}
+                />
+              </FormField>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+          <h3 className="mb-4 text-base font-semibold text-gray-900 dark:text-white">
+            Configuración del {TYPE_LABELS[template.type].toLowerCase()}
+          </h3>
+          {template.type === "poll" && (
+            <PollFields
+              value={template.poll}
+              onChange={(next) => setTemplate({ ...template, poll: next })}
+            />
+          )}
+          {template.type === "quiz" && (
+            <QuizFields
+              value={template.quiz}
+              onChange={(next) => setTemplate({ ...template, quiz: next })}
+            />
+          )}
+          {template.type === "wordcloud" && (
+            <WordCloudFields
+              value={template.wordcloud}
+              onChange={(next) => setTemplate({ ...template, wordcloud: next })}
+            />
+          )}
+          {template.type === "bingo" && (
+            <BingoFields
+              value={template.bingo}
+              onChange={(next) => setTemplate({ ...template, bingo: next })}
+            />
+          )}
+          {submitted && errors.config && (
+            <p className="mt-3 text-sm text-red-600 dark:text-red-400">
+              {errors.config}
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving
+              ? "Guardando..."
+              : isEdit
+                ? "Actualizar"
+                : "Crear plantilla"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/react/admin/minigame-templates/MinigameTemplateList.tsx
+++ b/src/components/react/admin/minigame-templates/MinigameTemplateList.tsx
@@ -1,0 +1,391 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { api } from "@/lib/api";
+import { Toast } from "../ui/Toast";
+import {
+  TYPE_COLORS,
+  TYPE_LABELS,
+  emptyForType,
+  type MinigameType,
+  type Template,
+} from "./types";
+import { MinigameTemplateForm } from "./MinigameTemplateForm";
+
+const PAGE_SIZE = 10;
+
+function formatUpdatedAt(value: Template["updatedAt"]): string {
+  if (!value) return "—";
+  if (typeof value === "object" && value !== null && "seconds" in value) {
+    const seconds = value.seconds ?? 0;
+    return new Date(seconds * 1000).toLocaleString("es-PE");
+  }
+  if (typeof value === "string") {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d.toLocaleString("es-PE");
+  }
+  return "—";
+}
+
+export function MinigameTemplateList() {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+
+  const [editing, setEditing] = useState<Template | null>(null);
+  const [creatingFor, setCreatingFor] = useState<MinigameType | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    loadTemplates();
+  }, []);
+
+  useEffect(() => {
+    setPage(1);
+  }, [search]);
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    function handler(ev: MouseEvent) {
+      if (
+        pickerRef.current &&
+        ev.target instanceof Node &&
+        !pickerRef.current.contains(ev.target)
+      ) {
+        setPickerOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [pickerOpen]);
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return templates;
+    const q = search.toLowerCase();
+    return templates.filter(
+      (t) =>
+        t.title.toLowerCase().includes(q) ||
+        TYPE_LABELS[t.type].toLowerCase().includes(q)
+    );
+  }, [templates, search]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  async function loadTemplates() {
+    setLoading(true);
+    const res = await api.listMinigameTemplates();
+    if (res.success && Array.isArray(res.data)) {
+      setTemplates(res.data as Template[]);
+      setError(null);
+    } else {
+      setError(res.error || "Error al cargar plantillas");
+    }
+    setLoading(false);
+  }
+
+  async function handleSubmit(template: Template) {
+    setSaving(true);
+    const isNew = !editing;
+    // Strip server-managed fields before sending.
+    const {
+      id: _id,
+      version: _version,
+      updatedAt: _updatedAt,
+      ...payload
+    } = template as Template & {
+      id?: string;
+      version?: number;
+      updatedAt?: unknown;
+    };
+    void _id;
+    void _version;
+    void _updatedAt;
+
+    const res = isNew
+      ? await api.addMinigameTemplate(payload)
+      : await api.updateMinigameTemplate(template.id!, payload);
+
+    if (res.success) {
+      setToast({
+        message: `Plantilla ${isNew ? "creada" : "actualizada"}`,
+        type: "success",
+      });
+      setEditing(null);
+      setCreatingFor(null);
+      loadTemplates();
+    } else {
+      setToast({ message: res.error || "Error al guardar", type: "error" });
+    }
+    setSaving(false);
+  }
+
+  async function handleDelete(id: string, title: string) {
+    if (!confirm(`Eliminar plantilla "${title}"?`)) return;
+    setDeleting(id);
+    const res = await api.deleteMinigameTemplate(id);
+    if (res.success) {
+      setTemplates((prev) => prev.filter((t) => t.id !== id));
+      setToast({ message: "Plantilla eliminada", type: "success" });
+    } else {
+      setToast({ message: res.error || "Error al eliminar", type: "error" });
+    }
+    setDeleting(null);
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+        {error}
+      </div>
+    );
+  }
+
+  if (editing || creatingFor) {
+    const initial: Template = editing ?? emptyForType(creatingFor!);
+    return (
+      <MinigameTemplateForm
+        initial={initial}
+        isEdit={Boolean(editing)}
+        saving={saving}
+        onCancel={() => {
+          setEditing(null);
+          setCreatingFor(null);
+        }}
+        onSubmit={handleSubmit}
+      />
+    );
+  }
+
+  return (
+    <div>
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar por título o tipo..."
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none sm:w-64 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+          />
+          <span className="shrink-0 text-sm text-gray-500 dark:text-gray-400">
+            {filtered.length} plantilla{filtered.length !== 1 && "s"}
+          </span>
+        </div>
+        <div ref={pickerRef} className="relative shrink-0">
+          <button
+            type="button"
+            onClick={() => setPickerOpen((o) => !o)}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            + Nueva plantilla ▾
+          </button>
+          {pickerOpen && (
+            <div className="absolute right-0 z-10 mt-2 w-56 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800">
+              {(Object.keys(TYPE_LABELS) as MinigameType[]).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => {
+                    setCreatingFor(t);
+                    setPickerOpen(false);
+                  }}
+                  className="flex w-full items-center justify-between px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                  <span>{TYPE_LABELS[t]}</span>
+                  <span
+                    className={`rounded px-2 py-0.5 text-xs ${TYPE_COLORS[t]}`}
+                  >
+                    {t}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Desktop table */}
+      <div className="hidden overflow-hidden rounded-lg border border-gray-200 bg-white md:block dark:border-gray-700 dark:bg-gray-800">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-900">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                Tipo
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                Título
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                Última actualización
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                Acciones
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+            {paginated.map((t) => (
+              <tr
+                key={t.id}
+                className="hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                <td className="px-6 py-4">
+                  <span
+                    className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[t.type]}`}
+                  >
+                    {TYPE_LABELS[t.type]}
+                  </span>
+                </td>
+                <td className="px-6 py-4">
+                  <p className="font-medium text-gray-900 dark:text-white">
+                    {t.title}
+                  </p>
+                  {t.description && (
+                    <p className="mt-0.5 line-clamp-1 text-xs text-gray-500 dark:text-gray-400">
+                      {t.description}
+                    </p>
+                  )}
+                </td>
+                <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+                  {formatUpdatedAt(t.updatedAt)}
+                </td>
+                <td className="px-6 py-4 text-right">
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => setEditing(t)}
+                      className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      onClick={() => handleDelete(t.id!, t.title)}
+                      disabled={deleting === t.id}
+                      className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+                    >
+                      {deleting === t.id ? "..." : "Eliminar"}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile cards */}
+      <div className="space-y-3 md:hidden">
+        {paginated.map((t) => (
+          <div
+            key={t.id}
+            className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800"
+          >
+            <div className="mb-2 flex items-start justify-between gap-2">
+              <p className="font-medium text-gray-900 dark:text-white">
+                {t.title}
+              </p>
+              <span
+                className={`shrink-0 rounded px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[t.type]}`}
+              >
+                {TYPE_LABELS[t.type]}
+              </span>
+            </div>
+            {t.description && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {t.description}
+              </p>
+            )}
+            <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+              Actualizado {formatUpdatedAt(t.updatedAt)}
+            </p>
+            <div className="mt-3 flex justify-end gap-2 border-t border-gray-100 pt-3 dark:border-gray-700">
+              <button
+                onClick={() => setEditing(t)}
+                className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+              >
+                Editar
+              </button>
+              <button
+                onClick={() => handleDelete(t.id!, t.title)}
+                disabled={deleting === t.id}
+                className="rounded px-3 py-1 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+              >
+                {deleting === t.id ? "..." : "Eliminar"}
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {paginated.length === 0 && (
+        <p className="py-8 text-center text-gray-500 dark:text-gray-400">
+          {search
+            ? "Sin resultados"
+            : "Aún no hay plantillas. Crea la primera con el botón de arriba."}
+        </p>
+      )}
+
+      {totalPages > 1 && (
+        <div className="mt-6 flex items-center justify-between">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Mostrando {(page - 1) * PAGE_SIZE + 1}-
+            {Math.min(page * PAGE_SIZE, filtered.length)} de {filtered.length}
+          </p>
+          <div className="flex gap-1">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-40 dark:border-gray-600 dark:text-gray-300"
+            >
+              Anterior
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+              <button
+                key={p}
+                onClick={() => setPage(p)}
+                className={`rounded-lg px-3 py-1.5 text-sm ${
+                  p === page
+                    ? "bg-blue-600 text-white"
+                    : "border border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                }`}
+              >
+                {p}
+              </button>
+            ))}
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm disabled:opacity-40 dark:border-gray-600 dark:text-gray-300"
+            >
+              Siguiente
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/react/admin/minigame-templates/__tests__/MinigameTemplateForm.test.tsx
+++ b/src/components/react/admin/minigame-templates/__tests__/MinigameTemplateForm.test.tsx
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MinigameTemplateForm } from "../MinigameTemplateForm";
+import { emptyForType, type Template } from "../types";
+
+// jsdom doesn't ship with crypto.randomUUID in older Node lifecycles; provide
+// a deterministic stub so option/question IDs render consistently.
+let counter = 0;
+beforeEach(() => {
+  counter = 0;
+  if (!globalThis.crypto) {
+    (globalThis as unknown as { crypto: Crypto }).crypto = {} as Crypto;
+  }
+  globalThis.crypto.randomUUID = (() =>
+    `id-${++counter}`) as Crypto["randomUUID"];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderForm(initial: Template, isEdit = false) {
+  const onCancel = vi.fn();
+  const onSubmit = vi.fn();
+  render(
+    <MinigameTemplateForm
+      initial={initial}
+      isEdit={isEdit}
+      saving={false}
+      onCancel={onCancel}
+      onSubmit={onSubmit}
+    />
+  );
+  return { onCancel, onSubmit };
+}
+
+describe("MinigameTemplateForm", () => {
+  it("renders poll fields by default for a poll template", () => {
+    renderForm(emptyForType("poll"));
+    expect(
+      screen.getByPlaceholderText(/cuál es tu opción favorita/i)
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Opción 1/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Opción 2/i)).toBeInTheDocument();
+  });
+
+  it("switches to quiz fields when type changes", async () => {
+    const user = userEvent.setup();
+    renderForm(emptyForType("poll"));
+    const select = screen.getByLabelText(/Tipo de minijuego/i);
+    await user.selectOptions(select, "quiz");
+    expect(screen.getByText(/Pregunta 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Tiempo límite/i)).toBeInTheDocument();
+  });
+
+  it("renders bingo textarea when switching to bingo", async () => {
+    const user = userEvent.setup();
+    renderForm(emptyForType("poll"));
+    await user.selectOptions(
+      screen.getByLabelText(/Tipo de minijuego/i),
+      "bingo"
+    );
+    expect(screen.getByText(/Términos del bingo/i)).toBeInTheDocument();
+    expect(screen.getByText(/0 términos detectados/i)).toBeInTheDocument();
+  });
+
+  it("blocks submit and shows error when title is empty", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm(emptyForType("poll"));
+    await user.click(screen.getByRole("button", { name: /Crear plantilla/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(/título es obligatorio/i)).toBeInTheDocument();
+  });
+
+  it("blocks submit when poll options are missing labels", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm(emptyForType("poll"));
+    await user.type(
+      screen.getByPlaceholderText(/Quiz de bienvenida/i),
+      "Mi poll"
+    );
+    await user.type(
+      screen.getByPlaceholderText(/cuál es tu opción favorita/i),
+      "Pick"
+    );
+    await user.click(screen.getByRole("button", { name: /Crear plantilla/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(/opciones deben tener texto/i)).toBeInTheDocument();
+  });
+
+  it("submits a valid poll payload", async () => {
+    const user = userEvent.setup();
+    const initial = emptyForType("poll");
+    const { onSubmit } = renderForm(initial);
+    await user.type(screen.getByPlaceholderText(/Quiz de bienvenida/i), "Quiz");
+    await user.type(
+      screen.getByPlaceholderText(/cuál es tu opción favorita/i),
+      "Pick"
+    );
+    await user.type(screen.getByPlaceholderText(/Opción 1/i), "Yes");
+    await user.type(screen.getByPlaceholderText(/Opción 2/i), "No");
+    await user.click(screen.getByRole("button", { name: /Crear plantilla/i }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0] as Template;
+    expect(submitted.type).toBe("poll");
+    expect(submitted.title).toBe("Quiz");
+    if (submitted.type === "poll") {
+      expect(submitted.poll.question).toBe("Pick");
+      expect(submitted.poll.options.map((o) => o.label)).toEqual(["Yes", "No"]);
+    }
+  });
+
+  it("disables type selector and shows hint when editing", () => {
+    const initial: Template = {
+      ...emptyForType("poll"),
+      id: "t1",
+      title: "Existing",
+      version: 2,
+    };
+    renderForm(initial, true);
+    const select = screen.getByLabelText(
+      /Tipo de minijuego/i
+    ) as HTMLSelectElement;
+    expect(select).toBeDisabled();
+    expect(screen.getByText(/no se puede cambiar/i)).toBeInTheDocument();
+  });
+
+  it("calls onCancel when Cancelar is clicked", () => {
+    const { onCancel } = renderForm(emptyForType("wordcloud"));
+    fireEvent.click(screen.getByRole("button", { name: /^Cancelar$/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("rejects bingo with fewer than 16 terms", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm(emptyForType("bingo"));
+    await user.type(
+      screen.getByPlaceholderText(/Quiz de bienvenida/i),
+      "Bingo"
+    );
+    const textarea = screen.getByPlaceholderText(
+      /Un término por línea/i
+    ) as HTMLTextAreaElement;
+    await user.type(textarea, "alpha\nbeta\ngamma");
+    await user.click(screen.getByRole("button", { name: /Crear plantilla/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(/al menos 16 términos/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/react/admin/minigame-templates/forms/BingoFields.tsx
+++ b/src/components/react/admin/minigame-templates/forms/BingoFields.tsx
@@ -1,0 +1,60 @@
+import { useMemo, useState } from "react";
+import { FormField } from "../../ui/FormField";
+import { inputClass, type BingoConfig } from "../types";
+
+interface Props {
+  value: BingoConfig;
+  onChange: (next: BingoConfig) => void;
+}
+
+function termsToText(terms: string[]): string {
+  return terms.join("\n");
+}
+
+function textToTerms(raw: string): string[] {
+  return raw
+    .split(/\r?\n/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+}
+
+export function BingoFields({ value, onChange }: Props) {
+  // We keep a local raw textarea value so the admin can edit freely (including
+  // empty lines while typing). The parsed term list is derived on change and
+  // pushed up so validation stays consistent with the schema.
+  const [raw, setRaw] = useState(termsToText(value.terms));
+
+  const termCount = useMemo(() => textToTerms(raw).length, [raw]);
+
+  function handleTextChange(next: string) {
+    setRaw(next);
+    onChange({ ...value, terms: textToTerms(next) });
+  }
+
+  return (
+    <div className="space-y-4">
+      <FormField label="Términos del bingo" required>
+        <textarea
+          value={raw}
+          onChange={(e) => handleTextChange(e.target.value)}
+          rows={10}
+          placeholder="Un término por línea..."
+          className={`${inputClass} font-mono`}
+        />
+      </FormField>
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        {termCount} términos detectados. Mínimo 16 (cada cartón es 4×4).
+      </p>
+
+      <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+        <input
+          type="checkbox"
+          checked={value.freeCenter}
+          onChange={(e) => onChange({ ...value, freeCenter: e.target.checked })}
+          className="h-4 w-4 rounded border-gray-300"
+        />
+        Centro libre (no usado en cartones 4×4)
+      </label>
+    </div>
+  );
+}

--- a/src/components/react/admin/minigame-templates/forms/PollFields.tsx
+++ b/src/components/react/admin/minigame-templates/forms/PollFields.tsx
@@ -1,0 +1,95 @@
+import { FormField } from "../../ui/FormField";
+import {
+  inputClass,
+  newOptionId,
+  type OptionItem,
+  type PollConfig,
+} from "../types";
+
+interface Props {
+  value: PollConfig;
+  onChange: (next: PollConfig) => void;
+}
+
+export function PollFields({ value, onChange }: Props) {
+  function setQuestion(question: string) {
+    onChange({ ...value, question });
+  }
+
+  function setOption(index: number, label: string) {
+    const next = value.options.map((o, i) =>
+      i === index ? { ...o, label } : o
+    );
+    onChange({ ...value, options: next });
+  }
+
+  function addOption() {
+    if (value.options.length >= 6) return;
+    const next: OptionItem[] = [
+      ...value.options,
+      { id: newOptionId(), label: "" },
+    ];
+    onChange({ ...value, options: next });
+  }
+
+  function removeOption(index: number) {
+    if (value.options.length <= 2) return;
+    onChange({
+      ...value,
+      options: value.options.filter((_, i) => i !== index),
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <FormField label="Pregunta" required>
+        <input
+          type="text"
+          value={value.question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder="¿Cuál es tu opción favorita?"
+          className={inputClass}
+        />
+      </FormField>
+
+      <div>
+        <p className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+          Opciones <span className="text-red-500">*</span>
+        </p>
+        <div className="space-y-2">
+          {value.options.map((opt, i) => (
+            <div key={opt.id} className="flex gap-2">
+              <input
+                type="text"
+                value={opt.label}
+                onChange={(e) => setOption(i, e.target.value)}
+                placeholder={`Opción ${i + 1}`}
+                className={inputClass}
+              />
+              <button
+                type="button"
+                onClick={() => removeOption(i)}
+                disabled={value.options.length <= 2}
+                className="shrink-0 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                aria-label={`Eliminar opción ${i + 1}`}
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={addOption}
+          disabled={value.options.length >= 6}
+          className="mt-2 rounded-lg border border-dashed border-gray-300 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+        >
+          + Agregar opción
+        </button>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Mínimo 2, máximo 6 opciones.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/minigame-templates/forms/QuizFields.tsx
+++ b/src/components/react/admin/minigame-templates/forms/QuizFields.tsx
@@ -1,0 +1,237 @@
+import { FormField } from "../../ui/FormField";
+import {
+  inputClass,
+  newOptionId,
+  newQuestionId,
+  type QuizConfig,
+  type QuizQuestion,
+} from "../types";
+
+interface Props {
+  value: QuizConfig;
+  onChange: (next: QuizConfig) => void;
+}
+
+function emptyQuestion(): QuizQuestion {
+  const optA = newOptionId();
+  return {
+    id: newQuestionId(),
+    prompt: "",
+    options: [
+      { id: optA, label: "" },
+      { id: newOptionId(), label: "" },
+    ],
+    correctOptionId: optA,
+    timeLimitSec: 30,
+    points: 100,
+  };
+}
+
+export function QuizFields({ value, onChange }: Props) {
+  function setQuestion(index: number, next: QuizQuestion) {
+    onChange({
+      ...value,
+      questions: value.questions.map((q, i) => (i === index ? next : q)),
+    });
+  }
+
+  function addQuestion() {
+    if (value.questions.length >= 50) return;
+    onChange({ ...value, questions: [...value.questions, emptyQuestion()] });
+  }
+
+  function removeQuestion(index: number) {
+    if (value.questions.length <= 1) return;
+    onChange({
+      ...value,
+      questions: value.questions.filter((_, i) => i !== index),
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        Define las preguntas del quiz. Cada pregunta tiene su propio
+        temporizador y puntaje. Mínimo 1, máximo 50 preguntas.
+      </p>
+
+      {value.questions.map((q, qi) => (
+        <QuestionEditor
+          key={q.id}
+          index={qi}
+          value={q}
+          onChange={(next) => setQuestion(qi, next)}
+          onRemove={() => removeQuestion(qi)}
+          canRemove={value.questions.length > 1}
+        />
+      ))}
+
+      <button
+        type="button"
+        onClick={addQuestion}
+        disabled={value.questions.length >= 50}
+        className="rounded-lg border border-dashed border-gray-300 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+      >
+        + Agregar pregunta
+      </button>
+    </div>
+  );
+}
+
+interface QuestionEditorProps {
+  index: number;
+  value: QuizQuestion;
+  onChange: (next: QuizQuestion) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}
+
+function QuestionEditor({
+  index,
+  value,
+  onChange,
+  onRemove,
+  canRemove,
+}: QuestionEditorProps) {
+  function set<K extends keyof QuizQuestion>(key: K, next: QuizQuestion[K]) {
+    onChange({ ...value, [key]: next });
+  }
+
+  function setOption(optIndex: number, label: string) {
+    onChange({
+      ...value,
+      options: value.options.map((o, i) =>
+        i === optIndex ? { ...o, label } : o
+      ),
+    });
+  }
+
+  function addOption() {
+    if (value.options.length >= 6) return;
+    onChange({
+      ...value,
+      options: [...value.options, { id: newOptionId(), label: "" }],
+    });
+  }
+
+  function removeOption(optIndex: number) {
+    if (value.options.length <= 2) return;
+    const removed = value.options[optIndex];
+    const nextOptions = value.options.filter((_, i) => i !== optIndex);
+    onChange({
+      ...value,
+      options: nextOptions,
+      // If we just removed the correct option, fall back to the first one.
+      correctOptionId:
+        value.correctOptionId === removed.id
+          ? nextOptions[0].id
+          : value.correctOptionId,
+    });
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/30">
+      <div className="mb-3 flex items-center justify-between">
+        <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+          Pregunta {index + 1}
+        </h4>
+        <button
+          type="button"
+          onClick={onRemove}
+          disabled={!canRemove}
+          className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-40 dark:text-red-400 dark:hover:bg-red-900/20"
+        >
+          Eliminar
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        <FormField label="Enunciado" required>
+          <input
+            type="text"
+            value={value.prompt}
+            onChange={(e) => set("prompt", e.target.value)}
+            placeholder="¿Cuál de estos modelos es multimodal?"
+            className={inputClass}
+          />
+        </FormField>
+
+        <div>
+          <p className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+            Opciones <span className="text-red-500">*</span> · marca la correcta
+          </p>
+          <div className="space-y-2">
+            {value.options.map((opt, oi) => (
+              <div key={opt.id} className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name={`correct-${value.id}`}
+                  checked={value.correctOptionId === opt.id}
+                  onChange={() => set("correctOptionId", opt.id)}
+                  className="h-4 w-4 text-blue-600"
+                />
+                <input
+                  type="text"
+                  value={opt.label}
+                  onChange={(e) => setOption(oi, e.target.value)}
+                  placeholder={`Opción ${oi + 1}`}
+                  className={inputClass}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeOption(oi)}
+                  disabled={value.options.length <= 2}
+                  className="shrink-0 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                  aria-label={`Eliminar opción ${oi + 1}`}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={addOption}
+            disabled={value.options.length >= 6}
+            className="mt-2 rounded-lg border border-dashed border-gray-300 px-3 py-1.5 text-xs text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            + Opción
+          </button>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <FormField label="Tiempo límite (segundos)">
+            <input
+              type="number"
+              min={5}
+              max={300}
+              value={value.timeLimitSec}
+              onChange={(e) =>
+                set(
+                  "timeLimitSec",
+                  Math.max(5, Math.min(300, Number(e.target.value) || 30))
+                )
+              }
+              className={inputClass}
+            />
+          </FormField>
+          <FormField label="Puntos">
+            <input
+              type="number"
+              min={0}
+              max={10000}
+              value={value.points}
+              onChange={(e) =>
+                set(
+                  "points",
+                  Math.max(0, Math.min(10000, Number(e.target.value) || 0))
+                )
+              }
+              className={inputClass}
+            />
+          </FormField>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/minigame-templates/forms/WordCloudFields.tsx
+++ b/src/components/react/admin/minigame-templates/forms/WordCloudFields.tsx
@@ -1,0 +1,64 @@
+import { FormField } from "../../ui/FormField";
+import { inputClass, type WordCloudConfig } from "../types";
+
+interface Props {
+  value: WordCloudConfig;
+  onChange: (next: WordCloudConfig) => void;
+}
+
+export function WordCloudFields({ value, onChange }: Props) {
+  function set<K extends keyof WordCloudConfig>(
+    key: K,
+    next: WordCloudConfig[K]
+  ) {
+    onChange({ ...value, [key]: next });
+  }
+
+  return (
+    <div className="space-y-4">
+      <FormField label="Prompt para los asistentes" required>
+        <input
+          type="text"
+          value={value.prompt}
+          onChange={(e) => set("prompt", e.target.value)}
+          placeholder="¿Qué palabra describe AI para ti?"
+          className={inputClass}
+        />
+      </FormField>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <FormField label="Palabras máx. por participante">
+          <input
+            type="number"
+            min={1}
+            max={10}
+            value={value.maxWordsPerUser}
+            onChange={(e) =>
+              set(
+                "maxWordsPerUser",
+                Math.max(1, Math.min(10, Number(e.target.value) || 1))
+              )
+            }
+            className={inputClass}
+          />
+        </FormField>
+
+        <FormField label="Largo máximo (caracteres)">
+          <input
+            type="number"
+            min={5}
+            max={120}
+            value={value.maxLength}
+            onChange={(e) =>
+              set(
+                "maxLength",
+                Math.max(5, Math.min(120, Number(e.target.value) || 60))
+              )
+            }
+            className={inputClass}
+          />
+        </FormField>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/minigame-templates/types.ts
+++ b/src/components/react/admin/minigame-templates/types.ts
@@ -1,0 +1,143 @@
+export type MinigameType = "poll" | "quiz" | "wordcloud" | "bingo";
+
+export interface OptionItem {
+  id: string;
+  label: string;
+}
+
+export interface PollConfig {
+  question: string;
+  options: OptionItem[];
+}
+
+export interface QuizQuestion {
+  id: string;
+  prompt: string;
+  options: OptionItem[];
+  correctOptionId: string;
+  timeLimitSec: number;
+  points: number;
+}
+
+export interface QuizConfig {
+  questions: QuizQuestion[];
+}
+
+export interface WordCloudConfig {
+  prompt: string;
+  maxWordsPerUser: number;
+  maxLength: number;
+}
+
+export interface BingoConfig {
+  terms: string[];
+  cardSize: 4;
+  freeCenter: boolean;
+}
+
+interface BaseTemplate {
+  id?: string;
+  title: string;
+  description: string;
+  version?: number;
+  updatedAt?: { seconds?: number } | string | null;
+}
+
+export type Template =
+  | (BaseTemplate & { type: "poll"; poll: PollConfig })
+  | (BaseTemplate & { type: "quiz"; quiz: QuizConfig })
+  | (BaseTemplate & { type: "wordcloud"; wordcloud: WordCloudConfig })
+  | (BaseTemplate & { type: "bingo"; bingo: BingoConfig });
+
+export const TYPE_LABELS: Record<MinigameType, string> = {
+  poll: "Encuesta",
+  quiz: "Quiz",
+  wordcloud: "Nube de palabras",
+  bingo: "Bingo",
+};
+
+export const TYPE_COLORS: Record<MinigameType, string> = {
+  poll: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  quiz: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
+  wordcloud:
+    "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  bingo: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+};
+
+function makeId(): string {
+  if (
+    typeof globalThis.crypto !== "undefined" &&
+    typeof globalThis.crypto.randomUUID === "function"
+  ) {
+    return globalThis.crypto.randomUUID();
+  }
+  // Fallback for very old browsers / non-secure contexts.
+  return `id-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
+}
+
+export const newOptionId = makeId;
+export const newQuestionId = makeId;
+
+export function emptyForType(type: MinigameType): Template {
+  switch (type) {
+    case "poll":
+      return {
+        type: "poll",
+        title: "",
+        description: "",
+        poll: {
+          question: "",
+          options: [
+            { id: makeId(), label: "" },
+            { id: makeId(), label: "" },
+          ],
+        },
+      };
+    case "quiz":
+      return {
+        type: "quiz",
+        title: "",
+        description: "",
+        quiz: {
+          questions: [
+            {
+              id: makeId(),
+              prompt: "",
+              options: [
+                { id: makeId(), label: "" },
+                { id: makeId(), label: "" },
+              ],
+              correctOptionId: "",
+              timeLimitSec: 30,
+              points: 100,
+            },
+          ],
+        },
+      };
+    case "wordcloud":
+      return {
+        type: "wordcloud",
+        title: "",
+        description: "",
+        wordcloud: {
+          prompt: "",
+          maxWordsPerUser: 3,
+          maxLength: 60,
+        },
+      };
+    case "bingo":
+      return {
+        type: "bingo",
+        title: "",
+        description: "",
+        bingo: {
+          terms: [],
+          cardSize: 4,
+          freeCenter: false,
+        },
+      };
+  }
+}
+
+export const inputClass =
+  "w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400";

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -93,6 +93,15 @@ const realApi = {
     request("PUT", `/locations/${id}`, data),
   deleteLocation: (id: string) => request("DELETE", `/locations/${id}`),
 
+  // Minigame Templates (admin-only on the server)
+  listMinigameTemplates: () => request("GET", "/minigame-templates"),
+  addMinigameTemplate: (data: unknown) =>
+    request("POST", "/minigame-templates", data),
+  updateMinigameTemplate: (id: string, data: unknown) =>
+    request("PUT", `/minigame-templates/${id}`, data),
+  deleteMinigameTemplate: (id: string) =>
+    request("DELETE", `/minigame-templates/${id}`),
+
   // Rebuild
   triggerRebuild: () => request("POST", "/rebuild"),
 };

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -56,5 +56,10 @@ export const mockApi = {
   updateLocation: () => ok({ id: "updated" }),
   deleteLocation: () => ok(null),
 
+  listMinigameTemplates: () => ok([]),
+  addMinigameTemplate: () => ok({ id: "new-template" }),
+  updateMinigameTemplate: () => ok({ id: "updated", version: 2 }),
+  deleteMinigameTemplate: () => ok(null),
+
   triggerRebuild: () => ok(null),
 };

--- a/src/pages/admin/minigame-templates/index.astro
+++ b/src/pages/admin/minigame-templates/index.astro
@@ -1,0 +1,12 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Minijuegos">
+  <AdminApp
+    client:load
+    page="minigame-templates"
+    currentPath="/admin/minigame-templates"
+  />
+</AdminLayout>

--- a/tests/rules/minigame-templates.test.ts
+++ b/tests/rules/minigame-templates.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
+import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+} from "firebase/firestore";
+import { cleanup, clearAll, getTestEnv } from "./setup";
+
+const SAMPLE_POLL = {
+  type: "poll",
+  title: "Sample",
+  description: "",
+  poll: {
+    question: "Q?",
+    options: [
+      { id: "a", label: "A" },
+      { id: "b", label: "B" },
+    ],
+  },
+  createdAt: 0,
+  updatedAt: 0,
+  createdBy: "admin-uid",
+  version: 1,
+};
+
+describe("firestore.rules — minigame_templates", () => {
+  beforeAll(async () => {
+    await getTestEnv();
+  });
+
+  afterEach(async () => {
+    await clearAll();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it("allows authenticated users to read templates", async () => {
+    const env = await getTestEnv();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), "minigame_templates/template-1"),
+        SAMPLE_POLL
+      );
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertSucceeds(getDoc(doc(auth, "minigame_templates/template-1")));
+    await assertSucceeds(getDocs(collection(auth, "minigame_templates")));
+  });
+
+  it("denies unauthenticated reads", async () => {
+    const env = await getTestEnv();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), "minigame_templates/template-1"),
+        SAMPLE_POLL
+      );
+    });
+    const anon = env.unauthenticatedContext().firestore();
+    await assertFails(getDoc(doc(anon, "minigame_templates/template-1")));
+  });
+
+  it("denies all client writes — even from authenticated users", async () => {
+    const env = await getTestEnv();
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(doc(auth, "minigame_templates/template-1"), SAMPLE_POLL)
+    );
+  });
+
+  it("denies anonymous writes", async () => {
+    const env = await getTestEnv();
+    const anon = env.unauthenticatedContext().firestore();
+    await assertFails(
+      setDoc(doc(anon, "minigame_templates/template-1"), SAMPLE_POLL)
+    );
+  });
+
+  it("denies client deletes", async () => {
+    const env = await getTestEnv();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), "minigame_templates/template-1"),
+        SAMPLE_POLL
+      );
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(deleteDoc(doc(auth, "minigame_templates/template-1")));
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of 7 for the **live mini-games** feature. Adds a reusable template library that admins manage from the admin panel. Templates aren't yet attached to events — that lands in PR3.

Builds on the test infra from #156. Toda la API es admin-only.

## What's added

### Backend
- **Zod discriminated union** schema for the four template types (poll, quiz, wordcloud, bingo) with per-type config validation and \`.strict()\` to reject unknown fields.
- **CRUD handler** \`functions/src/handlers/minigameTemplates.ts\` with versioning + audit_log entries on every write.
- **Routes** \`/api/minigame-templates {GET, POST, PUT, DELETE}\` gated by \`requireRole(\"admin\")\` + \`writeLimiter\` + \`validateBody\`.
- **Firestore rules**: \`minigame_templates\` allows read for any signed-in user, all writes denied (server-only via Cloud Functions).

### Frontend
- New admin section \`/admin/minigame-templates\` with:
  - **List view**: search, pagination, type-color badges, mobile cards + desktop table
  - **In-place form** with type selector and four sub-forms
  - **\"+ Nueva plantilla ▾\"** dropdown picks the type, opens the form pre-filled
- Quiz sub-form supports nested questions (per-question prompt, options, radio-style correct picker, timer, points)
- Stable IDs via \`crypto.randomUUID()\` on add, preserved on edit — important so PR6's voting can map responses to options even after admin reorders
- AdminShell nav exposes the section behind \`adminOnly\`, so organizers don't see it

## Test plan

- [x] \`pnpm test\` — 11 root tests (component-level, with mocked api + crypto stub)
- [x] \`pnpm test:functions\` — 27 functions tests (10 schema validation + 10 handler unit + existing 7)
- [x] \`pnpm test:rules\` — 12 rules tests (5 new for minigame_templates: read auth, write deny, delete deny + existing 7 baseline)
- [x] \`pnpm lint\` — clean
- [x] \`pnpm build\` — Astro builds, new page \`/admin/minigame-templates\` generated
- [x] \`cd functions && npm run build\` — clean tsc, lib excludes test files
- [ ] CI green
- [ ] Smoke test with emulators: create one of each type, edit, delete, verify audit_log entries

## Out of scope (later PRs)

- PR3: attach templates to events + activate/deactivate state
- PR4: participant join flow (anon auth + alias)
- PR5: word cloud + bingo gameplay
- PR6: poll + quiz overlays + leaderboard
- PR7: projector view + QR + final polish

## Notes

- Editing a template is a full-replace (admin always sends the complete config). \`version\` is bumped server-side, \`updatedAt\` set via \`serverTimestamp()\`.
- \`type\` is locked when editing — changing template kind would invalidate any future event instance, so we just disable the selector.