### PR TITLE
feat(admin): attach mini-game templates to events + state + aggregates trigger

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,13 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "minigames",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "state", "order": "ASCENDING" },
+        { "fieldPath": "order", "order": "ASCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -22,6 +22,38 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Per-event mini-game instances and their subcollections.
+    // Reads are public so participants can subscribe in PR4-PR6 without
+    // authenticating. All writes are denied here in PR3 — Cloud Functions
+    // do every mutation via the Admin SDK. PR4 (participants), PR5 (words),
+    // PR6 (responses) will progressively open specific writes.
+    match /events/{eventSlug} {
+      allow read: if true;
+      allow write: if false;
+
+      match /minigames/{instanceId} {
+        allow read: if true;
+        allow write: if false;
+
+        match /participants/{participantUid} {
+          allow read: if true;
+          allow write: if false;
+        }
+        match /responses/{responseId} {
+          allow read: if true;
+          allow write: if false;
+        }
+        match /words/{wordId} {
+          allow read: if true;
+          allow write: if false;
+        }
+        match /aggregates/{docId} {
+          allow read: if true;
+          allow write: if false;
+        }
+      }
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }

--- a/functions/src/handlers/minigameInstances.test.ts
+++ b/functions/src/handlers/minigameInstances.test.ts
@@ -1,0 +1,488 @@
+import { Request, Response } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fieldValueServerTimestamp = "__SERVER_TS__";
+
+const mocks = vi.hoisted(() => ({
+  collectionMock: vi.fn(),
+}));
+
+vi.mock("firebase-admin", () => ({
+  firestore: Object.assign(() => ({ collection: mocks.collectionMock }), {
+    FieldValue: {
+      serverTimestamp: () => "__SERVER_TS__",
+    },
+  }),
+}));
+
+import * as handler from "./minigameInstances";
+import type { AuthenticatedRequest } from "../middleware/auth";
+
+const { collectionMock } = mocks;
+
+interface ResMock extends Response {
+  __status: number | undefined;
+  __body: unknown;
+}
+
+function buildRes(): ResMock {
+  const res: Partial<ResMock> = {};
+  res.status = vi.fn(function (this: ResMock, code: number) {
+    this.__status = code;
+    return this;
+  }) as ResMock["status"];
+  res.json = vi.fn(function (this: ResMock, body: unknown) {
+    this.__body = body;
+    return this;
+  }) as ResMock["json"];
+  return res as ResMock;
+}
+
+function buildReq(body: unknown, params: Record<string, string> = {}): Request {
+  const req = {
+    body,
+    params,
+    user: { uid: "admin-uid" },
+  } as unknown as AuthenticatedRequest;
+  return req as unknown as Request;
+}
+
+const SAMPLE_POLL_TEMPLATE = {
+  type: "poll" as const,
+  title: "Pick one",
+  description: "",
+  poll: {
+    question: "Q?",
+    options: [
+      { id: "a", label: "A" },
+      { id: "b", label: "B" },
+    ],
+  },
+  version: 3,
+};
+
+const SAMPLE_QUIZ_TEMPLATE = {
+  type: "quiz" as const,
+  title: "Mini Quiz",
+  description: "",
+  quiz: {
+    questions: [
+      {
+        id: "q1",
+        prompt: "?",
+        options: [
+          { id: "a", label: "A" },
+          { id: "b", label: "B" },
+        ],
+        correctOptionId: "a",
+        timeLimitSec: 30,
+        points: 100,
+      },
+      {
+        id: "q2",
+        prompt: "??",
+        options: [
+          { id: "a", label: "A" },
+          { id: "b", label: "B" },
+        ],
+        correctOptionId: "b",
+        timeLimitSec: 20,
+        points: 100,
+      },
+    ],
+  },
+  version: 1,
+};
+
+const SAMPLE_BINGO_TEMPLATE = {
+  type: "bingo" as const,
+  title: "Buzzword",
+  description: "",
+  bingo: {
+    terms: Array.from({ length: 16 }, (_, i) => `t${i}`),
+    cardSize: 4 as const,
+    freeCenter: false,
+  },
+  version: 1,
+};
+
+interface InstanceRefStub {
+  get: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+}
+
+interface CollectionWiring {
+  template?: { exists: boolean; data?: () => unknown };
+  instance?: { exists: boolean; data?: () => unknown };
+  // Mocks captured for later assertions:
+  eventSet: ReturnType<typeof vi.fn>;
+  instanceAdd: ReturnType<typeof vi.fn>;
+  instanceRef: InstanceRefStub;
+  auditAdd: ReturnType<typeof vi.fn>;
+  instancesOrderBy: ReturnType<typeof vi.fn>;
+  instanceListGet: ReturnType<typeof vi.fn>;
+}
+
+function wireCollections(
+  templateData: { exists: boolean; data?: () => unknown },
+  instanceData: { exists: boolean; data?: () => unknown },
+  listDocs: Array<{ id: string; data: () => unknown }> = []
+): CollectionWiring {
+  const eventSet = vi.fn(async () => undefined);
+  const instanceAdd = vi.fn(async () => ({ id: "new-instance-id" }));
+  const auditAdd = vi.fn(async () => undefined);
+  const instanceListGet = vi.fn(async () => ({ docs: listDocs }));
+  const orderByInner = vi.fn(() => ({ get: instanceListGet }));
+  const instancesOrderBy = vi.fn(() => ({ orderBy: orderByInner }));
+
+  const instanceRef: InstanceRefStub = {
+    get: vi.fn(async () => instanceData),
+    update: vi.fn(async () => undefined),
+    delete: vi.fn(async () => undefined),
+  };
+
+  const eventDoc = vi.fn(() => ({
+    set: eventSet,
+    collection: vi.fn(() => ({
+      doc: vi.fn(() => instanceRef),
+      add: instanceAdd,
+      orderBy: instancesOrderBy,
+    })),
+  }));
+
+  const templateRef = {
+    get: vi.fn(async () => templateData),
+  };
+
+  collectionMock.mockImplementation((name: string) => {
+    if (name === "events") return { doc: eventDoc };
+    if (name === "minigame_templates") return { doc: () => templateRef };
+    if (name === "audit_log") return { add: auditAdd };
+    throw new Error("unexpected collection " + name);
+  });
+
+  return {
+    eventSet,
+    instanceAdd,
+    instanceRef,
+    auditAdd,
+    instancesOrderBy,
+    instanceListGet,
+  };
+}
+
+describe("minigameInstances handler", () => {
+  beforeEach(() => {
+    collectionMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("attach", () => {
+    it("snapshots a poll template and creates the shadow event doc", async () => {
+      const wiring = wireCollections(
+        { exists: true, data: () => SAMPLE_POLL_TEMPLATE },
+        { exists: false }
+      );
+      const res = buildRes();
+      await handler.attach(
+        buildReq({ templateId: "tpl-1", order: 0 }, { slug: "devfest-2025" }),
+        res
+      );
+
+      expect(wiring.eventSet).toHaveBeenCalledTimes(1);
+      const [eventPayload, eventOpts] = wiring.eventSet.mock.calls[0];
+      expect(eventPayload).toMatchObject({ slug: "devfest-2025" });
+      expect(eventOpts).toEqual({ merge: true });
+
+      expect(wiring.instanceAdd).toHaveBeenCalledTimes(1);
+      const stored = wiring.instanceAdd.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >;
+      expect(stored).toMatchObject({
+        eventSlug: "devfest-2025",
+        templateId: "tpl-1",
+        templateVersion: 3,
+        type: "poll",
+        mode: "realtime",
+        state: "scheduled",
+        title: "Pick one",
+        config: SAMPLE_POLL_TEMPLATE.poll,
+        order: 0,
+        createdBy: "admin-uid",
+      });
+      expect(stored.createdAt).toBe(fieldValueServerTimestamp);
+      // Poll has no quiz fields.
+      expect(stored.currentQuestionIndex).toBeUndefined();
+
+      expect(res.__status).toBe(201);
+      expect(res.__body).toEqual({
+        success: true,
+        data: { id: "new-instance-id", type: "poll" },
+      });
+
+      const auditPayload = wiring.auditAdd.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >;
+      expect(auditPayload).toMatchObject({
+        action: "minigame_instance.attach",
+        targetId: "new-instance-id",
+        targetType: "minigame_instance",
+      });
+    });
+
+    it("seeds quiz runtime fields when attaching a quiz template", async () => {
+      const wiring = wireCollections(
+        { exists: true, data: () => SAMPLE_QUIZ_TEMPLATE },
+        { exists: false }
+      );
+      const res = buildRes();
+      await handler.attach(
+        buildReq({ templateId: "tpl-q", order: 1 }, { slug: "devfest-2025" }),
+        res
+      );
+      const stored = wiring.instanceAdd.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >;
+      expect(stored).toMatchObject({
+        type: "quiz",
+        mode: "realtime",
+        currentQuestionIndex: -1,
+        currentQuestionStartedAt: null,
+      });
+      expect(stored.config).toEqual(SAMPLE_QUIZ_TEMPLATE.quiz);
+    });
+
+    it("derives mode='global' for bingo", async () => {
+      const wiring = wireCollections(
+        { exists: true, data: () => SAMPLE_BINGO_TEMPLATE },
+        { exists: false }
+      );
+      const res = buildRes();
+      await handler.attach(
+        buildReq({ templateId: "tpl-b", order: 0 }, { slug: "devfest-2025" }),
+        res
+      );
+      const stored = wiring.instanceAdd.mock.calls[0][0] as Record<
+        string,
+        unknown
+      >;
+      expect(stored.type).toBe("bingo");
+      expect(stored.mode).toBe("global");
+      expect(stored.currentQuestionIndex).toBeUndefined();
+    });
+
+    it("returns 404 if template does not exist", async () => {
+      wireCollections({ exists: false }, { exists: false });
+      const res = buildRes();
+      await handler.attach(
+        buildReq({ templateId: "missing", order: 0 }, { slug: "devfest-2025" }),
+        res
+      );
+      expect(res.__status).toBe(404);
+      expect((res.__body as { error: string }).error).toMatch(
+        /template not found/i
+      );
+    });
+  });
+
+  describe("setState", () => {
+    it("sets state=live and stamps activatedAt", async () => {
+      const wiring = wireCollections(
+        { exists: false },
+        { exists: true, data: () => ({ state: "scheduled" }) }
+      );
+      const res = buildRes();
+      await handler.setState(
+        buildReq({ state: "live" }, { slug: "x", id: "i1" }),
+        res
+      );
+      expect(wiring.instanceRef.update).toHaveBeenCalledWith({
+        state: "live",
+        activatedAt: fieldValueServerTimestamp,
+      });
+      expect(res.__body).toEqual({
+        success: true,
+        data: { id: "i1", state: "live" },
+      });
+    });
+
+    it("allows reopening (closed -> live)", async () => {
+      const wiring = wireCollections(
+        { exists: false },
+        { exists: true, data: () => ({ state: "closed" }) }
+      );
+      const res = buildRes();
+      await handler.setState(
+        buildReq({ state: "live" }, { slug: "x", id: "i1" }),
+        res
+      );
+      expect(wiring.instanceRef.update).toHaveBeenCalled();
+      expect(res.__status).toBeUndefined();
+    });
+
+    it("stamps closedAt when going to closed", async () => {
+      const wiring = wireCollections(
+        { exists: false },
+        { exists: true, data: () => ({ state: "live" }) }
+      );
+      const res = buildRes();
+      await handler.setState(
+        buildReq({ state: "closed" }, { slug: "x", id: "i1" }),
+        res
+      );
+      expect(wiring.instanceRef.update).toHaveBeenCalledWith({
+        state: "closed",
+        closedAt: fieldValueServerTimestamp,
+      });
+    });
+
+    it("returns 404 when instance is missing", async () => {
+      wireCollections({ exists: false }, { exists: false });
+      const res = buildRes();
+      await handler.setState(
+        buildReq({ state: "live" }, { slug: "x", id: "ghost" }),
+        res
+      );
+      expect(res.__status).toBe(404);
+    });
+  });
+
+  describe("quizAdvance", () => {
+    it("increments currentQuestionIndex and stamps startedAt", async () => {
+      const wiring = wireCollections(
+        { exists: false },
+        {
+          exists: true,
+          data: () => ({
+            type: "quiz",
+            state: "live",
+            currentQuestionIndex: 0,
+            config: { questions: [{ id: "q1" }, { id: "q2" }] },
+          }),
+        }
+      );
+      const res = buildRes();
+      await handler.quizAdvance(buildReq({}, { slug: "x", id: "i1" }), res);
+      expect(wiring.instanceRef.update).toHaveBeenCalledWith({
+        currentQuestionIndex: 1,
+        currentQuestionStartedAt: fieldValueServerTimestamp,
+      });
+      expect(res.__body).toEqual({
+        success: true,
+        data: { id: "i1", currentQuestionIndex: 1 },
+      });
+    });
+
+    it("rejects non-quiz instances", async () => {
+      wireCollections(
+        { exists: false },
+        {
+          exists: true,
+          data: () => ({ type: "poll", state: "live" }),
+        }
+      );
+      const res = buildRes();
+      await handler.quizAdvance(buildReq({}, { slug: "x", id: "i1" }), res);
+      expect(res.__status).toBe(400);
+    });
+
+    it("rejects when state is not live", async () => {
+      wireCollections(
+        { exists: false },
+        {
+          exists: true,
+          data: () => ({ type: "quiz", state: "scheduled" }),
+        }
+      );
+      const res = buildRes();
+      await handler.quizAdvance(buildReq({}, { slug: "x", id: "i1" }), res);
+      expect(res.__status).toBe(400);
+    });
+
+    it("rejects when already on the last question", async () => {
+      wireCollections(
+        { exists: false },
+        {
+          exists: true,
+          data: () => ({
+            type: "quiz",
+            state: "live",
+            currentQuestionIndex: 1,
+            config: { questions: [{ id: "q1" }, { id: "q2" }] },
+          }),
+        }
+      );
+      const res = buildRes();
+      await handler.quizAdvance(buildReq({}, { slug: "x", id: "i1" }), res);
+      expect(res.__status).toBe(400);
+      expect((res.__body as { error: string }).error).toMatch(/last/i);
+    });
+  });
+
+  describe("remove", () => {
+    it("deletes a scheduled instance", async () => {
+      const wiring = wireCollections(
+        { exists: false },
+        { exists: true, data: () => ({ state: "scheduled", title: "X" }) }
+      );
+      const res = buildRes();
+      await handler.remove(buildReq({}, { slug: "x", id: "i1" }), res);
+      expect(wiring.instanceRef.delete).toHaveBeenCalled();
+      expect(res.__body).toEqual({ success: true });
+    });
+
+    it("returns 409 when instance is live", async () => {
+      const wiring = wireCollections(
+        { exists: false },
+        { exists: true, data: () => ({ state: "live" }) }
+      );
+      const res = buildRes();
+      await handler.remove(buildReq({}, { slug: "x", id: "i1" }), res);
+      expect(wiring.instanceRef.delete).not.toHaveBeenCalled();
+      expect(res.__status).toBe(409);
+    });
+
+    it("returns 409 when instance is closed", async () => {
+      wireCollections(
+        { exists: false },
+        { exists: true, data: () => ({ state: "closed" }) }
+      );
+      const res = buildRes();
+      await handler.remove(buildReq({}, { slug: "x", id: "i1" }), res);
+      expect(res.__status).toBe(409);
+    });
+
+    it("returns 404 when instance is missing", async () => {
+      wireCollections({ exists: false }, { exists: false });
+      const res = buildRes();
+      await handler.remove(buildReq({}, { slug: "x", id: "ghost" }), res);
+      expect(res.__status).toBe(404);
+    });
+  });
+
+  describe("list", () => {
+    it("returns docs ordered by order asc, createdAt asc", async () => {
+      const wiring = wireCollections({ exists: false }, { exists: false }, [
+        { id: "i1", data: () => ({ order: 0, type: "poll" }) },
+        { id: "i2", data: () => ({ order: 1, type: "quiz" }) },
+      ]);
+      const res = buildRes();
+      await handler.list(buildReq({}, { slug: "x" }), res);
+      expect(wiring.instancesOrderBy).toHaveBeenCalledWith("order", "asc");
+      expect(res.__body).toEqual({
+        success: true,
+        data: [
+          { id: "i1", order: 0, type: "poll" },
+          { id: "i2", order: 1, type: "quiz" },
+        ],
+      });
+    });
+  });
+});

--- a/functions/src/handlers/minigameInstances.ts
+++ b/functions/src/handlers/minigameInstances.ts
@@ -1,0 +1,306 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { safeError } from "../middleware/validate";
+import type { MinigameTemplate, MinigameTemplateType } from "../schemas";
+
+interface AuditDetails {
+  slug?: string;
+  type?: MinigameTemplateType;
+  title?: string;
+  state?: string;
+  templateId?: string;
+  fromIndex?: number;
+  toIndex?: number;
+}
+
+function modeForType(type: MinigameTemplateType): "global" | "realtime" {
+  return type === "poll" || type === "quiz" ? "realtime" : "global";
+}
+
+function auditEntry(
+  action: string,
+  performedBy: string,
+  targetId: string,
+  details: AuditDetails
+) {
+  return {
+    action,
+    performedBy,
+    targetId,
+    targetType: "minigame_instance",
+    details,
+    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+  };
+}
+
+function eventDocRef(slug: string) {
+  return admin.firestore().collection("events").doc(slug);
+}
+
+function instancesCol(slug: string) {
+  return eventDocRef(slug).collection("minigames");
+}
+
+// GET /api/events/:slug/minigames
+export async function list(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const snap = await instancesCol(slug)
+      .orderBy("order", "asc")
+      .orderBy("createdAt", "asc")
+      .get();
+    res.json({
+      success: true,
+      data: snap.docs.map((d) => ({ id: d.id, ...d.data() })),
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+// POST /api/events/:slug/minigames  body: { templateId, order }
+export async function attach(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const user = (req as AuthenticatedRequest).user;
+    const { templateId, order } = req.body as {
+      templateId: string;
+      order: number;
+    };
+
+    const tplRef = admin
+      .firestore()
+      .collection("minigame_templates")
+      .doc(templateId);
+    const tplSnap = await tplRef.get();
+    if (!tplSnap.exists) {
+      res.status(404).json({ success: false, error: "Template not found" });
+      return;
+    }
+    const tpl = tplSnap.data() as
+      | (MinigameTemplate & { version?: number })
+      | undefined;
+    if (!tpl) {
+      res.status(404).json({ success: false, error: "Template not found" });
+      return;
+    }
+
+    // Lazily create the parent shadow doc so subcollection rules can match.
+    // `merge: true` keeps any later admin-written fields safe.
+    const eventRef = eventDocRef(slug);
+    await eventRef.set(
+      {
+        slug,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+
+    const now = admin.firestore.FieldValue.serverTimestamp();
+    const config = pickConfig(tpl);
+    const baseInstance: Record<string, unknown> = {
+      eventSlug: slug,
+      templateId,
+      templateVersion: tpl.version ?? 1,
+      type: tpl.type,
+      mode: modeForType(tpl.type),
+      state: "scheduled",
+      title: tpl.title,
+      config,
+      order,
+      createdAt: now,
+      createdBy: user.uid,
+    };
+    if (tpl.type === "quiz") {
+      baseInstance.currentQuestionIndex = -1;
+      baseInstance.currentQuestionStartedAt = null;
+    }
+
+    const ref = await instancesCol(slug).add(baseInstance);
+
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add(
+        auditEntry("minigame_instance.attach", user.uid, ref.id, {
+          slug,
+          type: tpl.type,
+          title: tpl.title,
+          templateId,
+        })
+      );
+
+    res
+      .status(201)
+      .json({ success: true, data: { id: ref.id, type: tpl.type } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+// PATCH /api/events/:slug/minigames/:id/state  body: { state }
+export async function setState(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const id = req.params.id as string;
+    const user = (req as AuthenticatedRequest).user;
+    const { state } = req.body as {
+      state: "scheduled" | "live" | "closed";
+    };
+
+    const ref = instancesCol(slug).doc(id);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      res
+        .status(404)
+        .json({ success: false, error: "Minigame instance not found" });
+      return;
+    }
+
+    const update: Record<string, unknown> = { state };
+    if (state === "live") {
+      update.activatedAt = admin.firestore.FieldValue.serverTimestamp();
+    } else if (state === "closed") {
+      update.closedAt = admin.firestore.FieldValue.serverTimestamp();
+    }
+
+    await ref.update(update);
+
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add(
+        auditEntry(`minigame_instance.state.${state}`, user.uid, id, {
+          slug,
+          state,
+        })
+      );
+
+    res.json({ success: true, data: { id, state } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+// POST /api/events/:slug/minigames/:id/quiz/advance
+export async function quizAdvance(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const id = req.params.id as string;
+    const user = (req as AuthenticatedRequest).user;
+
+    const ref = instancesCol(slug).doc(id);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      res
+        .status(404)
+        .json({ success: false, error: "Minigame instance not found" });
+      return;
+    }
+    const data = snap.data() as
+      | {
+          type?: string;
+          state?: string;
+          currentQuestionIndex?: number;
+          config?: { questions?: unknown[] };
+        }
+      | undefined;
+    if (!data || data.type !== "quiz") {
+      res.status(400).json({ success: false, error: "Not a quiz instance" });
+      return;
+    }
+    if (data.state !== "live") {
+      res
+        .status(400)
+        .json({ success: false, error: "Quiz must be live to advance" });
+      return;
+    }
+    const questions = data.config?.questions ?? [];
+    const fromIndex = data.currentQuestionIndex ?? -1;
+    const toIndex = fromIndex + 1;
+    if (toIndex >= questions.length) {
+      res
+        .status(400)
+        .json({ success: false, error: "Already on last question" });
+      return;
+    }
+
+    await ref.update({
+      currentQuestionIndex: toIndex,
+      currentQuestionStartedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add(
+        auditEntry("minigame_instance.quiz.advance", user.uid, id, {
+          slug,
+          fromIndex,
+          toIndex,
+        })
+      );
+
+    res.json({ success: true, data: { id, currentQuestionIndex: toIndex } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+// DELETE /api/events/:slug/minigames/:id  (only when state == "scheduled")
+export async function remove(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const id = req.params.id as string;
+    const user = (req as AuthenticatedRequest).user;
+
+    const ref = instancesCol(slug).doc(id);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      res
+        .status(404)
+        .json({ success: false, error: "Minigame instance not found" });
+      return;
+    }
+    const data = snap.data() as { state?: string; title?: string } | undefined;
+    if (data?.state !== "scheduled") {
+      res.status(409).json({
+        success: false,
+        error:
+          "Only scheduled instances can be deleted. Close the game and leave it as historical record.",
+      });
+      return;
+    }
+    await ref.delete();
+
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add(
+        auditEntry("minigame_instance.delete", user.uid, id, {
+          slug,
+          title: data?.title,
+        })
+      );
+
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+// Strip server-managed wrapper fields so the snapshot inside the instance
+// stays focused on the runtime config the participant overlay needs.
+function pickConfig(tpl: MinigameTemplate): Record<string, unknown> {
+  switch (tpl.type) {
+    case "poll":
+      return { ...tpl.poll };
+    case "quiz":
+      return { ...tpl.quiz };
+    case "wordcloud":
+      return { ...tpl.wordcloud };
+    case "bingo":
+      return { ...tpl.bingo };
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -14,6 +14,8 @@ import {
   teamMemberSchema,
   locationSchema,
   minigameTemplateSchema,
+  minigameInstanceCreateSchema,
+  minigameStateSchema,
 } from "./schemas";
 import { register } from "./handlers/auth";
 import * as events from "./handlers/events";
@@ -26,6 +28,7 @@ import * as forms from "./handlers/forms";
 import { triggerRebuild } from "./handlers/rebuild";
 import * as locations from "./handlers/locations";
 import * as minigameTemplates from "./handlers/minigameTemplates";
+import * as minigameInstances from "./handlers/minigameInstances";
 
 admin.initializeApp();
 
@@ -287,6 +290,48 @@ app.delete(
   minigameTemplates.remove
 );
 
+// Minigame Instances (admin-only — attach templates to events)
+const slugP = validateParamId("slug");
+app.get(
+  "/api/events/:slug/minigames",
+  requireRole("admin"),
+  slugP,
+  minigameInstances.list
+);
+app.post(
+  "/api/events/:slug/minigames",
+  requireRole("admin"),
+  slugP,
+  writeLimiter,
+  validateBody(minigameInstanceCreateSchema),
+  minigameInstances.attach
+);
+app.patch(
+  "/api/events/:slug/minigames/:id/state",
+  requireRole("admin"),
+  slugP,
+  vid,
+  writeLimiter,
+  validateBody(minigameStateSchema),
+  minigameInstances.setState
+);
+app.post(
+  "/api/events/:slug/minigames/:id/quiz/advance",
+  requireRole("admin"),
+  slugP,
+  vid,
+  writeLimiter,
+  minigameInstances.quizAdvance
+);
+app.delete(
+  "/api/events/:slug/minigames/:id",
+  requireRole("admin"),
+  slugP,
+  vid,
+  writeLimiter,
+  minigameInstances.remove
+);
+
 // Rebuild
 app.post("/api/rebuild", requireRole("admin"), writeLimiter, triggerRebuild);
 
@@ -294,3 +339,7 @@ export const api = onRequest(
   { secrets: [GITHUB_TOKEN], invoker: "public" },
   app
 );
+
+// Firestore trigger: incrementally maintains aggregates/current per
+// minigame instance whenever a participant response is created.
+export { onMinigameResponseWritten } from "./triggers/recomputeAggregates";

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -224,3 +224,23 @@ export const minigameTemplateSchema = z.discriminatedUnion("type", [
 
 export type MinigameTemplate = z.infer<typeof minigameTemplateSchema>;
 export type MinigameTemplateType = MinigameTemplate["type"];
+
+// Mini-game instances (template attached to an event) ---------------------
+//
+// Two narrow body schemas, one per write endpoint. The instance document
+// itself stores the snapshotted template config (built server-side at
+// attach time) plus runtime fields managed by the Cloud Function — those
+// are not part of any client write payload.
+
+export const minigameInstanceCreateSchema = z
+  .object({
+    templateId: shortText(100).min(1),
+    order: z.number().int().min(0).max(1000).default(0),
+  })
+  .strict();
+
+export const minigameStateSchema = z
+  .object({
+    state: z.enum(["scheduled", "live", "closed"]),
+  })
+  .strict();

--- a/functions/src/services/bingo.test.ts
+++ b/functions/src/services/bingo.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { generateBingoCard } from "./bingo";
+
+const TERMS_25 = Array.from({ length: 25 }, (_, i) => `term-${i + 1}`);
+
+describe("generateBingoCard", () => {
+  it("returns exactly 16 terms", () => {
+    const card = generateBingoCard(TERMS_25, "user-1:instance-A");
+    expect(card).toHaveLength(16);
+  });
+
+  it("contains only terms from the bank, with no duplicates", () => {
+    const card = generateBingoCard(TERMS_25, "abc");
+    const set = new Set(card);
+    expect(set.size).toBe(16);
+    for (const term of card) {
+      expect(TERMS_25).toContain(term);
+    }
+  });
+
+  it("is deterministic for the same seed", () => {
+    const a = generateBingoCard(TERMS_25, "seed-x");
+    const b = generateBingoCard(TERMS_25, "seed-x");
+    expect(a).toEqual(b);
+  });
+
+  it("produces different cards for different seeds (statistically)", () => {
+    const a = generateBingoCard(TERMS_25, "seed-1");
+    const b = generateBingoCard(TERMS_25, "seed-2");
+    // It is theoretically possible (probability ~1/C(25,16)) that two
+    // shuffles yield the same first-16. With these specific seeds we know
+    // they don't, but assert "not equal" since that is the user-visible
+    // property we care about.
+    expect(a).not.toEqual(b);
+  });
+
+  it("dedupes the input bank before sampling", () => {
+    const sloppy = [
+      ...TERMS_25,
+      ...TERMS_25.slice(0, 5), // duplicates
+      "  term-1  ", // whitespace-padded duplicate
+    ];
+    const card = generateBingoCard(sloppy, "seed");
+    expect(card).toHaveLength(16);
+    expect(new Set(card).size).toBe(16);
+  });
+
+  it("throws if dedup yields fewer than 16 terms", () => {
+    const tooFew = ["a", "b", "c", "a", "b", "c"];
+    expect(() => generateBingoCard(tooFew, "seed")).toThrowError(
+      /at least 16/i
+    );
+  });
+
+  it("ignores empty/whitespace-only terms when counting", () => {
+    const withGarbage = [...TERMS_25.slice(0, 16), "", "   ", "\t"];
+    const card = generateBingoCard(withGarbage, "seed");
+    expect(card).toHaveLength(16);
+    expect(card).not.toContain("");
+  });
+});

--- a/functions/src/services/bingo.ts
+++ b/functions/src/services/bingo.ts
@@ -1,0 +1,55 @@
+// Deterministic bingo card generation.
+//
+// `generateBingoCard` returns 16 unique terms drawn from the input bank
+// using a seeded shuffle. Same seed → same card, every time. We use this in
+// PR4's join handler so every participant gets a stable, reproducible card
+// derived from their UID + the instance ID, with no Firestore round-trips.
+
+const CARD_SIZE = 16;
+
+// 32-bit FNV-1a hash → seed value for the PRNG.
+function hashSeed(seed: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  // Force unsigned 32-bit
+  return h >>> 0;
+}
+
+// Mulberry32 — small fast deterministic 32-bit PRNG. Returns [0, 1).
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function generateBingoCard(terms: string[], seed: string): string[] {
+  // De-dupe input first — admins can be sloppy. Preserve first-seen order.
+  const unique = Array.from(
+    new Set(terms.map((t) => t.trim())).values()
+  ).filter((t) => t.length > 0);
+
+  if (unique.length < CARD_SIZE) {
+    throw new Error(
+      `Bingo term bank must have at least ${CARD_SIZE} unique terms (got ${unique.length})`
+    );
+  }
+
+  const rand = mulberry32(hashSeed(seed));
+  const arr = unique.slice();
+  // Fisher–Yates with seeded RNG.
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+  }
+  return arr.slice(0, CARD_SIZE);
+}

--- a/functions/src/triggers/recomputeAggregates.test.ts
+++ b/functions/src/triggers/recomputeAggregates.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted, so any vars used inside its factory must be declared
+// via vi.hoisted to share initialization order with the mock.
+const mocks = vi.hoisted(() => {
+  const setMock = vi.fn();
+  const docMock = vi.fn(() => ({ set: setMock }));
+  const incrementMock = vi.fn((n: number) => ({ __increment: n }));
+  const serverTsMock = vi.fn(() => "__SERVER_TS__");
+  return { setMock, docMock, incrementMock, serverTsMock };
+});
+
+vi.mock("firebase-admin", () => ({
+  firestore: Object.assign(() => ({ doc: mocks.docMock }), {
+    FieldValue: {
+      increment: mocks.incrementMock,
+      serverTimestamp: mocks.serverTsMock,
+    },
+  }),
+}));
+
+// Stub `firebase-functions/v2/firestore` so importing the module does not
+// require Functions runtime config. We don't invoke the wrapped export
+// directly; tests target the exported inner handler.
+vi.mock("firebase-functions/v2/firestore", () => ({
+  onDocumentWritten: (_path: string, handler: unknown) => handler,
+}));
+
+const { setMock, docMock, incrementMock, serverTsMock } = mocks;
+
+import {
+  recomputeAggregatesFromEvent,
+  type ResponseWriteEvent,
+} from "./recomputeAggregates";
+
+function createEvent(
+  data: { questionId?: string; optionId?: string } | undefined,
+  opts: { beforeExists?: boolean; afterExists?: boolean } = {}
+): ResponseWriteEvent {
+  const { beforeExists = false, afterExists = true } = opts;
+  return {
+    data: {
+      before: { exists: beforeExists },
+      after: {
+        exists: afterExists,
+        data: () => data,
+      },
+    },
+    params: { slug: "devfest-2025", id: "instance-A" },
+  };
+}
+
+describe("recomputeAggregatesFromEvent", () => {
+  beforeEach(() => {
+    setMock.mockReset();
+    docMock.mockClear();
+    incrementMock.mockClear();
+    serverTsMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("increments optionCounts and totalResponses on create", async () => {
+    await recomputeAggregatesFromEvent(
+      createEvent({ questionId: "q1", optionId: "a" })
+    );
+    expect(docMock).toHaveBeenCalledWith(
+      "events/devfest-2025/minigames/instance-A/aggregates/current"
+    );
+    expect(setMock).toHaveBeenCalledTimes(1);
+    const [payload, options] = setMock.mock.calls[0];
+    expect(payload.optionCounts["q1:a"]).toEqual({ __increment: 1 });
+    expect(payload.totalResponses).toEqual({ __increment: 1 });
+    expect(payload.updatedAt).toBe("__SERVER_TS__");
+    expect(options).toEqual({ merge: true });
+  });
+
+  it("uses a separate counter per (question,option) pair", async () => {
+    await recomputeAggregatesFromEvent(
+      createEvent({ questionId: "q1", optionId: "a" })
+    );
+    await recomputeAggregatesFromEvent(
+      createEvent({ questionId: "q1", optionId: "b" })
+    );
+    await recomputeAggregatesFromEvent(
+      createEvent({ questionId: "q2", optionId: "a" })
+    );
+    const keys = setMock.mock.calls.map(
+      (c) => Object.keys((c[0] as { optionCounts: object }).optionCounts)[0]
+    );
+    expect(keys).toEqual(["q1:a", "q1:b", "q2:a"]);
+    expect(setMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("ignores updates (before exists)", async () => {
+    await recomputeAggregatesFromEvent(
+      createEvent({ questionId: "q1", optionId: "a" }, { beforeExists: true })
+    );
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores deletes (after does not exist)", async () => {
+    await recomputeAggregatesFromEvent(
+      createEvent(undefined, { afterExists: false })
+    );
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed responses missing questionId or optionId", async () => {
+    await recomputeAggregatesFromEvent(createEvent({ questionId: "q1" }));
+    await recomputeAggregatesFromEvent(createEvent({ optionId: "a" }));
+    await recomputeAggregatesFromEvent(createEvent({}));
+    expect(setMock).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/triggers/recomputeAggregates.ts
+++ b/functions/src/triggers/recomputeAggregates.ts
@@ -1,0 +1,68 @@
+import { onDocumentWritten } from "firebase-functions/v2/firestore";
+import * as admin from "firebase-admin";
+
+// Fires whenever a response doc is written under a minigame instance and
+// keeps the single `aggregates/current` doc in sync. Spectators (the
+// projector view, the live overlays) listen to that one doc instead of the
+// raw responses collection — so this trigger absorbs the fan-out and caps
+// realtime read costs to 1 listener per game per phone.
+//
+// Implementation is intentionally O(1) per write: we use FieldValue.increment
+// and merge: true. PR6 will extend this trigger to also recompute the quiz
+// leaderboard (top N participants by score) — for now we just count votes
+// and total responses, which is what the poll/wordcloud overlays consume.
+//
+// Rule deletes responses are blocked, so we ignore the delete edge case
+// (no `before && !after`). For pure update events (also blocked by rules in
+// PR3+), we still no-op to avoid double-counting.
+export interface ResponseWriteEvent {
+  data?: {
+    before?: { exists: boolean };
+    after?: {
+      exists: boolean;
+      data: () => { questionId?: string; optionId?: string } | undefined;
+    };
+  };
+  params: { slug: string; id: string };
+}
+
+// Inner handler — exported for unit tests so we can drive it with a synthetic
+// event without spinning up the emulator.
+export async function recomputeAggregatesFromEvent(
+  event: ResponseWriteEvent
+): Promise<void> {
+  const before = event.data?.before;
+  const after = event.data?.after;
+  // Skip everything except creates. Updates/deletes shouldn't happen with
+  // the current rules, but defending here keeps aggregates accurate even
+  // if rules drift later.
+  if (!after?.exists || before?.exists) return;
+
+  const data = after.data();
+  if (!data?.questionId || !data?.optionId) return;
+
+  const { slug, id } = event.params;
+  const aggregateRef = admin
+    .firestore()
+    .doc(`events/${slug}/minigames/${id}/aggregates/current`);
+
+  const optionKey = `${data.questionId}:${data.optionId}`;
+  await aggregateRef.set(
+    {
+      optionCounts: {
+        [optionKey]: admin.firestore.FieldValue.increment(1),
+      },
+      totalResponses: admin.firestore.FieldValue.increment(1),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+}
+
+export const onMinigameResponseWritten = onDocumentWritten(
+  "events/{slug}/minigames/{id}/responses/{respId}",
+  // Cast at the call site so the v2 SDK's strong event type is preserved
+  // for deployment without bleeding into our test-friendly inner shape.
+  (event) =>
+    recomputeAggregatesFromEvent(event as unknown as ResponseWriteEvent)
+);

--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -14,6 +14,7 @@ import { FormRegistry } from "./forms/FormRegistry";
 import { FormViewer } from "./forms/FormViewer";
 import { LocationList } from "./locations/LocationList";
 import { MinigameTemplateList } from "./minigame-templates/MinigameTemplateList";
+import { EventMinigameManager } from "./event-minigames/EventMinigameManager";
 
 interface Props {
   page: string;
@@ -95,6 +96,8 @@ function AdminContent({ page, currentPath }: Props) {
         return <LocationList />;
       case "minigame-templates":
         return <MinigameTemplateList />;
+      case "event-minigames":
+        return <EventMinigameManager />;
       default:
         return (
           <p className="text-gray-500 dark:text-gray-400">
@@ -134,6 +137,8 @@ function DevContent({ page, currentPath }: Props) {
         return <LocationList />;
       case "minigame-templates":
         return <MinigameTemplateList />;
+      case "event-minigames":
+        return <EventMinigameManager />;
       default:
         return (
           <p className="text-gray-500 dark:text-gray-400">

--- a/src/components/react/admin/event-minigames/AttachTemplateModal.tsx
+++ b/src/components/react/admin/event-minigames/AttachTemplateModal.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "@/lib/api";
+import {
+  TYPE_COLORS,
+  TYPE_LABELS,
+  type Template,
+} from "../minigame-templates/types";
+
+interface Props {
+  alreadyAttachedTemplateIds: Set<string>;
+  onCancel: () => void;
+  onAttached: () => void;
+  onError: (message: string) => void;
+  attach: (templateId: string) => Promise<{ success: boolean; error?: string }>;
+}
+
+export function AttachTemplateModal({
+  alreadyAttachedTemplateIds,
+  onCancel,
+  onAttached,
+  onError,
+  attach,
+}: Props) {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const res = await api.listMinigameTemplates();
+      if (cancelled) return;
+      if (res.success && Array.isArray(res.data)) {
+        setTemplates(res.data as Template[]);
+      } else {
+        onError(res.error || "Error al cargar plantillas");
+      }
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [onError]);
+
+  const available = useMemo(
+    () =>
+      templates.filter((t) => t.id && !alreadyAttachedTemplateIds.has(t.id)),
+    [templates, alreadyAttachedTemplateIds]
+  );
+
+  async function handleAttach(templateId: string) {
+    setSubmitting(templateId);
+    const res = await attach(templateId);
+    if (res.success) {
+      onAttached();
+    } else {
+      onError(res.error || "Error al adjuntar plantilla");
+      setSubmitting(null);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="fixed inset-0 bg-black/50"
+        onClick={onCancel}
+        aria-hidden
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Adjuntar plantilla"
+        className="relative z-10 max-h-[80vh] w-full max-w-lg overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-gray-800"
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Adjuntar plantilla
+          </h2>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg p-1 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+            aria-label="Cerrar"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="max-h-[60vh] overflow-y-auto p-6">
+          {loading && (
+            <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+              Cargando plantillas...
+            </p>
+          )}
+          {!loading && available.length === 0 && (
+            <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+              No hay plantillas disponibles. Crea una en{" "}
+              <a
+                href="/admin/minigame-templates"
+                className="text-blue-600 hover:underline dark:text-blue-400"
+              >
+                /admin/minigame-templates
+              </a>
+              .
+            </p>
+          )}
+          {!loading && available.length > 0 && (
+            <ul className="space-y-2">
+              {available.map((t) => (
+                <li
+                  key={t.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 p-3 dark:border-gray-700"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="mb-1 flex items-center gap-2">
+                      <span
+                        className={`rounded px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[t.type]}`}
+                      >
+                        {TYPE_LABELS[t.type]}
+                      </span>
+                    </div>
+                    <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
+                      {t.title}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleAttach(t.id!)}
+                    disabled={submitting !== null}
+                    className="shrink-0 rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    {submitting === t.id ? "..." : "Adjuntar"}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/event-minigames/EventMinigameManager.tsx
+++ b/src/components/react/admin/event-minigames/EventMinigameManager.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { api } from "@/lib/api";
+import { Toast } from "../ui/Toast";
+import { AttachTemplateModal } from "./AttachTemplateModal";
+import { InstanceCard } from "./InstanceCard";
+import type { InstanceState, MinigameInstance } from "./types";
+
+interface Props {
+  // Optional injection point so unit tests can avoid touching window.location.
+  initialSlug?: string;
+}
+
+function slugFromUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  const params = new URLSearchParams(window.location.search);
+  return params.get("slug");
+}
+
+export function EventMinigameManager({ initialSlug }: Props) {
+  const [slug] = useState<string | null>(initialSlug ?? slugFromUrl());
+  const [instances, setInstances] = useState<MinigameInstance[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+  const [attaching, setAttaching] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    if (!slug) return;
+    const res = await api.listEventMinigames(slug);
+    if (res.success && Array.isArray(res.data)) {
+      setInstances(res.data as MinigameInstance[]);
+      setError(null);
+    } else {
+      setError(res.error || "Error al cargar instancias");
+    }
+    setLoading(false);
+  }, [slug]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const attachedTemplateIds = useMemo(
+    () => new Set(instances.map((i) => i.templateId)),
+    [instances]
+  );
+
+  async function handleSetState(id: string, state: InstanceState) {
+    if (!slug) return;
+    setBusyId(id);
+    const res = await api.setMinigameState(slug, id, state);
+    if (res.success) {
+      setToast({ message: `Estado: ${state}`, type: "success" });
+      await reload();
+    } else {
+      setToast({
+        message: res.error || "Error al cambiar estado",
+        type: "error",
+      });
+    }
+    setBusyId(null);
+  }
+
+  async function handleAdvanceQuiz(id: string) {
+    if (!slug) return;
+    setBusyId(id);
+    const res = await api.advanceQuizQuestion(slug, id);
+    if (res.success) {
+      setToast({ message: "Pregunta avanzada", type: "success" });
+      await reload();
+    } else {
+      setToast({
+        message: res.error || "Error al avanzar pregunta",
+        type: "error",
+      });
+    }
+    setBusyId(null);
+  }
+
+  async function handleDelete(id: string) {
+    if (!slug) return;
+    setBusyId(id);
+    const res = await api.removeMinigameFromEvent(slug, id);
+    if (res.success) {
+      setToast({ message: "Instancia eliminada", type: "success" });
+      setInstances((prev) => prev.filter((i) => i.id !== id));
+    } else {
+      setToast({ message: res.error || "Error al eliminar", type: "error" });
+    }
+    setBusyId(null);
+  }
+
+  if (!slug) {
+    return (
+      <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-4 text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-400">
+        Falta el parámetro <code>?slug=</code> en la URL.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+
+      <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <a
+            href="/admin/eventos"
+            className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+          >
+            ← Volver a eventos
+          </a>
+          <h1 className="mt-1 text-xl font-bold text-gray-900 dark:text-white">
+            Mini-juegos · <span className="font-mono">{slug}</span>
+          </h1>
+        </div>
+        <button
+          type="button"
+          onClick={() => setAttaching(true)}
+          className="shrink-0 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          + Adjuntar plantilla
+        </button>
+      </div>
+
+      {loading && (
+        <div className="flex justify-center py-12">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && instances.length === 0 && (
+        <p className="py-8 text-center text-gray-500 dark:text-gray-400">
+          Aún no hay mini-juegos en este evento. Adjunta una plantilla para
+          empezar.
+        </p>
+      )}
+
+      {!loading && instances.length > 0 && (
+        <div className="space-y-3">
+          {instances.map((inst) => (
+            <InstanceCard
+              key={inst.id}
+              instance={inst}
+              busy={busyId === inst.id}
+              onSetState={(state) => handleSetState(inst.id, state)}
+              onAdvanceQuiz={() => handleAdvanceQuiz(inst.id)}
+              onDelete={() => handleDelete(inst.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {attaching && (
+        <AttachTemplateModal
+          alreadyAttachedTemplateIds={attachedTemplateIds}
+          onCancel={() => setAttaching(false)}
+          onError={(message) => setToast({ message, type: "error" })}
+          onAttached={async () => {
+            setAttaching(false);
+            setToast({ message: "Plantilla adjuntada", type: "success" });
+            await reload();
+          }}
+          attach={async (templateId) => {
+            const res = await api.attachMinigameToEvent(slug, {
+              templateId,
+              order: instances.length,
+            });
+            return res;
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/react/admin/event-minigames/InstanceCard.tsx
+++ b/src/components/react/admin/event-minigames/InstanceCard.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { TYPE_COLORS, TYPE_LABELS } from "../minigame-templates/types";
+import {
+  MODE_LABELS,
+  STATE_COLORS,
+  STATE_LABELS,
+  type InstanceState,
+  type MinigameInstance,
+} from "./types";
+
+interface Props {
+  instance: MinigameInstance;
+  onSetState: (state: InstanceState) => Promise<void> | void;
+  onAdvanceQuiz: () => Promise<void> | void;
+  onDelete: () => Promise<void> | void;
+  busy: boolean;
+}
+
+function questionCount(instance: MinigameInstance): number {
+  if (instance.type !== "quiz") return 0;
+  const questions = (instance.config?.questions as unknown[] | undefined) ?? [];
+  return questions.length;
+}
+
+export function InstanceCard({
+  instance,
+  onSetState,
+  onAdvanceQuiz,
+  onDelete,
+  busy,
+}: Props) {
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const isQuiz = instance.type === "quiz";
+  const totalQuestions = questionCount(instance);
+  const currentQ =
+    instance.currentQuestionIndex !== undefined &&
+    instance.currentQuestionIndex >= 0
+      ? instance.currentQuestionIndex + 1
+      : 0;
+  const isOnLastQuestion = isQuiz && currentQ >= totalQuestions;
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <span
+              className={`rounded px-2 py-0.5 text-xs font-medium ${TYPE_COLORS[instance.type]}`}
+            >
+              {TYPE_LABELS[instance.type]}
+            </span>
+            <span
+              className={`rounded px-2 py-0.5 text-xs font-medium ${STATE_COLORS[instance.state]}`}
+              data-testid="state-badge"
+            >
+              {STATE_LABELS[instance.state]}
+            </span>
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {MODE_LABELS[instance.mode]}
+            </span>
+          </div>
+          <h3 className="truncate text-base font-semibold text-gray-900 dark:text-white">
+            {instance.title}
+          </h3>
+          {isQuiz && (
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Pregunta {currentQ} de {totalQuestions}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 border-t border-gray-100 pt-4 dark:border-gray-700">
+        {instance.state === "scheduled" && (
+          <>
+            <button
+              type="button"
+              onClick={() => onSetState("live")}
+              disabled={busy}
+              className="rounded-lg bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+            >
+              ▶ Iniciar
+            </button>
+            {!confirmDelete && (
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(true)}
+                disabled={busy}
+                className="rounded-lg border border-red-300 px-3 py-1.5 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/20"
+              >
+                🗑 Eliminar
+              </button>
+            )}
+            {confirmDelete && (
+              <span className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={async () => {
+                    await onDelete();
+                    setConfirmDelete(false);
+                  }}
+                  disabled={busy}
+                  className="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                >
+                  Confirmar
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(false)}
+                  className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                >
+                  Cancelar
+                </button>
+              </span>
+            )}
+          </>
+        )}
+
+        {instance.state === "live" && (
+          <>
+            <button
+              type="button"
+              onClick={() => onSetState("closed")}
+              disabled={busy}
+              className="rounded-lg bg-gray-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50"
+            >
+              ⏹ Cerrar
+            </button>
+            {isQuiz && (
+              <button
+                type="button"
+                onClick={() => onAdvanceQuiz()}
+                disabled={busy || isOnLastQuestion}
+                className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                ⏭ Avanzar pregunta
+              </button>
+            )}
+          </>
+        )}
+
+        {instance.state === "closed" && (
+          <button
+            type="button"
+            onClick={() => onSetState("live")}
+            disabled={busy}
+            className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            ↻ Reabrir
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/event-minigames/__tests__/EventMinigameManager.test.tsx
+++ b/src/components/react/admin/event-minigames/__tests__/EventMinigameManager.test.tsx
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mocks = vi.hoisted(() => ({
+  listEventMinigames: vi.fn(),
+  attachMinigameToEvent: vi.fn(),
+  setMinigameState: vi.fn(),
+  advanceQuizQuestion: vi.fn(),
+  removeMinigameFromEvent: vi.fn(),
+  listMinigameTemplates: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    listEventMinigames: mocks.listEventMinigames,
+    attachMinigameToEvent: mocks.attachMinigameToEvent,
+    setMinigameState: mocks.setMinigameState,
+    advanceQuizQuestion: mocks.advanceQuizQuestion,
+    removeMinigameFromEvent: mocks.removeMinigameFromEvent,
+    listMinigameTemplates: mocks.listMinigameTemplates,
+  },
+}));
+
+import { EventMinigameManager } from "../EventMinigameManager";
+
+const SAMPLE_INSTANCES = [
+  {
+    id: "i1",
+    eventSlug: "devfest-2025",
+    templateId: "tpl-1",
+    templateVersion: 1,
+    type: "poll" as const,
+    mode: "realtime" as const,
+    state: "scheduled" as const,
+    title: "First poll",
+    order: 0,
+  },
+  {
+    id: "i2",
+    eventSlug: "devfest-2025",
+    templateId: "tpl-2",
+    templateVersion: 1,
+    type: "wordcloud" as const,
+    mode: "global" as const,
+    state: "live" as const,
+    title: "Word cloud",
+    order: 1,
+  },
+];
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.listEventMinigames.mockResolvedValue({
+    success: true,
+    data: SAMPLE_INSTANCES,
+  });
+  mocks.listMinigameTemplates.mockResolvedValue({ success: true, data: [] });
+  mocks.attachMinigameToEvent.mockResolvedValue({
+    success: true,
+    data: { id: "new", type: "poll" },
+  });
+  mocks.setMinigameState.mockResolvedValue({
+    success: true,
+    data: { id: "i1", state: "live" },
+  });
+  mocks.removeMinigameFromEvent.mockResolvedValue({ success: true });
+});
+
+afterEach(() => cleanup());
+
+describe("EventMinigameManager", () => {
+  it("renders an error if no slug is provided", () => {
+    render(<EventMinigameManager />);
+    expect(screen.getByText(/Falta el parámetro/i)).toBeInTheDocument();
+    expect(mocks.listEventMinigames).not.toHaveBeenCalled();
+  });
+
+  it("loads instances using the slug from props", async () => {
+    render(<EventMinigameManager initialSlug="devfest-2025" />);
+    await waitFor(() =>
+      expect(mocks.listEventMinigames).toHaveBeenCalledWith("devfest-2025")
+    );
+    expect(await screen.findByText("First poll")).toBeInTheDocument();
+    expect(screen.getByText("Word cloud")).toBeInTheDocument();
+  });
+
+  it("calls setMinigameState when Iniciar is clicked", async () => {
+    const user = userEvent.setup();
+    render(<EventMinigameManager initialSlug="devfest-2025" />);
+    await screen.findByText("First poll");
+    await user.click(screen.getByRole("button", { name: /Iniciar/i }));
+    await waitFor(() =>
+      expect(mocks.setMinigameState).toHaveBeenCalledWith(
+        "devfest-2025",
+        "i1",
+        "live"
+      )
+    );
+  });
+
+  it("opens attach modal and lists only unattached templates", async () => {
+    mocks.listMinigameTemplates.mockResolvedValue({
+      success: true,
+      data: [
+        { id: "tpl-1", type: "poll", title: "Already attached" },
+        { id: "tpl-3", type: "bingo", title: "Available bingo" },
+      ],
+    });
+    const user = userEvent.setup();
+    render(<EventMinigameManager initialSlug="devfest-2025" />);
+    await screen.findByText("First poll");
+    await user.click(
+      screen.getByRole("button", { name: /Adjuntar plantilla/i })
+    );
+    expect(await screen.findByText("Available bingo")).toBeInTheDocument();
+    expect(screen.queryByText("Already attached")).not.toBeInTheDocument();
+  });
+
+  it("posts attach with order=instances.length when adjuntar is clicked", async () => {
+    mocks.listMinigameTemplates.mockResolvedValue({
+      success: true,
+      data: [{ id: "tpl-3", type: "bingo", title: "Available bingo" }],
+    });
+    const user = userEvent.setup();
+    render(<EventMinigameManager initialSlug="devfest-2025" />);
+    await screen.findByText("First poll");
+    await user.click(
+      screen.getByRole("button", { name: /Adjuntar plantilla/i })
+    );
+    await screen.findByText("Available bingo");
+    await user.click(screen.getByRole("button", { name: /^Adjuntar$/i }));
+    await waitFor(() =>
+      expect(mocks.attachMinigameToEvent).toHaveBeenCalledWith("devfest-2025", {
+        templateId: "tpl-3",
+        order: 2,
+      })
+    );
+  });
+});

--- a/src/components/react/admin/event-minigames/__tests__/InstanceCard.test.tsx
+++ b/src/components/react/admin/event-minigames/__tests__/InstanceCard.test.tsx
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { InstanceCard } from "../InstanceCard";
+import type { MinigameInstance } from "../types";
+
+afterEach(() => cleanup());
+
+function makeInstance(
+  overrides: Partial<MinigameInstance> = {}
+): MinigameInstance {
+  return {
+    id: "i1",
+    eventSlug: "ev",
+    templateId: "tpl",
+    templateVersion: 1,
+    type: "poll",
+    mode: "realtime",
+    state: "scheduled",
+    title: "Sample game",
+    order: 0,
+    ...overrides,
+  };
+}
+
+describe("InstanceCard", () => {
+  it("renders type, state and mode badges", () => {
+    render(
+      <InstanceCard
+        instance={makeInstance()}
+        onSetState={vi.fn()}
+        onAdvanceQuiz={vi.fn()}
+        onDelete={vi.fn()}
+        busy={false}
+      />
+    );
+    expect(screen.getByText("Encuesta")).toBeInTheDocument();
+    expect(screen.getByText("Programado")).toBeInTheDocument();
+    expect(screen.getByText("En tiempo real")).toBeInTheDocument();
+    expect(screen.getByText("Sample game")).toBeInTheDocument();
+  });
+
+  it("shows Iniciar + Eliminar in scheduled state", () => {
+    render(
+      <InstanceCard
+        instance={makeInstance({ state: "scheduled" })}
+        onSetState={vi.fn()}
+        onAdvanceQuiz={vi.fn()}
+        onDelete={vi.fn()}
+        busy={false}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /Iniciar/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Eliminar/i })
+    ).toBeInTheDocument();
+  });
+
+  it("calls onSetState('live') when Iniciar is clicked", () => {
+    const onSetState = vi.fn();
+    render(
+      <InstanceCard
+        instance={makeInstance({ state: "scheduled" })}
+        onSetState={onSetState}
+        onAdvanceQuiz={vi.fn()}
+        onDelete={vi.fn()}
+        busy={false}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Iniciar/i }));
+    expect(onSetState).toHaveBeenCalledWith("live");
+  });
+
+  it("shows Cerrar in live state for non-quiz", () => {
+    render(
+      <InstanceCard
+        instance={makeInstance({ state: "live", type: "poll" })}
+        onSetState={vi.fn()}
+        onAdvanceQuiz={vi.fn()}
+        onDelete={vi.fn()}
+        busy={false}
+      />
+    );
+    expect(screen.getByRole("button", { name: /Cerrar/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Avanzar pregunta/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Avanzar pregunta only for live quiz", () => {
+    render(
+      <InstanceCard
+        instance={makeInstance({
+          state: "live",
+          type: "quiz",
+          currentQuestionIndex: 0,
+          config: { questions: [{ id: "q1" }, { id: "q2" }] },
+        })}
+        onSetState={vi.fn()}
+        onAdvanceQuiz={vi.fn()}
+        onDelete={vi.fn()}
+        busy={false}
+      />
+    );
+    const advance = screen.getByRole("button", { name: /Avanzar pregunta/i });
+    expect(advance).toBeEnabled();
+  });
+
+  it("disables Avanzar pregunta on the last question", () => {
+    render(
+      <InstanceCard
+        instance={makeInstance({
+          state: "live",
+          type: "quiz",
+          currentQuestionIndex: 1,
+          config: { questions: [{ id: "q1" }, { id: "q2" }] },
+        })}
+        onSetState={vi.fn()}
+        onAdvanceQuiz={vi.fn()}
+        onDelete={vi.fn()}
+        busy={false}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /Avanzar pregunta/i })
+    ).toBeDisabled();
+  });
+
+  it("shows Reabrir in closed state and calls onSetState('live')", () => {
+    const onSetState = vi.fn();
+    render(
+      <InstanceCard
+        instance={makeInstance({ state: "closed" })}
+        onSetState={onSetState}
+        onAdvanceQuiz={vi.fn()}
+        onDelete={vi.fn()}
+        busy={false}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Reabrir/i }));
+    expect(onSetState).toHaveBeenCalledWith("live");
+  });
+
+  it("requires confirmation before delete", () => {
+    const onDelete = vi.fn();
+    render(
+      <InstanceCard
+        instance={makeInstance({ state: "scheduled" })}
+        onSetState={vi.fn()}
+        onAdvanceQuiz={vi.fn()}
+        onDelete={onDelete}
+        busy={false}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Eliminar/i }));
+    // Now in confirm mode
+    expect(onDelete).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /Confirmar/i }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/react/admin/event-minigames/types.ts
+++ b/src/components/react/admin/event-minigames/types.ts
@@ -1,0 +1,35 @@
+import type { MinigameType } from "../minigame-templates/types";
+
+export type InstanceState = "scheduled" | "live" | "closed";
+export type InstanceMode = "global" | "realtime";
+
+export interface MinigameInstance {
+  id: string;
+  eventSlug: string;
+  templateId: string;
+  templateVersion: number;
+  type: MinigameType;
+  mode: InstanceMode;
+  state: InstanceState;
+  title: string;
+  order: number;
+  config?: Record<string, unknown>;
+  currentQuestionIndex?: number;
+}
+
+export const STATE_LABELS: Record<InstanceState, string> = {
+  scheduled: "Programado",
+  live: "En vivo",
+  closed: "Cerrado",
+};
+
+export const STATE_COLORS: Record<InstanceState, string> = {
+  scheduled: "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300",
+  live: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+  closed: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400",
+};
+
+export const MODE_LABELS: Record<InstanceMode, string> = {
+  global: "Global",
+  realtime: "En tiempo real",
+};

--- a/src/components/react/admin/events/EventList.tsx
+++ b/src/components/react/admin/events/EventList.tsx
@@ -135,6 +135,12 @@ export function EventList() {
                     >
                       Editar
                     </a>
+                    <a
+                      href={`/admin/eventos/minigames?slug=${encodeURIComponent(event.id)}`}
+                      className="rounded px-3 py-1 text-sm text-green-600 hover:bg-green-50 dark:text-green-400 dark:hover:bg-green-900/20"
+                    >
+                      🎮 Mini-juegos
+                    </a>
                     <button
                       onClick={() => handleDelete(event.id)}
                       disabled={deleting === event.id}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -102,6 +102,25 @@ const realApi = {
   deleteMinigameTemplate: (id: string) =>
     request("DELETE", `/minigame-templates/${id}`),
 
+  // Minigame Instances (per event, admin-only)
+  listEventMinigames: (slug: string) =>
+    request("GET", `/events/${encodeURIComponent(slug)}/minigames`),
+  attachMinigameToEvent: (slug: string, data: unknown) =>
+    request("POST", `/events/${encodeURIComponent(slug)}/minigames`, data),
+  setMinigameState: (slug: string, id: string, state: string) =>
+    request(
+      "PATCH",
+      `/events/${encodeURIComponent(slug)}/minigames/${id}/state`,
+      { state }
+    ),
+  advanceQuizQuestion: (slug: string, id: string) =>
+    request(
+      "POST",
+      `/events/${encodeURIComponent(slug)}/minigames/${id}/quiz/advance`
+    ),
+  removeMinigameFromEvent: (slug: string, id: string) =>
+    request("DELETE", `/events/${encodeURIComponent(slug)}/minigames/${id}`),
+
   // Rebuild
   triggerRebuild: () => request("POST", "/rebuild"),
 };

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -61,5 +61,13 @@ export const mockApi = {
   updateMinigameTemplate: () => ok({ id: "updated", version: 2 }),
   deleteMinigameTemplate: () => ok(null),
 
+  listEventMinigames: () => ok([]),
+  attachMinigameToEvent: () => ok({ id: "new-instance", type: "poll" }),
+  setMinigameState: (_slug: string, id: string, state: string) =>
+    ok({ id, state }),
+  advanceQuizQuestion: (_slug: string, id: string) =>
+    ok({ id, currentQuestionIndex: 0 }),
+  removeMinigameFromEvent: () => ok(null),
+
   triggerRebuild: () => ok(null),
 };

--- a/src/pages/admin/eventos/minigames.astro
+++ b/src/pages/admin/eventos/minigames.astro
@@ -1,0 +1,12 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Mini-juegos del evento">
+  <AdminApp
+    client:load
+    page="event-minigames"
+    currentPath="/admin/eventos/minigames"
+  />
+</AdminLayout>

--- a/tests/rules/minigame-instances.test.ts
+++ b/tests/rules/minigame-instances.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
+import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
+import { deleteDoc, doc, getDoc, setDoc } from "firebase/firestore";
+import { cleanup, clearAll, getTestEnv } from "./setup";
+
+const SLUG = "devfest-2025";
+const INSTANCE_ID = "instance-A";
+
+const SAMPLE_INSTANCE = {
+  eventSlug: SLUG,
+  templateId: "tpl-1",
+  templateVersion: 1,
+  type: "poll",
+  mode: "realtime",
+  state: "scheduled",
+  title: "Sample poll",
+  config: { question: "Q?", options: [] },
+  order: 0,
+  createdBy: "admin-uid",
+  createdAt: 0,
+};
+
+describe("firestore.rules — events/{slug}/minigames", () => {
+  beforeAll(async () => {
+    await getTestEnv();
+  });
+
+  afterEach(async () => {
+    await clearAll();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it("allows anyone to read the shadow event doc", async () => {
+    const env = await getTestEnv();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), `events/${SLUG}`), {
+        slug: SLUG,
+        createdAt: 0,
+      });
+    });
+    const anon = env.unauthenticatedContext().firestore();
+    await assertSucceeds(getDoc(doc(anon, `events/${SLUG}`)));
+  });
+
+  it("allows anyone to read instance docs", async () => {
+    const env = await getTestEnv();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `events/${SLUG}/minigames/${INSTANCE_ID}`),
+        SAMPLE_INSTANCE
+      );
+    });
+    const anon = env.unauthenticatedContext().firestore();
+    await assertSucceeds(
+      getDoc(doc(anon, `events/${SLUG}/minigames/${INSTANCE_ID}`))
+    );
+  });
+
+  it("allows anyone to read aggregates (for live overlays)", async () => {
+    const env = await getTestEnv();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(
+          ctx.firestore(),
+          `events/${SLUG}/minigames/${INSTANCE_ID}/aggregates/current`
+        ),
+        { totalResponses: 0 }
+      );
+    });
+    const anon = env.unauthenticatedContext().firestore();
+    await assertSucceeds(
+      getDoc(
+        doc(anon, `events/${SLUG}/minigames/${INSTANCE_ID}/aggregates/current`)
+      )
+    );
+  });
+
+  it("denies authenticated client writes to the event shadow doc", async () => {
+    const env = await getTestEnv();
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(doc(auth, `events/${SLUG}`), { slug: SLUG, createdAt: 0 })
+    );
+  });
+
+  it("denies authenticated client writes to instance docs", async () => {
+    const env = await getTestEnv();
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(auth, `events/${SLUG}/minigames/${INSTANCE_ID}`),
+        SAMPLE_INSTANCE
+      )
+    );
+  });
+
+  it("denies authenticated client writes to subcollections (PR3 baseline)", async () => {
+    const env = await getTestEnv();
+    const auth = env.authenticatedContext("user-1").firestore();
+    const base = `events/${SLUG}/minigames/${INSTANCE_ID}`;
+    await assertFails(
+      setDoc(doc(auth, `${base}/participants/u1`), { alias: "a" })
+    );
+    await assertFails(
+      setDoc(doc(auth, `${base}/responses/u1_q1`), {
+        questionId: "q1",
+        optionId: "a",
+      })
+    );
+    await assertFails(
+      setDoc(doc(auth, `${base}/words/hello`), { text: "hello", count: 1 })
+    );
+    await assertFails(
+      setDoc(doc(auth, `${base}/aggregates/current`), { totalResponses: 1 })
+    );
+  });
+
+  it("denies client deletes on instances", async () => {
+    const env = await getTestEnv();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `events/${SLUG}/minigames/${INSTANCE_ID}`),
+        SAMPLE_INSTANCE
+      );
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      deleteDoc(doc(auth, `events/${SLUG}/minigames/${INSTANCE_ID}`))
+    );
+  });
+});


### PR DESCRIPTION
## Summary

PR 3 of 7 for the **live mini-games** feature. Builds on #157 (templates).

Admins can now adjuntar plantillas to specific events, control instance state (\`scheduled\` → \`live\` → \`closed\`), advance quiz questions, and a Firestore trigger keeps aggregate counters in sync — laying the groundwork for the participant-facing PRs (4-7).

## What's new

### Backend
- **Handler** \`functions/src/handlers/minigameInstances.ts\` — five admin-only endpoints under \`/api/events/:slug/minigames\`:
  - \`POST\` attach (snapshots template config, derives \`mode\` from type, lazily creates the \`events/{slug}\` shadow doc, seeds quiz runtime fields)
  - \`GET\` list (ordered by \`order asc, createdAt asc\`)
  - \`PATCH /:id/state\` — set \`scheduled\` | \`live\` | \`closed\`
  - \`POST /:id/quiz/advance\` — increments \`currentQuestionIndex\`, refuses non-quiz / non-live / past-last-question
  - \`DELETE /:id\` — only when \`state == \"scheduled\"\` (409 otherwise)
- **First non-HTTP Cloud Function**: \`onMinigameResponseWritten\` (\`functions/src/triggers/recomputeAggregates.ts\`) — listens on \`events/{slug}/minigames/{id}/responses/{respId}\` and uses \`FieldValue.increment\` to maintain the single \`aggregates/current\` doc that PR4-PR6 listeners will consume.
- **Bingo card service** \`functions/src/services/bingo.ts\` — pure deterministic generator (FNV-1a + Mulberry32 + Fisher-Yates). PR4's join handler will start using it.
- Two narrow Zod schemas: \`minigameInstanceCreateSchema\` and \`minigameStateSchema\` (both \`.strict()\`).

### Firestore
- \`firestore.rules\` — added \`events/{slug}\` + \`minigames/{id}\` + four subcollections (\`participants\`, \`responses\`, \`words\`, \`aggregates\`) with **read public, write deny**. Subsequent PRs progressively open specific writes.
- \`firestore.indexes.json\` — composite \`(state asc, order asc)\` on the \`minigames\` collection group for PR4's \"where state=='live'\" query.

### Frontend
- New page \`/admin/eventos/minigames?slug=X\` (single static Astro page, consistent with \`?edit=Y\` pattern for events; no rebuild needed for new events).
- React island \`EventMinigameManager\` with:
  - \`InstanceCard\` — state-driven controls (Iniciar / Cerrar / Reabrir / Avanzar pregunta), inline delete confirmation
  - \`AttachTemplateModal\` — lists only un-attached templates, posts attach with \`order = instances.length\`
- \"🎮 Mini-juegos\" button added to each row in the events admin list.

## Behaviour decisions

- **No \"1 realtime live\" invariant** — multiple poll/quiz instances can be \`live\` in parallel. PR6's overlays will stack/list them.
- **Re-open allowed** (\`closed → live\`) as admin override.
- **Delete is scheduled-only** (409 on \`live\`/\`closed\`). Protects historical play data.

## Test plan

- [x] \`pnpm test\` — 24 root tests (8 InstanceCard, 5 EventMinigameManager, 11 PR2)
- [x] \`pnpm test:functions\` — 56 functions tests (17 instance handler, 5 trigger, 7 bingo, 27 PR1+PR2)
- [x] \`pnpm test:rules\` — 19 rules tests (7 new event/minigames paths, 12 baseline+templates)
- [x] \`pnpm lint\` clean
- [x] \`pnpm build\` — Astro generates 28 pages (one new admin page)
- [x] \`cd functions && npm run build\` — clean tsc, lib excludes test files, includes new \`triggers/\` and \`services/\`
- [ ] CI green
- [ ] Smoke with emulators: attach all 4 template types to a test event, cycle through state transitions, advance a quiz, write a response and watch \`aggregates/current\` populate

## Out of scope (later PRs)

- PR4: participant join flow (anon auth + alias) — will start consuming \`generateBingoCard\`
- PR5: word-cloud + bingo gameplay (opens \`words/*\` + \`participants/{uid}\` writes in rules)
- PR6: poll + quiz overlays + leaderboard (opens \`responses/*\` writes in rules; trigger extended to compute leaderboard)
- PR7: projector view + QR + final polish