### PR TITLE
feat(event): participant join flow with anonymous Firebase auth

### DIFF
--- a/functions/src/handlers/minigameJoin.test.ts
+++ b/functions/src/handlers/minigameJoin.test.ts
@@ -1,0 +1,330 @@
+import { Request, Response } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SERVER_TS = "__SERVER_TS__";
+
+const mocks = vi.hoisted(() => ({
+  collectionMock: vi.fn(),
+  runTransactionMock: vi.fn(),
+}));
+
+vi.mock("firebase-admin", () => ({
+  firestore: Object.assign(
+    () => ({
+      collection: mocks.collectionMock,
+      runTransaction: mocks.runTransactionMock,
+    }),
+    {
+      FieldValue: {
+        serverTimestamp: () => "__SERVER_TS__",
+      },
+    }
+  ),
+}));
+
+import * as handler from "./minigameJoin";
+import type { AuthenticatedRequest } from "../middleware/auth";
+
+const { collectionMock, runTransactionMock } = mocks;
+
+interface ResMock extends Response {
+  __status: number | undefined;
+  __body: unknown;
+}
+
+function buildRes(): ResMock {
+  const res: Partial<ResMock> = {};
+  res.status = vi.fn(function (this: ResMock, code: number) {
+    this.__status = code;
+    return this;
+  }) as ResMock["status"];
+  res.json = vi.fn(function (this: ResMock, body: unknown) {
+    this.__body = body;
+    return this;
+  }) as ResMock["json"];
+  return res as ResMock;
+}
+
+function buildReq(
+  body: unknown,
+  params: Record<string, string> = {},
+  uid = "anon-uid-1"
+): Request {
+  const req = {
+    body,
+    params,
+    user: { uid },
+  } as unknown as AuthenticatedRequest;
+  return req as unknown as Request;
+}
+
+interface InstanceFixture {
+  id: string;
+  type: string;
+  state: string;
+  config?: { terms?: string[] };
+  existingParticipant?: {
+    alias: string;
+    bingoCard?: string[];
+  };
+}
+
+interface WiringResult {
+  txCalls: Array<Record<string, unknown>>;
+  setCalls: Array<{ ref: object; data: Record<string, unknown> }>;
+  auditAdd: ReturnType<typeof vi.fn>;
+}
+
+function wireFirestore(
+  liveInstances: InstanceFixture[],
+  slug = "devfest-2025"
+): WiringResult {
+  const setCalls: Array<{ ref: object; data: Record<string, unknown> }> = [];
+  const auditAdd = vi.fn(async () => undefined);
+
+  const instanceDocs = liveInstances.map((i) => {
+    const participantRef = { __participantFor: i.id };
+    const ref = {
+      collection: vi.fn((name: string) => {
+        if (name === "participants") {
+          return { doc: vi.fn(() => participantRef) };
+        }
+        throw new Error("unexpected nested collection " + name);
+      }),
+      __participantRef: participantRef,
+    };
+    return {
+      id: i.id,
+      data: () => ({ type: i.type, state: i.state, config: i.config }),
+      ref,
+      __existing: i.existingParticipant,
+    };
+  });
+
+  const limitMock = vi.fn(() => ({
+    get: vi.fn(async () => ({
+      empty: instanceDocs.length === 0,
+      docs: instanceDocs,
+    })),
+  }));
+  const whereMock = vi.fn(() => ({ limit: limitMock }));
+  const minigamesCol = { where: whereMock };
+  const eventDocFn = vi.fn(() => ({
+    collection: vi.fn(() => minigamesCol),
+  }));
+
+  collectionMock.mockImplementation((name: string) => {
+    if (name === "events") return { doc: eventDocFn };
+    if (name === "audit_log") return { add: auditAdd };
+    throw new Error("unexpected collection " + name);
+  });
+
+  runTransactionMock.mockImplementation(async (callback) => {
+    // Find which instance ref the upcoming tx.set/get refers to. We
+    // expose `tx.get(participantRef)` and `tx.set(participantRef, data)`.
+    const tx = {
+      get: vi.fn(async (ref: object) => {
+        const inst = instanceDocs.find((d) => d.ref.__participantRef === ref);
+        if (inst?.__existing) {
+          return { exists: true, data: () => inst.__existing };
+        }
+        return { exists: false };
+      }),
+      set: vi.fn((ref: object, data: Record<string, unknown>) => {
+        setCalls.push({ ref, data });
+      }),
+    };
+    await callback(tx);
+  });
+
+  return { txCalls: [], setCalls, auditAdd };
+}
+
+const POLL_INSTANCE: InstanceFixture = {
+  id: "i-poll",
+  type: "poll",
+  state: "live",
+};
+
+const QUIZ_INSTANCE: InstanceFixture = {
+  id: "i-quiz",
+  type: "quiz",
+  state: "live",
+};
+
+const BINGO_INSTANCE: InstanceFixture = {
+  id: "i-bingo",
+  type: "bingo",
+  state: "live",
+  config: { terms: Array.from({ length: 25 }, (_, i) => `term-${i}`) },
+};
+
+describe("minigameJoin handler", () => {
+  beforeEach(() => {
+    collectionMock.mockReset();
+    runTransactionMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects empty alias", async () => {
+    wireFirestore([]);
+    const res = buildRes();
+    await handler.join(buildReq({ alias: "   " }, { slug: "x" }), res);
+    expect(res.__status).toBe(400);
+    expect((res.__body as { error: string }).error).toMatch(/alias/i);
+  });
+
+  it("rejects profane alias", async () => {
+    wireFirestore([]);
+    const res = buildRes();
+    await handler.join(buildReq({ alias: "FUCKER" }, { slug: "x" }), res);
+    expect(res.__status).toBe(400);
+  });
+
+  it("returns alias with empty instances list when no game is live", async () => {
+    wireFirestore([]);
+    const res = buildRes();
+    await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), res);
+    expect(res.__status).toBeUndefined();
+    expect(res.__body).toEqual({
+      success: true,
+      data: { alias: "Ana", instances: [] },
+    });
+  });
+
+  it("creates participant doc for a poll instance without bingo card", async () => {
+    const wiring = wireFirestore([POLL_INSTANCE]);
+    const res = buildRes();
+    await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), res);
+    expect(wiring.setCalls).toHaveLength(1);
+    const stored = wiring.setCalls[0].data;
+    expect(stored).toMatchObject({
+      uid: "anon-uid-1",
+      alias: "Ana",
+    });
+    expect(stored.bingoCard).toBeUndefined();
+    expect(stored.joinedAt).toBe(SERVER_TS);
+    const body = res.__body as { data: { instances: { joined: boolean }[] } };
+    expect(body.data.instances[0].joined).toBe(true);
+  });
+
+  it("seeds a deterministic bingo card for bingo instances", async () => {
+    const wiring = wireFirestore([BINGO_INSTANCE]);
+    const res = buildRes();
+    await handler.join(buildReq({ alias: "Bea" }, { slug: "x" }), res);
+    expect(wiring.setCalls).toHaveLength(1);
+    const stored = wiring.setCalls[0].data;
+    const card = stored.bingoCard as string[];
+    expect(Array.isArray(card)).toBe(true);
+    expect(card).toHaveLength(16);
+    expect(new Set(card).size).toBe(16);
+    const body = res.__body as {
+      data: { instances: { bingoCard?: string[] }[] };
+    };
+    expect(body.data.instances[0].bingoCard).toEqual(card);
+  });
+
+  it("joins multiple live instances in one call with a single alias", async () => {
+    const wiring = wireFirestore([
+      POLL_INSTANCE,
+      QUIZ_INSTANCE,
+      BINGO_INSTANCE,
+    ]);
+    const res = buildRes();
+    await handler.join(buildReq({ alias: "Carlos" }, { slug: "x" }), res);
+    expect(wiring.setCalls).toHaveLength(3);
+    for (const call of wiring.setCalls) {
+      expect(call.data.alias).toBe("Carlos");
+      expect(call.data.uid).toBe("anon-uid-1");
+    }
+    const types = (
+      res.__body as { data: { instances: { type: string }[] } }
+    ).data.instances.map((i) => i.type);
+    expect(types.sort()).toEqual(["bingo", "poll", "quiz"]);
+  });
+
+  it("is idempotent on rejoin and returns the original alias", async () => {
+    const wiring = wireFirestore([
+      {
+        ...POLL_INSTANCE,
+        existingParticipant: { alias: "OriginalAna" },
+      },
+    ]);
+    const res = buildRes();
+    await handler.join(
+      buildReq({ alias: "DifferentAlias" }, { slug: "x" }),
+      res
+    );
+    expect(wiring.setCalls).toHaveLength(0); // No new write
+    const body = res.__body as {
+      data: { alias: string; instances: { joined: boolean }[] };
+    };
+    expect(body.data.alias).toBe("OriginalAna");
+    expect(body.data.instances[0].joined).toBe(false);
+  });
+
+  it("preserves the existing bingo card on rejoin", async () => {
+    const existingCard = Array.from({ length: 16 }, (_, i) => `keep-${i}`);
+    wireFirestore([
+      {
+        ...BINGO_INSTANCE,
+        existingParticipant: { alias: "Bea", bingoCard: existingCard },
+      },
+    ]);
+    const res = buildRes();
+    await handler.join(buildReq({ alias: "Bea" }, { slug: "x" }), res);
+    const body = res.__body as {
+      data: { instances: { bingoCard?: string[] }[] };
+    };
+    expect(body.data.instances[0].bingoCard).toEqual(existingCard);
+  });
+
+  it("logs an audit entry per /join call (not per instance)", async () => {
+    const wiring = wireFirestore([POLL_INSTANCE, QUIZ_INSTANCE]);
+    const res = buildRes();
+    await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), res);
+    expect(wiring.auditAdd).toHaveBeenCalledTimes(1);
+    const audit = wiring.auditAdd.mock.calls[0][0] as Record<string, unknown>;
+    expect(audit).toMatchObject({
+      action: "minigame_participant.join",
+      performedBy: "anon-uid-1",
+      targetId: "x",
+      targetType: "event",
+    });
+    const details = audit.details as {
+      alias: string;
+      instanceCount: number;
+      newJoins: number;
+    };
+    expect(details).toMatchObject({
+      alias: "Ana",
+      instanceCount: 2,
+      newJoins: 2,
+    });
+  });
+
+  it("handles a malformed bingo template by skipping card seeding", async () => {
+    wireFirestore([
+      {
+        ...BINGO_INSTANCE,
+        config: { terms: ["only-three", "ok-fine", "uno-mas"] },
+      },
+    ]);
+    const res = buildRes();
+    await handler.join(buildReq({ alias: "Test" }, { slug: "x" }), res);
+    // Should not throw / not 500. Card empty in summary.
+    expect(res.__status).toBeUndefined();
+  });
+
+  it("returns 500 when Firestore unexpectedly throws", async () => {
+    collectionMock.mockImplementation(() => {
+      throw new Error("kaboom");
+    });
+    const res = buildRes();
+    await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), res);
+    expect(res.__status).toBe(500);
+  });
+});

--- a/functions/src/handlers/minigameJoin.ts
+++ b/functions/src/handlers/minigameJoin.ts
@@ -1,0 +1,154 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { safeError } from "../middleware/validate";
+import { isCleanAlias } from "../services/profanity";
+import { generateBingoCard } from "../services/bingo";
+
+interface BingoConfig {
+  terms?: string[];
+}
+
+interface InstanceData {
+  type?: string;
+  state?: string;
+  config?: BingoConfig;
+}
+
+interface JoinedInstanceSummary {
+  id: string;
+  type: string;
+  joined: boolean;
+  bingoCard?: string[];
+}
+
+// POST /api/events/:slug/minigames/join
+//
+// Public participant entry point. Auth uses any Firebase ID token
+// (anonymous OK). Idempotent: subsequent calls return the alias that
+// was stored on the first successful join, even if the request body
+// carries a different alias — alias is fixed per (event, uid).
+export async function join(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const user = (req as AuthenticatedRequest).user;
+    const requestedAlias = (req.body as { alias: string }).alias.trim();
+
+    if (!isCleanAlias(requestedAlias)) {
+      res.status(400).json({ success: false, error: "Alias no permitido" });
+      return;
+    }
+
+    const db = admin.firestore();
+    const instancesSnap = await db
+      .collection("events")
+      .doc(slug)
+      .collection("minigames")
+      .where("state", "==", "live")
+      .limit(50)
+      .get();
+
+    if (instancesSnap.empty) {
+      res.json({
+        success: true,
+        data: { alias: requestedAlias, instances: [] },
+      });
+      return;
+    }
+
+    // Run one transaction per instance. Parallel is safe because each
+    // transaction touches a different participant doc, so there is no
+    // contention. Bingo cards are deterministic per (uid, instanceId)
+    // so retries land on the same card.
+    let canonicalAlias = requestedAlias;
+    const summaries = await Promise.all(
+      instancesSnap.docs.map(async (instanceDoc) => {
+        const instanceId = instanceDoc.id;
+        const instanceData = instanceDoc.data() as InstanceData;
+        const participantRef = instanceDoc.ref
+          .collection("participants")
+          .doc(user.uid);
+
+        const summary: JoinedInstanceSummary = {
+          id: instanceId,
+          type: instanceData.type ?? "unknown",
+          joined: false,
+        };
+
+        await db.runTransaction(async (tx) => {
+          const existing = await tx.get(participantRef);
+          if (existing.exists) {
+            const data = existing.data() as
+              | { alias?: string; bingoCard?: string[] }
+              | undefined;
+            // Lock alias to whatever was stored first.
+            if (data?.alias) {
+              canonicalAlias = data.alias;
+            }
+            if (data?.bingoCard) {
+              summary.bingoCard = data.bingoCard;
+            }
+            summary.joined = false;
+            return;
+          }
+
+          const participantDoc: Record<string, unknown> = {
+            uid: user.uid,
+            alias: requestedAlias,
+            joinedAt: admin.firestore.FieldValue.serverTimestamp(),
+          };
+
+          if (instanceData.type === "bingo") {
+            const terms = instanceData.config?.terms ?? [];
+            // generateBingoCard validates length and dedupes; if the
+            // template is somehow short we surface a clean error
+            // instead of crashing the whole join.
+            try {
+              const card = generateBingoCard(
+                terms,
+                `${user.uid}:${instanceId}`
+              );
+              participantDoc.bingoCard = card;
+              summary.bingoCard = card;
+            } catch {
+              // Skip card seeding for malformed bingo templates; the
+              // participant doc is still useful (alias, joinedAt).
+              participantDoc.bingoCard = [];
+            }
+          }
+
+          tx.set(participantRef, participantDoc);
+          summary.joined = true;
+        });
+
+        return summary;
+      })
+    );
+
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add({
+        action: "minigame_participant.join",
+        performedBy: user.uid,
+        targetId: slug,
+        targetType: "event",
+        details: {
+          alias: canonicalAlias,
+          instanceCount: summaries.length,
+          newJoins: summaries.filter((s) => s.joined).length,
+        },
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      });
+
+    res.json({
+      success: true,
+      data: {
+        alias: canonicalAlias,
+        instances: summaries,
+      },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -16,6 +16,7 @@ import {
   minigameTemplateSchema,
   minigameInstanceCreateSchema,
   minigameStateSchema,
+  minigameJoinSchema,
 } from "./schemas";
 import { register } from "./handlers/auth";
 import * as events from "./handlers/events";
@@ -29,6 +30,7 @@ import { triggerRebuild } from "./handlers/rebuild";
 import * as locations from "./handlers/locations";
 import * as minigameTemplates from "./handlers/minigameTemplates";
 import * as minigameInstances from "./handlers/minigameInstances";
+import * as minigameJoin from "./handlers/minigameJoin";
 
 admin.initializeApp();
 
@@ -88,6 +90,21 @@ const writeLimiter = rateLimit({
   message: {
     success: false,
     error: "Too many write requests, slow down",
+  },
+});
+
+// Public participant /join endpoint runs on Firebase anon tokens, which
+// any client can mint without cost — UID-based limiting is therefore
+// bypassable. We pin this limiter to the IP only.
+const joinLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => `ip:${ipKeyGenerator(req.ip ?? "unknown")}`,
+  message: {
+    success: false,
+    error: "Demasiados intentos, espera un momento",
   },
 });
 
@@ -330,6 +347,16 @@ app.delete(
   vid,
   writeLimiter,
   minigameInstances.remove
+);
+
+// Public participant join — accepts any Firebase token (incl. anon).
+app.post(
+  "/api/events/:slug/minigames/join",
+  requireAuth(),
+  slugP,
+  joinLimiter,
+  validateBody(minigameJoinSchema),
+  minigameJoin.join
 );
 
 // Rebuild

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -244,3 +244,11 @@ export const minigameStateSchema = z
     state: z.enum(["scheduled", "live", "closed"]),
   })
   .strict();
+
+// Public participant join body. Tight validation here keeps the join
+// handler focused on idempotency and bingo card seeding.
+export const minigameJoinSchema = z
+  .object({
+    alias: z.string().trim().min(1).max(24),
+  })
+  .strict();

--- a/functions/src/services/profanity.test.ts
+++ b/functions/src/services/profanity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { isCleanAlias } from "./profanity";
+
+describe("isCleanAlias", () => {
+  it("accepts ordinary aliases", () => {
+    expect(isCleanAlias("Ana")).toBe(true);
+    expect(isCleanAlias("Carlos 123")).toBe(true);
+    expect(isCleanAlias("Maria_Jose")).toBe(true);
+    expect(isCleanAlias("Aleksandra-Ñ")).toBe(true);
+  });
+
+  it("rejects empty / whitespace-only aliases", () => {
+    expect(isCleanAlias("")).toBe(false);
+    expect(isCleanAlias("   ")).toBe(false);
+    expect(isCleanAlias("\t\n")).toBe(false);
+  });
+
+  it("blocks denylist terms regardless of case", () => {
+    expect(isCleanAlias("FUCK")).toBe(false);
+    expect(isCleanAlias("Fuck you")).toBe(false);
+    expect(isCleanAlias("PUTAvida")).toBe(false);
+    expect(isCleanAlias("the_bitch")).toBe(false);
+  });
+
+  it("blocks denylist terms with whitespace/punctuation bypasses", () => {
+    expect(isCleanAlias("f u c k")).toBe(false);
+    expect(isCleanAlias("fu_ck")).toBe(false);
+    expect(isCleanAlias("p.u.t.a")).toBe(false);
+    expect(isCleanAlias("m i e r d a")).toBe(false);
+  });
+
+  it("normalises accents to catch direct denylist matches", () => {
+    // "coño" -> "cono"; denylist entry "coño" also normalises to "cono",
+    // so the substring match catches it.
+    expect(isCleanAlias("coño")).toBe(false);
+    expect(isCleanAlias("CÓÑO")).toBe(false);
+  });
+
+  it("does not flag substrings that only happen to share letters", () => {
+    expect(isCleanAlias("Catarina")).toBe(true);
+    expect(isCleanAlias("Pedro")).toBe(true);
+    // "Conchita" -> "conchita". Denylist has "concha" (ends in a), so the
+    // first 6 chars "conchi" don't match — the alias passes.
+    expect(isCleanAlias("Conchita")).toBe(true);
+  });
+});

--- a/functions/src/services/profanity.ts
+++ b/functions/src/services/profanity.ts
@@ -1,0 +1,76 @@
+// Light first-line profanity filter for participant aliases.
+//
+// This is intentionally minimal — abuse during a GDG event is low-risk
+// and a small denylist beats no filter at all without enforcing
+// false-positive-prone rules. PR8+ may add server-side moderation if
+// real abuse appears.
+//
+// The list is alphabetised so additions stay easy to review. Entries
+// must be lowercase; comparison is done after normalising both the
+// input and the denylist itself to bare a-z/0-9.
+
+const DENYLIST: ReadonlyArray<string> = [
+  // Spanish
+  "cabron",
+  "carajo",
+  "chinga",
+  "concha",
+  "coño",
+  "culiao",
+  "joto",
+  "marica",
+  "maricon",
+  "mierda",
+  "pendejo",
+  "puta",
+  "puto",
+  "verga",
+  // English
+  "asshole",
+  "bastard",
+  "bitch",
+  "cunt",
+  "dick",
+  "fag",
+  "fuck",
+  "nigger",
+  "nigga",
+  "pussy",
+  "shit",
+  "slut",
+  "twat",
+  "whore",
+];
+
+// U+0300–U+036F is the Combining Diacritical Marks block. Use 4-digit
+// escapes so the character class works without the `u` flag and is
+// preserved verbatim by Prettier and editors.
+const DIACRITICS_RE = /[̀-ͯ]/g;
+const NON_ASCII_ALNUM_RE = /[^a-z0-9]/g;
+
+function normalize(raw: string): string {
+  // Lowercase, strip diacritics, then strip everything else that isn't
+  // bare a-z/0-9. Collapses simple bypasses ("f u c k", "fu_ck") and
+  // folds accented letters ("coño" → "cono") so comparison is robust.
+  return raw
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(DIACRITICS_RE, "")
+    .replace(NON_ASCII_ALNUM_RE, "");
+}
+
+// Pre-normalised denylist so input.includes(term) works after both
+// sides have been folded to bare lowercase ASCII.
+const NORMALIZED_DENYLIST: ReadonlyArray<string> = DENYLIST.map(
+  normalize
+).filter((s) => s.length > 0);
+
+export function isCleanAlias(alias: string): boolean {
+  if (!alias) return false;
+  const normalized = normalize(alias);
+  if (!normalized) return false;
+  for (const term of NORMALIZED_DENYLIST) {
+    if (normalized.includes(term)) return false;
+  }
+  return true;
+}

--- a/src/components/react/event/JoinModal.tsx
+++ b/src/components/react/event/JoinModal.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { TYPE_COLORS, TYPE_LABELS } from "../admin/minigame-templates/types";
+import type { LiveInstance } from "./types";
+
+interface Props {
+  liveInstances: LiveInstance[];
+  defaultAlias?: string;
+  onSubmit: (alias: string) => Promise<{ success: boolean; error?: string }>;
+  onDismiss: () => void;
+}
+
+const ALIAS_MAX = 24;
+
+function isLocallyClean(alias: string): boolean {
+  // Mirror the server's denylist with a small client check so we surface
+  // the error before round-tripping. Server is still source of truth.
+  const normalized = alias
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]/g, "");
+  if (!normalized) return false;
+  const blockers = ["fuck", "shit", "puta", "puto", "mierda", "bitch"];
+  return !blockers.some((b) => normalized.includes(b));
+}
+
+export function JoinModal({
+  liveInstances,
+  defaultAlias = "",
+  onSubmit,
+  onDismiss,
+}: Props) {
+  const [alias, setAlias] = useState(defaultAlias);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = alias.trim();
+  const aliasOk = trimmed.length > 0 && trimmed.length <= ALIAS_MAX;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+    if (!aliasOk) {
+      setError(`El alias debe tener entre 1 y ${ALIAS_MAX} caracteres`);
+      return;
+    }
+    if (!isLocallyClean(trimmed)) {
+      setError("Por favor, elige un alias respetuoso");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    const res = await onSubmit(trimmed);
+    if (!res.success) {
+      setError(res.error || "No pudimos conectarte. Intenta de nuevo.");
+      setSubmitting(false);
+    }
+    // On success the parent unmounts the modal, so no need to clear state.
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="join-modal-title"
+    >
+      <button
+        type="button"
+        aria-label="Cerrar haciendo clic fuera"
+        className="fixed inset-0 cursor-default bg-black/60"
+        onClick={onDismiss}
+      />
+      <div className="relative z-10 w-full max-w-md overflow-hidden rounded-2xl bg-white shadow-2xl dark:bg-gray-800">
+        <div className="bg-gradient-to-br from-blue-500 to-purple-600 px-6 py-5 text-white">
+          <p className="text-sm font-medium tracking-wider uppercase opacity-80">
+            ¡Hay un juego en vivo!
+          </p>
+          <h2
+            id="join-modal-title"
+            className="mt-1 text-2xl leading-tight font-bold"
+          >
+            Únete con un alias
+          </h2>
+        </div>
+
+        <div className="space-y-5 px-6 py-5">
+          {liveInstances.length > 0 && (
+            <div>
+              <p className="mb-2 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                Activos ahora
+              </p>
+              <ul className="flex flex-wrap gap-2">
+                {liveInstances.map((inst) => (
+                  <li
+                    key={inst.id}
+                    className={`rounded-full px-3 py-1 text-xs font-medium ${TYPE_COLORS[inst.type]}`}
+                  >
+                    {TYPE_LABELS[inst.type]} · {inst.title}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-3" noValidate>
+            <label className="block">
+              <span className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Tu alias
+              </span>
+              <input
+                type="text"
+                value={alias}
+                maxLength={ALIAS_MAX}
+                onChange={(e) => {
+                  setAlias(e.target.value);
+                  setError(null);
+                }}
+                placeholder="ej. Ana"
+                autoFocus
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-base focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+              />
+              <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+                {trimmed.length}/{ALIAS_MAX} caracteres. No se puede cambiar
+                después.
+              </span>
+            </label>
+
+            {error && (
+              <p
+                className="text-sm text-red-600 dark:text-red-400"
+                role="alert"
+              >
+                {error}
+              </p>
+            )}
+
+            <div className="flex items-center justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={onDismiss}
+                disabled={submitting}
+                className="rounded-lg px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-700"
+              >
+                Cerrar
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !aliasOk}
+                className="rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {submitting ? "Conectando..." : "Conectarme"}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/event/MiniGamesRoot.tsx
+++ b/src/components/react/event/MiniGamesRoot.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { api } from "@/lib/api";
+import { signInAnonymouslyIfNeeded } from "@/lib/firebase";
+import { JoinModal } from "./JoinModal";
+import { useLiveMinigames } from "./useLiveMinigames";
+import { LOCAL_STORAGE_ALIAS_KEY, type LiveInstance } from "./types";
+
+interface Props {
+  slug: string;
+  eventStatus?: string;
+}
+
+type Step = "init" | "no_live" | "modal" | "joining" | "joined" | "dismissed";
+
+function readStoredAlias(slug: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(LOCAL_STORAGE_ALIAS_KEY(slug));
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredAlias(slug: string, alias: string) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LOCAL_STORAGE_ALIAS_KEY(slug), alias);
+  } catch {
+    /* ignore quota / privacy */
+  }
+}
+
+function readForcePlay(): boolean {
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(window.location.search).get("play") === "1";
+}
+
+export function MiniGamesRoot({ slug }: Props) {
+  const [authReady, setAuthReady] = useState(false);
+  const [step, setStep] = useState<Step>("init");
+  const [alias, setAlias] = useState<string | null>(() =>
+    typeof window === "undefined" ? null : readStoredAlias(slug)
+  );
+  const [forcePlay] = useState<boolean>(() => readForcePlay());
+
+  const { loading, liveInstances } = useLiveMinigames(authReady ? slug : null);
+
+  // Sign in anonymously (or reuse current user) on mount.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await signInAnonymouslyIfNeeded();
+        if (!cancelled) setAuthReady(true);
+      } catch {
+        if (!cancelled) setAuthReady(true); // proceed; /join will fail loudly
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const submitJoin = useCallback(
+    async (
+      pendingAlias: string
+    ): Promise<{ success: boolean; error?: string }> => {
+      const res = await api.joinEventMinigames(slug, { alias: pendingAlias });
+      if (res.success && res.data) {
+        const stored = res.data.alias;
+        writeStoredAlias(slug, stored);
+        setAlias(stored);
+        setStep("joined");
+        return { success: true };
+      }
+      return { success: false, error: res.error };
+    },
+    [slug]
+  );
+
+  // Drive the state machine off (live instances, alias, dismissed).
+  useEffect(() => {
+    if (!authReady || loading) return;
+
+    if (liveInstances.length === 0) {
+      // No live games; reset to neutral state. Keep alias in localStorage.
+      if (step !== "joined") setStep("no_live");
+      return;
+    }
+
+    if (step === "joined" && !forcePlay) return;
+    if (step === "dismissed" && !forcePlay) return;
+
+    if (alias && !forcePlay) {
+      // Auto-rejoin silently for returning visitors.
+      setStep("joining");
+      submitJoin(alias).then((res) => {
+        if (!res.success) {
+          // Surface the modal so the user can pick a new alias.
+          setStep("modal");
+        }
+      });
+      return;
+    }
+
+    setStep("modal");
+  }, [
+    authReady,
+    loading,
+    liveInstances.length,
+    alias,
+    forcePlay,
+    step,
+    submitJoin,
+  ]);
+
+  const indicatorAlias = useMemo(
+    () => (step === "joined" ? alias : null),
+    [step, alias]
+  );
+
+  if (!authReady || loading || step === "init") return null;
+  if (step === "no_live") return null;
+
+  return (
+    <>
+      {step === "modal" && (
+        <JoinModal
+          liveInstances={liveInstances as LiveInstance[]}
+          defaultAlias={alias ?? ""}
+          onSubmit={submitJoin}
+          onDismiss={() => setStep("dismissed")}
+        />
+      )}
+
+      {indicatorAlias && (
+        <div className="container my-4 flex items-center justify-center">
+          <div className="flex items-center gap-2 rounded-full border border-green-200 bg-green-50 px-4 py-2 text-sm text-green-700 shadow-sm dark:border-green-800 dark:bg-green-900/20 dark:text-green-400">
+            <span aria-hidden>🎉</span>
+            <span>
+              Conectado como <strong>{indicatorAlias}</strong> ·{" "}
+              {liveInstances.length} juego{liveInstances.length !== 1 && "s"} en
+              vivo
+            </span>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+// Default export so Astro's React integration can hydrate the island
+// from a single import path without a named-export hop.
+export default MiniGamesRoot;

--- a/src/components/react/event/__tests__/JoinModal.test.tsx
+++ b/src/components/react/event/__tests__/JoinModal.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { JoinModal } from "../JoinModal";
+import type { LiveInstance } from "../types";
+
+afterEach(() => cleanup());
+
+const SAMPLE_INSTANCES: LiveInstance[] = [
+  {
+    id: "i1",
+    type: "poll",
+    mode: "realtime",
+    state: "live",
+    title: "Sample poll",
+    order: 0,
+  },
+];
+
+describe("JoinModal", () => {
+  it("renders the live instance pill and the alias input", () => {
+    render(
+      <JoinModal
+        liveInstances={SAMPLE_INSTANCES}
+        onSubmit={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("dialog", { name: /únete con un alias/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Sample poll/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/ej\. ana/i)).toBeInTheDocument();
+  });
+
+  it("calls onSubmit with the trimmed alias on click", async () => {
+    const onSubmit = vi.fn().mockResolvedValue({ success: true });
+    const user = userEvent.setup();
+    render(
+      <JoinModal
+        liveInstances={SAMPLE_INSTANCES}
+        onSubmit={onSubmit}
+        onDismiss={vi.fn()}
+      />
+    );
+    await user.type(screen.getByPlaceholderText(/ej\. ana/i), "  Carlos  ");
+    await user.click(screen.getByRole("button", { name: /Conectarme/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith("Carlos");
+  });
+
+  it("does not double-submit when the button is mashed", async () => {
+    const onSubmit = vi.fn().mockImplementation(
+      () =>
+        new Promise<{ success: boolean }>((resolve) => {
+          setTimeout(() => resolve({ success: true }), 50);
+        })
+    );
+    const user = userEvent.setup();
+    render(
+      <JoinModal
+        liveInstances={SAMPLE_INSTANCES}
+        onSubmit={onSubmit}
+        onDismiss={vi.fn()}
+      />
+    );
+    await user.type(screen.getByPlaceholderText(/ej\. ana/i), "Ana");
+    const button = screen.getByRole("button", { name: /Conectarme/i });
+    await user.click(button);
+    await user.click(button); // disabled while pending
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks submit with empty alias", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <JoinModal
+        liveInstances={SAMPLE_INSTANCES}
+        onSubmit={onSubmit}
+        onDismiss={vi.fn()}
+      />
+    );
+    const button = screen.getByRole("button", { name: /Conectarme/i });
+    expect(button).toBeDisabled();
+    await user.click(button);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("blocks submit with locally-detected profanity", async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <JoinModal
+        liveInstances={SAMPLE_INSTANCES}
+        onSubmit={onSubmit}
+        onDismiss={vi.fn()}
+      />
+    );
+    await user.type(screen.getByPlaceholderText(/ej\. ana/i), "fuckyou");
+    await user.click(screen.getByRole("button", { name: /Conectarme/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/respetuoso/i);
+  });
+
+  it("surfaces a server error inline", async () => {
+    const onSubmit = vi
+      .fn()
+      .mockResolvedValue({ success: false, error: "Demasiados intentos" });
+    const user = userEvent.setup();
+    render(
+      <JoinModal
+        liveInstances={SAMPLE_INSTANCES}
+        onSubmit={onSubmit}
+        onDismiss={vi.fn()}
+      />
+    );
+    await user.type(screen.getByPlaceholderText(/ej\. ana/i), "Ana");
+    await user.click(screen.getByRole("button", { name: /Conectarme/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/demasiados/i)
+    );
+  });
+
+  it("calls onDismiss when Cerrar is clicked", async () => {
+    const onDismiss = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <JoinModal
+        liveInstances={SAMPLE_INSTANCES}
+        onSubmit={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /^Cerrar$/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/react/event/__tests__/MiniGamesRoot.test.tsx
+++ b/src/components/react/event/__tests__/MiniGamesRoot.test.tsx
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { LiveInstance } from "../types";
+
+const mocks = vi.hoisted(() => ({
+  joinEventMinigames: vi.fn(),
+  signInAnonymouslyIfNeeded: vi.fn(),
+  // useLiveMinigames is a hook; we replace it with a controllable mock so
+  // tests can drive the live-instance state without real Firestore.
+  useLiveMinigames: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    joinEventMinigames: mocks.joinEventMinigames,
+  },
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  signInAnonymouslyIfNeeded: mocks.signInAnonymouslyIfNeeded,
+}));
+
+vi.mock("../useLiveMinigames", () => ({
+  useLiveMinigames: mocks.useLiveMinigames,
+}));
+
+import { MiniGamesRoot } from "../MiniGamesRoot";
+
+const POLL: LiveInstance = {
+  id: "i-poll",
+  type: "poll",
+  mode: "realtime",
+  state: "live",
+  title: "Live poll",
+  order: 0,
+};
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.signInAnonymouslyIfNeeded.mockResolvedValue({ uid: "anon-uid" });
+  mocks.joinEventMinigames.mockResolvedValue({
+    success: true,
+    data: {
+      alias: "Ana",
+      instances: [{ id: "i-poll", type: "poll", joined: true }],
+    },
+  });
+  mocks.useLiveMinigames.mockReturnValue({
+    loading: false,
+    liveInstances: [],
+    error: null,
+  });
+  if (typeof window !== "undefined") {
+    window.localStorage.clear();
+    // jsdom default location is about:blank; emulate ?play=0 by clearing.
+    window.history.replaceState({}, "", "/eventos/x");
+  }
+});
+
+afterEach(() => cleanup());
+
+describe("MiniGamesRoot", () => {
+  it("renders nothing when there are no live games", async () => {
+    render(<MiniGamesRoot slug="x" />);
+    await waitFor(() =>
+      expect(mocks.signInAnonymouslyIfNeeded).toHaveBeenCalled()
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Conectado como/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the join modal when a live game appears and there's no alias", async () => {
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [POLL],
+      error: null,
+    });
+    render(<MiniGamesRoot slug="x" />);
+    expect(
+      await screen.findByRole("dialog", { name: /únete con un alias/i })
+    ).toBeInTheDocument();
+  });
+
+  it("auto-rejoins silently when there is a stored alias", async () => {
+    window.localStorage.setItem("gdg_minigame_alias_x", "Ana");
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [POLL],
+      error: null,
+    });
+    render(<MiniGamesRoot slug="x" />);
+    await waitFor(() =>
+      expect(mocks.joinEventMinigames).toHaveBeenCalledWith("x", {
+        alias: "Ana",
+      })
+    );
+    expect(await screen.findByText(/Conectado como/i)).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("submits a chosen alias and switches to the connected indicator", async () => {
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [POLL],
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(<MiniGamesRoot slug="x" />);
+    await screen.findByRole("dialog");
+    await user.type(screen.getByPlaceholderText(/ej\. ana/i), "Carlos");
+    mocks.joinEventMinigames.mockResolvedValueOnce({
+      success: true,
+      data: {
+        alias: "Carlos",
+        instances: [{ id: "i-poll", type: "poll", joined: true }],
+      },
+    });
+    await user.click(screen.getByRole("button", { name: /Conectarme/i }));
+    await waitFor(() =>
+      expect(window.localStorage.getItem("gdg_minigame_alias_x")).toBe("Carlos")
+    );
+    expect(await screen.findByText(/Conectado como/i)).toBeInTheDocument();
+  });
+
+  it("dismisses the modal when Cerrar is clicked and stays dismissed", async () => {
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [POLL],
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(<MiniGamesRoot slug="x" />);
+    await screen.findByRole("dialog");
+    await user.click(screen.getByRole("button", { name: /^Cerrar$/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mocks.joinEventMinigames).not.toHaveBeenCalled();
+  });
+
+  it("forces the modal open when ?play=1 is in the URL even with stored alias", async () => {
+    window.localStorage.setItem("gdg_minigame_alias_x", "Ana");
+    window.history.replaceState({}, "", "/eventos/x?play=1");
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [POLL],
+      error: null,
+    });
+    render(<MiniGamesRoot slug="x" />);
+    expect(
+      await screen.findByRole("dialog", { name: /únete con un alias/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/react/event/types.ts
+++ b/src/components/react/event/types.ts
@@ -1,0 +1,35 @@
+// Shared types for the public event island (PR4 + PR5/PR6).
+
+import type { MinigameType } from "../admin/minigame-templates/types";
+import type {
+  InstanceMode,
+  InstanceState,
+} from "../admin/event-minigames/types";
+
+export type { MinigameType, InstanceMode, InstanceState };
+
+export interface LiveInstance {
+  id: string;
+  type: MinigameType;
+  mode: InstanceMode;
+  state: InstanceState;
+  title: string;
+  order: number;
+  // Snapshotted template config — shape varies by `type`. PR5/PR6 reach
+  // into the relevant subtree; PR4 only needs `type` for badges.
+  config?: Record<string, unknown>;
+  currentQuestionIndex?: number;
+}
+
+export interface JoinResult {
+  alias: string;
+  instances: {
+    id: string;
+    type: string;
+    joined: boolean;
+    bingoCard?: string[];
+  }[];
+}
+
+export const LOCAL_STORAGE_ALIAS_KEY = (slug: string) =>
+  `gdg_minigame_alias_${slug}`;

--- a/src/components/react/event/useLiveMinigames.ts
+++ b/src/components/react/event/useLiveMinigames.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import { getFirestore } from "@/lib/firebase";
+import type { LiveInstance } from "./types";
+
+interface State {
+  loading: boolean;
+  liveInstances: LiveInstance[];
+  error: string | null;
+}
+
+// Subscribes to `events/{slug}/minigames where state == "live"`.
+// Returns the live snapshot in real time. The hook owns the listener
+// lifecycle so PR5/PR6 callers don't have to re-implement the cleanup
+// (memory leaks via stale onSnapshot are the most common bug here).
+export function useLiveMinigames(slug: string | null): State {
+  const [state, setState] = useState<State>({
+    loading: true,
+    liveInstances: [],
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!slug) {
+      setState({ loading: false, liveInstances: [], error: null });
+      return;
+    }
+    let unsub: (() => void) | null = null;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const db = await getFirestore();
+        const { collection, query, where, onSnapshot, orderBy } = await import(
+          "firebase/firestore"
+        );
+        if (cancelled) return;
+        const q = query(
+          collection(db, `events/${slug}/minigames`),
+          where("state", "==", "live"),
+          orderBy("order", "asc")
+        );
+        unsub = onSnapshot(
+          q,
+          (snap) => {
+            const liveInstances = snap.docs.map(
+              (d) => ({ id: d.id, ...d.data() }) as LiveInstance
+            );
+            setState({ loading: false, liveInstances, error: null });
+          },
+          (err) => {
+            setState({
+              loading: false,
+              liveInstances: [],
+              error: err.message,
+            });
+          }
+        );
+      } catch (err) {
+        setState({
+          loading: false,
+          liveInstances: [],
+          error: err instanceof Error ? err.message : "Listener error",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (unsub) unsub();
+    };
+  }, [slug]);
+
+  return state;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -121,6 +121,18 @@ const realApi = {
   removeMinigameFromEvent: (slug: string, id: string) =>
     request("DELETE", `/events/${encodeURIComponent(slug)}/minigames/${id}`),
 
+  // Public participant join (anon-friendly)
+  joinEventMinigames: (slug: string, data: { alias: string }) =>
+    request<{
+      alias: string;
+      instances: {
+        id: string;
+        type: string;
+        joined: boolean;
+        bingoCard?: string[];
+      }[];
+    }>("POST", `/events/${encodeURIComponent(slug)}/minigames/join`, data),
+
   // Rebuild
   triggerRebuild: () => request("POST", "/rebuild"),
 };

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -31,3 +31,14 @@ export async function getFirestore() {
   );
   return firebaseGetFirestore(app);
 }
+
+// Used by the public event island in PR4. No-ops when there is already
+// a signed-in user (e.g. an admin opening the participant page in the
+// same browser as their Google session) so we never clobber that.
+export async function signInAnonymouslyIfNeeded() {
+  const auth = await getAuth();
+  if (auth.currentUser) return auth.currentUser;
+  const { signInAnonymously } = await import("firebase/auth");
+  const result = await signInAnonymously(auth);
+  return result.user;
+}

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -69,5 +69,8 @@ export const mockApi = {
     ok({ id, currentQuestionIndex: 0 }),
   removeMinigameFromEvent: () => ok(null),
 
+  joinEventMinigames: (_slug: string, data: { alias: string }) =>
+    ok({ alias: data.alias, instances: [] }),
+
   triggerRebuild: () => ok(null),
 };

--- a/src/pages/eventos/[slug].astro
+++ b/src/pages/eventos/[slug].astro
@@ -25,6 +25,7 @@ import {
   Store,
 } from "@lucide/astro";
 import SharedButton from "@/components/react/SharedButton";
+import { MiniGamesRoot } from "@/components/react/event/MiniGamesRoot";
 import { parseSpanishDate } from "@/utils/parseSpanishDate";
 
 export async function getStaticPaths() {
@@ -542,4 +543,15 @@ const whatsappQrSvg = whatsappGroupLink
       </div>
     </div>
   </section>
+
+  {
+    (event.data.status?.type === "in-progress" ||
+      event.data.status?.type === "upcoming") && (
+      <MiniGamesRoot
+        client:idle
+        slug={event.id}
+        eventStatus={event.data.status?.type}
+      />
+    )
+  }
 </Layout>


### PR DESCRIPTION
## Summary

Adds participant join flow on public event pages. Visitors landing on `/eventos/{slug}` during a live mini-game can pick an alias and register themselves with one click, powered by anonymous Firebase Auth and a single `/join` endpoint.

## What's new

### Backend
- **`POST /api/events/:slug/minigames/join`** (`functions/src/handlers/minigameJoin.ts`):
  - `requireAuth` accepts any Firebase token, including anonymous.
  - Dedicated **IP-only `joinLimiter`** (10/min) — UID-based rate limiting is bypassable when anon UIDs are free to mint.
  - **Idempotent**: rejoins return the alias stored on first join, ignoring any new alias in the body. Keeps leaderboards and bingo cards consistent across reloads.
  - Each live instance gets a participant doc atomically (one transaction per instance, parallel). Bingo instances seed a 16-cell card via `generateBingoCard(terms, \"\${uid}:\${instanceId}\")` — same user opening twice gets the same card.
  - One `audit_log` entry per call (not per instance), tagged `action=\"minigame_participant.join\"`, `targetType=\"event\"`.
- **Light denylist profanity filter** (`functions/src/services/profanity.ts`): folds diacritics + non-alphanumerics so simple bypasses (\"p u t a\", \"PUTA\", \"pútä\") all hit the same normalised entries.
- New `minigameJoinSchema` (Zod, `.strict()`).

### Frontend
- **`signInAnonymouslyIfNeeded()`** in `src/lib/firebase.ts` — no-op if there's already a `currentUser`, so an admin opening the same event page in their Google session is not clobbered.
- **`src/components/react/event/`** new island:
  - `useLiveMinigames(slug)`: wraps `onSnapshot` of the `events/{slug}/minigames where state==\"live\"` query with proper `useEffect` cleanup.
  - `JoinModal`: alias input, type+title pills for active games, single-submit guard, light client-side profanity check, inline error.
  - `MiniGamesRoot`: top-level island driving the state machine **`init → no_live | modal | joining | joined | dismissed`**. Auto-rejoins silently when localStorage has an alias; otherwise shows the modal; `?play=1` forces it open even with stored alias.
- `src/pages/eventos/[slug].astro` mounts `<MiniGamesRoot client:idle>` only when status is `upcoming` or `in-progress`.

## Behavioural decisions
- **Auto-show modal** when a live game appears + no stored alias. \"Cerrar\" dismisses for the visit only (not persisted). `?play=1` overrides.
- **Alias is immutable per event**: server returns the original alias on rejoin; client updates localStorage to match.
- **Participant docs stay server-only** (rules `write: if false`). Cloud Functions create them via Admin SDK.

## Test plan

- [x] `pnpm test` — 37 root tests (7 JoinModal, 6 MiniGamesRoot, plus existing)
- [x] `pnpm test:functions` — 73 functions tests (11 join handler, 6 profanity, plus existing)
- [x] `pnpm test:rules` — 19 rules tests
- [x] `pnpm lint`, `pnpm build`, `cd functions && npm run build` — clean
- [ ] CI green
- [ ] Smoke with emulators: attach poll + bingo to a test event, activate both, open `/eventos/{slug}?play=1` in incognito, fill alias, observe `participants/{anon-uid}` doc with bingo card, refresh and watch silent rejoin + \"Conectado como X\" indicator.

## Pre-deploy step (production only)

Anonymous Authentication must be enabled in Firebase Console (project `appgdgica` → Authentication → Sign-in method → Anonymous → Enable) **before** this ships to prod. The emulator does not require this.