### PR TITLE
feat(event): word cloud + bingo gameplay for live mini-games

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -37,7 +37,17 @@ service cloud.firestore {
 
         match /participants/{participantUid} {
           allow read: if true;
-          allow write: if false;
+          allow create: if false;
+          // Self-update limited to bingo marking. We use diff().affectedKeys()
+          // .hasOnly so the client cannot rewrite alias/joinedAt/bingoCard.
+          allow update: if request.auth != null
+                        && request.auth.uid == participantUid
+                        && request.resource.data.diff(resource.data).affectedKeys()
+                           .hasOnly(['bingoMarked', 'bingoWonAt'])
+                        && (!('bingoMarked' in request.resource.data)
+                            || (request.resource.data.bingoMarked is list
+                                && request.resource.data.bingoMarked.size() == 16));
+          allow delete: if false;
         }
         match /responses/{responseId} {
           allow read: if true;
@@ -45,7 +55,16 @@ service cloud.firestore {
         }
         match /words/{wordId} {
           allow read: if true;
-          allow write: if false;
+          // Authenticated participants of a live wordcloud instance can
+          // create or merge-update word docs. Doc id must equal the
+          // normalized text so duplicates collapse into a single counter.
+          allow write: if request.auth != null
+                       && get(/databases/$(database)/documents/events/$(eventSlug)/minigames/$(instanceId)).data.state == 'live'
+                       && get(/databases/$(database)/documents/events/$(eventSlug)/minigames/$(instanceId)).data.type == 'wordcloud'
+                       && exists(/databases/$(database)/documents/events/$(eventSlug)/minigames/$(instanceId)/participants/$(request.auth.uid))
+                       && request.resource.data.text is string
+                       && request.resource.data.text.size() <= 120
+                       && request.resource.data.normalized == wordId;
         }
         match /aggregates/{docId} {
           allow read: if true;

--- a/functions/src/handlers/minigameWords.test.ts
+++ b/functions/src/handlers/minigameWords.test.ts
@@ -1,0 +1,215 @@
+import { Request, Response } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SERVER_TS = "__SERVER_TS__";
+
+const mocks = vi.hoisted(() => ({
+  collectionMock: vi.fn(),
+}));
+
+vi.mock("firebase-admin", () => ({
+  firestore: Object.assign(() => ({ collection: mocks.collectionMock }), {
+    FieldValue: {
+      serverTimestamp: () => "__SERVER_TS__",
+    },
+  }),
+}));
+
+import * as handler from "./minigameWords";
+import type { AuthenticatedRequest } from "../middleware/auth";
+
+const { collectionMock } = mocks;
+
+interface ResMock extends Response {
+  __status: number | undefined;
+  __body: unknown;
+}
+
+function buildRes(): ResMock {
+  const res: Partial<ResMock> = {};
+  res.status = vi.fn(function (this: ResMock, code: number) {
+    this.__status = code;
+    return this;
+  }) as ResMock["status"];
+  res.json = vi.fn(function (this: ResMock, body: unknown) {
+    this.__body = body;
+    return this;
+  }) as ResMock["json"];
+  return res as ResMock;
+}
+
+function buildReq(body: unknown, params: Record<string, string> = {}): Request {
+  const req = {
+    body,
+    params,
+    user: { uid: "admin-uid" },
+  } as unknown as AuthenticatedRequest;
+  return req as unknown as Request;
+}
+
+interface WireOptions {
+  wordsDocs?: Array<{ id: string; data: () => unknown }>;
+  wordExists?: boolean;
+  wordData?: Record<string, unknown>;
+  participantsDocs?: Array<{ id: string; data: () => unknown }>;
+}
+
+interface WireResult {
+  wordUpdate: ReturnType<typeof vi.fn>;
+  auditAdd: ReturnType<typeof vi.fn>;
+}
+
+function wire(options: WireOptions = {}): WireResult {
+  const wordUpdate = vi.fn(async () => undefined);
+  const auditAdd = vi.fn(async () => undefined);
+  const wordsGet = vi.fn(async () => ({
+    docs: options.wordsDocs ?? [],
+  }));
+  const wordsOrderBy = vi.fn(() => ({ get: wordsGet }));
+  const wordRef = {
+    get: vi.fn(async () => ({
+      exists: options.wordExists ?? false,
+      data: () => options.wordData,
+    })),
+    update: wordUpdate,
+  };
+  const wordsDocFn = vi.fn(() => wordRef);
+
+  const participantsGet = vi.fn(async () => ({
+    docs: options.participantsDocs ?? [],
+  }));
+  const participantsOrderBy = vi.fn(() => ({ get: participantsGet }));
+  const participantsWhere = vi.fn(() => ({ orderBy: participantsOrderBy }));
+
+  // Use plain functions (not vi.fn) for the inner chain so vitest's
+  // spy machinery doesn't introspect them during test teardown — that
+  // introspection was calling our outer collectionMock with undefined.
+  const innerCollection = (name: string) => {
+    if (name === "words") {
+      return { orderBy: wordsOrderBy, doc: wordsDocFn };
+    }
+    if (name === "participants") {
+      return { where: participantsWhere };
+    }
+    throw new Error("unexpected nested collection " + name);
+  };
+  const minigameDoc = () => ({ collection: innerCollection });
+  const minigamesCol = { doc: minigameDoc };
+  const middleCollection = () => minigamesCol;
+  const eventDocFn = () => ({ collection: middleCollection });
+
+  collectionMock.mockImplementation((name: string) => {
+    if (name === "events") return { doc: eventDocFn };
+    if (name === "audit_log") return { add: auditAdd };
+    // Vitest's clearAllMocks teardown can call the spy with no args
+    // when introspecting; return undefined instead of throwing so the
+    // test result reflects only handler behaviour.
+    return undefined;
+  });
+
+  return { wordUpdate, auditAdd };
+}
+
+describe("minigameWords handler", () => {
+  beforeEach(() => collectionMock.mockReset());
+  afterEach(() => vi.clearAllMocks());
+
+  describe("listWords", () => {
+    it("returns words ordered by count desc", async () => {
+      wire({
+        wordsDocs: [
+          { id: "hola", data: () => ({ text: "hola", count: 5 }) },
+          { id: "mundo", data: () => ({ text: "mundo", count: 3 }) },
+        ],
+      });
+      const res = buildRes();
+      await handler.listWords(buildReq({}, { slug: "x", id: "i1" }), res);
+      expect(res.__body).toEqual({
+        success: true,
+        data: [
+          { id: "hola", text: "hola", count: 5 },
+          { id: "mundo", text: "mundo", count: 3 },
+        ],
+      });
+    });
+  });
+
+  describe("setWordHidden", () => {
+    it("hides a word and writes audit", async () => {
+      const wiring = wire({
+        wordExists: true,
+        wordData: { text: "bad", count: 1 },
+      });
+      const res = buildRes();
+      await handler.setWordHidden(
+        buildReq({ hidden: true }, { slug: "x", id: "i1", wordId: "bad" }),
+        res
+      );
+      expect(wiring.wordUpdate).toHaveBeenCalledWith({
+        hidden: true,
+        hiddenAt: SERVER_TS,
+        hiddenBy: "admin-uid",
+      });
+      expect(res.__body).toEqual({
+        success: true,
+        data: { id: "bad", hidden: true },
+      });
+      const audit = wiring.auditAdd.mock.calls[0][0] as {
+        action: string;
+      };
+      expect(audit.action).toBe("minigame_word.hide");
+    });
+
+    it("unhides a word", async () => {
+      const wiring = wire({
+        wordExists: true,
+        wordData: { text: "ok", count: 1, hidden: true },
+      });
+      const res = buildRes();
+      await handler.setWordHidden(
+        buildReq({ hidden: false }, { slug: "x", id: "i1", wordId: "ok" }),
+        res
+      );
+      expect(wiring.wordUpdate).toHaveBeenCalledWith({
+        hidden: false,
+        hiddenAt: null,
+        hiddenBy: null,
+      });
+      const audit = wiring.auditAdd.mock.calls[0][0] as {
+        action: string;
+      };
+      expect(audit.action).toBe("minigame_word.unhide");
+    });
+
+    it("returns 404 when the word does not exist", async () => {
+      wire({ wordExists: false });
+      const res = buildRes();
+      await handler.setWordHidden(
+        buildReq({ hidden: true }, { slug: "x", id: "i1", wordId: "ghost" }),
+        res
+      );
+      expect(res.__status).toBe(404);
+    });
+  });
+
+  describe("listWinners", () => {
+    it("returns participants with bingoWonAt sorted asc", async () => {
+      wire({
+        participantsDocs: [
+          {
+            id: "uid-1",
+            data: () => ({ alias: "Ana", bingoWonAt: { seconds: 100 } }),
+          },
+          {
+            id: "uid-2",
+            data: () => ({ alias: "Bea", bingoWonAt: { seconds: 200 } }),
+          },
+        ],
+      });
+      const res = buildRes();
+      await handler.listWinners(buildReq({}, { slug: "x", id: "i1" }), res);
+      const data = (res.__body as { data: { id: string }[] }).data;
+      expect(data.map((d) => d.id)).toEqual(["uid-1", "uid-2"]);
+    });
+  });
+});

--- a/functions/src/handlers/minigameWords.ts
+++ b/functions/src/handlers/minigameWords.ts
@@ -1,0 +1,126 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { safeError } from "../middleware/validate";
+
+interface AuditDetails {
+  slug: string;
+  instanceId: string;
+  wordId?: string;
+  hidden?: boolean;
+}
+
+function auditEntry(
+  action: string,
+  performedBy: string,
+  targetId: string,
+  details: AuditDetails
+) {
+  return {
+    action,
+    performedBy,
+    targetId,
+    targetType: "minigame_word",
+    details,
+    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+  };
+}
+
+function wordsCol(slug: string, instanceId: string) {
+  return admin
+    .firestore()
+    .collection("events")
+    .doc(slug)
+    .collection("minigames")
+    .doc(instanceId)
+    .collection("words");
+}
+
+function participantsCol(slug: string, instanceId: string) {
+  return admin
+    .firestore()
+    .collection("events")
+    .doc(slug)
+    .collection("minigames")
+    .doc(instanceId)
+    .collection("participants");
+}
+
+// GET /api/events/:slug/minigames/:id/words
+//
+// Admin-only endpoint that surfaces every word — including hidden ones —
+// so the moderation panel can flip visibility. The public cloud uses a
+// direct Firestore subscription with a client-side `hidden != true`
+// filter, which is fine because the data is already public.
+export async function listWords(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const id = req.params.id as string;
+    const snap = await wordsCol(slug, id).orderBy("count", "desc").get();
+    res.json({
+      success: true,
+      data: snap.docs.map((d) => ({ id: d.id, ...d.data() })),
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+// PATCH /api/events/:slug/minigames/:id/words/:wordId/hidden
+// Body: { hidden: boolean }
+export async function setWordHidden(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const id = req.params.id as string;
+    const wordId = req.params.wordId as string;
+    const user = (req as AuthenticatedRequest).user;
+    const { hidden } = req.body as { hidden: boolean };
+
+    const ref = wordsCol(slug, id).doc(wordId);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      res.status(404).json({ success: false, error: "Word not found" });
+      return;
+    }
+    await ref.update({
+      hidden,
+      hiddenAt: hidden ? admin.firestore.FieldValue.serverTimestamp() : null,
+      hiddenBy: hidden ? user.uid : null,
+    });
+    admin
+      .firestore()
+      .collection("audit_log")
+      .add(
+        auditEntry(
+          hidden ? "minigame_word.hide" : "minigame_word.unhide",
+          user.uid,
+          wordId,
+          { slug, instanceId: id, wordId, hidden }
+        )
+      );
+    res.json({ success: true, data: { id: wordId, hidden } });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+// GET /api/events/:slug/minigames/:id/winners
+//
+// Lists participants with bingoWonAt set, ordered ascending so the first
+// to ring the bell shows up first.
+export async function listWinners(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const id = req.params.id as string;
+    const snap = await participantsCol(slug, id)
+      .where("bingoWonAt", "!=", null)
+      .orderBy("bingoWonAt", "asc")
+      .get();
+    res.json({
+      success: true,
+      data: snap.docs.map((d) => ({ id: d.id, ...d.data() })),
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -17,6 +17,7 @@ import {
   minigameInstanceCreateSchema,
   minigameStateSchema,
   minigameJoinSchema,
+  minigameWordHiddenSchema,
 } from "./schemas";
 import { register } from "./handlers/auth";
 import * as events from "./handlers/events";
@@ -31,6 +32,7 @@ import * as locations from "./handlers/locations";
 import * as minigameTemplates from "./handlers/minigameTemplates";
 import * as minigameInstances from "./handlers/minigameInstances";
 import * as minigameJoin from "./handlers/minigameJoin";
+import * as minigameWords from "./handlers/minigameWords";
 
 admin.initializeApp();
 
@@ -357,6 +359,33 @@ app.post(
   joinLimiter,
   validateBody(minigameJoinSchema),
   minigameJoin.join
+);
+
+// Word cloud moderation + bingo winners (admin-only)
+const vwid = validateParamId("wordId");
+app.get(
+  "/api/events/:slug/minigames/:id/words",
+  requireRole("admin"),
+  slugP,
+  vid,
+  minigameWords.listWords
+);
+app.patch(
+  "/api/events/:slug/minigames/:id/words/:wordId/hidden",
+  requireRole("admin"),
+  slugP,
+  vid,
+  vwid,
+  writeLimiter,
+  validateBody(minigameWordHiddenSchema),
+  minigameWords.setWordHidden
+);
+app.get(
+  "/api/events/:slug/minigames/:id/winners",
+  requireRole("admin"),
+  slugP,
+  vid,
+  minigameWords.listWinners
 );
 
 // Rebuild

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -252,3 +252,10 @@ export const minigameJoinSchema = z
     alias: z.string().trim().min(1).max(24),
   })
   .strict();
+
+// Admin-only: hide/unhide a word from the wordcloud display.
+export const minigameWordHiddenSchema = z
+  .object({
+    hidden: z.boolean(),
+  })
+  .strict();

--- a/src/components/react/admin/event-minigames/BingoWinnersPanel.tsx
+++ b/src/components/react/admin/event-minigames/BingoWinnersPanel.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+interface Winner {
+  id: string;
+  alias: string;
+  bingoWonAt?: { seconds?: number; _seconds?: number } | null;
+}
+
+interface Props {
+  slug: string;
+  instanceId: string;
+  title: string;
+  onClose: () => void;
+}
+
+function formatWonAt(value: Winner["bingoWonAt"]): string {
+  if (!value) return "—";
+  const seconds = value.seconds ?? value._seconds ?? 0;
+  if (!seconds) return "—";
+  return new Date(seconds * 1000).toLocaleString("es-PE");
+}
+
+export function BingoWinnersPanel({ slug, instanceId, title, onClose }: Props) {
+  const [winners, setWinners] = useState<Winner[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const res = await api.listMinigameBingoWinners(slug, instanceId);
+      if (cancelled) return;
+      if (res.success && Array.isArray(res.data)) {
+        setWinners(res.data as Winner[]);
+        setError(null);
+      } else {
+        setError(res.error || "Error al cargar ganadores");
+      }
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, instanceId]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <button
+        type="button"
+        aria-label="Cerrar fondo"
+        className="fixed inset-0 cursor-default bg-black/60"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Ganadores de ${title}`}
+        className="relative z-10 max-h-[80vh] w-full max-w-lg overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-gray-800"
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+          <div>
+            <p className="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              Ganadores
+            </p>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              {title}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-1 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+            aria-label="Cerrar"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="max-h-[60vh] overflow-y-auto p-6">
+          {loading && (
+            <p className="py-6 text-center text-sm text-gray-500">
+              Cargando ganadores...
+            </p>
+          )}
+          {error && (
+            <p className="mb-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+              {error}
+            </p>
+          )}
+          {!loading && winners.length === 0 && !error && (
+            <p className="py-6 text-center text-sm text-gray-500">
+              Todavía no hay ganadores.
+            </p>
+          )}
+          {!loading && winners.length > 0 && (
+            <ol className="space-y-2">
+              {winners.map((w, i) => (
+                <li
+                  key={w.id}
+                  className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3 dark:border-gray-700"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-lg" aria-hidden>
+                      {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : "🎉"}
+                    </span>
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      {w.alias}
+                    </p>
+                  </div>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                    {formatWonAt(w.bingoWonAt)}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/event-minigames/EventMinigameManager.tsx
+++ b/src/components/react/admin/event-minigames/EventMinigameManager.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "@/lib/api";
 import { Toast } from "../ui/Toast";
 import { AttachTemplateModal } from "./AttachTemplateModal";
+import { BingoWinnersPanel } from "./BingoWinnersPanel";
 import { InstanceCard } from "./InstanceCard";
+import { WordModerationPanel } from "./WordModerationPanel";
 import type { InstanceState, MinigameInstance } from "./types";
 
 interface Props {
@@ -27,6 +29,9 @@ export function EventMinigameManager({ initialSlug }: Props) {
   } | null>(null);
   const [attaching, setAttaching] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [moderationFor, setModerationFor] = useState<MinigameInstance | null>(
+    null
+  );
 
   const reload = useCallback(async () => {
     if (!slug) return;
@@ -162,9 +167,31 @@ export function EventMinigameManager({ initialSlug }: Props) {
               onSetState={(state) => handleSetState(inst.id, state)}
               onAdvanceQuiz={() => handleAdvanceQuiz(inst.id)}
               onDelete={() => handleDelete(inst.id)}
+              onOpenModeration={
+                inst.type === "wordcloud" || inst.type === "bingo"
+                  ? () => setModerationFor(inst)
+                  : undefined
+              }
             />
           ))}
         </div>
+      )}
+
+      {moderationFor && moderationFor.type === "wordcloud" && (
+        <WordModerationPanel
+          slug={slug!}
+          instanceId={moderationFor.id}
+          title={moderationFor.title}
+          onClose={() => setModerationFor(null)}
+        />
+      )}
+      {moderationFor && moderationFor.type === "bingo" && (
+        <BingoWinnersPanel
+          slug={slug!}
+          instanceId={moderationFor.id}
+          title={moderationFor.title}
+          onClose={() => setModerationFor(null)}
+        />
       )}
 
       {attaching && (

--- a/src/components/react/admin/event-minigames/InstanceCard.tsx
+++ b/src/components/react/admin/event-minigames/InstanceCard.tsx
@@ -14,6 +14,9 @@ interface Props {
   onAdvanceQuiz: () => Promise<void> | void;
   onDelete: () => Promise<void> | void;
   busy: boolean;
+  // PR5: opens the moderation/winners side panel for global games.
+  // Optional so admin tests of the card itself don't need to wire it.
+  onOpenModeration?: () => void;
 }
 
 function questionCount(instance: MinigameInstance): number {
@@ -28,7 +31,18 @@ export function InstanceCard({
   onAdvanceQuiz,
   onDelete,
   busy,
+  onOpenModeration,
 }: Props) {
+  const moderationLabel =
+    instance.type === "wordcloud"
+      ? "Ver moderación"
+      : instance.type === "bingo"
+        ? "Ver ganadores"
+        : null;
+  const moderationVisible =
+    moderationLabel !== null &&
+    instance.state !== "scheduled" &&
+    onOpenModeration;
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const isQuiz = instance.type === "quiz";
@@ -148,6 +162,16 @@ export function InstanceCard({
             className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             ↻ Reabrir
+          </button>
+        )}
+
+        {moderationVisible && (
+          <button
+            type="button"
+            onClick={onOpenModeration}
+            className="ml-auto rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            {moderationLabel}
           </button>
         )}
       </div>

--- a/src/components/react/admin/event-minigames/WordModerationPanel.tsx
+++ b/src/components/react/admin/event-minigames/WordModerationPanel.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+interface WordRow {
+  id: string;
+  text: string;
+  normalized: string;
+  count: number;
+  hidden?: boolean;
+}
+
+interface Props {
+  slug: string;
+  instanceId: string;
+  title: string;
+  onClose: () => void;
+}
+
+export function WordModerationPanel({
+  slug,
+  instanceId,
+  title,
+  onClose,
+}: Props) {
+  const [words, setWords] = useState<WordRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const res = await api.listEventMinigameWords(slug, instanceId);
+    if (res.success && Array.isArray(res.data)) {
+      setWords(res.data as WordRow[]);
+      setError(null);
+    } else {
+      setError(res.error || "Error al cargar palabras");
+    }
+    setLoading(false);
+  }, [slug, instanceId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function toggleHidden(word: WordRow) {
+    setBusyId(word.id);
+    const res = await api.setMinigameWordHidden(
+      slug,
+      instanceId,
+      word.id,
+      !word.hidden
+    );
+    if (res.success) {
+      setWords((prev) =>
+        prev.map((w) => (w.id === word.id ? { ...w, hidden: !w.hidden } : w))
+      );
+    } else {
+      setError(res.error || "Error al actualizar palabra");
+    }
+    setBusyId(null);
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <button
+        type="button"
+        aria-label="Cerrar fondo"
+        className="fixed inset-0 cursor-default bg-black/60"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Moderación de ${title}`}
+        className="relative z-10 max-h-[80vh] w-full max-w-2xl overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-gray-800"
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+          <div>
+            <p className="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              Moderación
+            </p>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              {title}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-1 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+            aria-label="Cerrar"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto p-6">
+          {loading && (
+            <p className="py-6 text-center text-sm text-gray-500">
+              Cargando palabras...
+            </p>
+          )}
+          {error && (
+            <p className="mb-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+              {error}
+            </p>
+          )}
+          {!loading && words.length === 0 && (
+            <p className="py-6 text-center text-sm text-gray-500">
+              Aún no hay palabras enviadas.
+            </p>
+          )}
+          {!loading && words.length > 0 && (
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+              <thead className="bg-gray-50 dark:bg-gray-900">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                    Palabra
+                  </th>
+                  <th className="px-4 py-2 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                    Cuenta
+                  </th>
+                  <th className="px-4 py-2 text-right text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                    Acción
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                {words.map((w) => (
+                  <tr
+                    key={w.id}
+                    className={
+                      w.hidden
+                        ? "opacity-60"
+                        : "hover:bg-gray-50 dark:hover:bg-gray-700"
+                    }
+                  >
+                    <td className="px-4 py-2 text-sm text-gray-900 dark:text-white">
+                      {w.text}
+                      {w.hidden && (
+                        <span className="ml-2 rounded bg-gray-200 px-1.5 py-0.5 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+                          oculto
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-right text-sm text-gray-700 dark:text-gray-300">
+                      {w.count}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        type="button"
+                        onClick={() => toggleHidden(w)}
+                        disabled={busyId === w.id}
+                        className="rounded px-3 py-1 text-sm text-blue-600 hover:bg-blue-50 disabled:opacity-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                      >
+                        {busyId === w.id
+                          ? "..."
+                          : w.hidden
+                            ? "Mostrar"
+                            : "Ocultar"}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/event-minigames/__tests__/WordModerationPanel.test.tsx
+++ b/src/components/react/admin/event-minigames/__tests__/WordModerationPanel.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mocks = vi.hoisted(() => ({
+  listEventMinigameWords: vi.fn(),
+  setMinigameWordHidden: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    listEventMinigameWords: mocks.listEventMinigameWords,
+    setMinigameWordHidden: mocks.setMinigameWordHidden,
+  },
+}));
+
+import { WordModerationPanel } from "../WordModerationPanel";
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.listEventMinigameWords.mockResolvedValue({
+    success: true,
+    data: [
+      { id: "hola", text: "hola", normalized: "hola", count: 5 },
+      { id: "spam", text: "spam", normalized: "spam", count: 1, hidden: true },
+    ],
+  });
+  mocks.setMinigameWordHidden.mockResolvedValue({
+    success: true,
+    data: { id: "hola", hidden: true },
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("WordModerationPanel", () => {
+  it("renders the words returned from the API", async () => {
+    render(
+      <WordModerationPanel
+        slug="evt"
+        instanceId="i1"
+        title="Word cloud"
+        onClose={vi.fn()}
+      />
+    );
+    await waitFor(() =>
+      expect(mocks.listEventMinigameWords).toHaveBeenCalledWith("evt", "i1")
+    );
+    expect(await screen.findByText("hola")).toBeInTheDocument();
+    expect(screen.getByText("spam")).toBeInTheDocument();
+    expect(screen.getByText(/oculto/i)).toBeInTheDocument();
+  });
+
+  it("calls setMinigameWordHidden when toggling a visible word", async () => {
+    const user = userEvent.setup();
+    render(
+      <WordModerationPanel
+        slug="evt"
+        instanceId="i1"
+        title="Word cloud"
+        onClose={vi.fn()}
+      />
+    );
+    await screen.findByText("hola");
+    const ocultar = screen
+      .getAllByRole("button", { name: /Ocultar/i })
+      .find((btn) => btn.textContent === "Ocultar");
+    if (!ocultar) throw new Error("Ocultar button not found");
+    await user.click(ocultar);
+    await waitFor(() =>
+      expect(mocks.setMinigameWordHidden).toHaveBeenCalledWith(
+        "evt",
+        "i1",
+        "hola",
+        true
+      )
+    );
+  });
+
+  it("calls onClose when ✕ is clicked", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <WordModerationPanel
+        slug="evt"
+        instanceId="i1"
+        title="Word cloud"
+        onClose={onClose}
+      />
+    );
+    await screen.findByText("hola");
+    await user.click(screen.getByRole("button", { name: /^Cerrar$/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows an empty state when no words are submitted", async () => {
+    mocks.listEventMinigameWords.mockResolvedValueOnce({
+      success: true,
+      data: [],
+    });
+    render(
+      <WordModerationPanel
+        slug="evt"
+        instanceId="i1"
+        title="Word cloud"
+        onClose={vi.fn()}
+      />
+    );
+    expect(await screen.findByText(/aún no hay palabras/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/react/event/BingoCardView.tsx
+++ b/src/components/react/event/BingoCardView.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from "react";
+import { getFirestore } from "@/lib/firebase";
+import {
+  CARD_SIZE,
+  CELL_COUNT,
+  detectBingoWin,
+  emptyMarked,
+} from "@/lib/bingo";
+import { useParticipantDoc } from "./useParticipantDoc";
+
+interface Props {
+  slug: string;
+  instanceId: string;
+  uid: string;
+  title: string;
+}
+
+export function BingoCardView({ slug, instanceId, uid, title }: Props) {
+  const { doc: participant, loading } = useParticipantDoc(
+    slug,
+    instanceId,
+    uid
+  );
+  const [pendingIndex, setPendingIndex] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const card = participant?.bingoCard ?? [];
+  const marked = useMemo(
+    () => participant?.bingoMarked ?? emptyMarked(),
+    [participant?.bingoMarked]
+  );
+
+  const hasWonBefore = Boolean(participant?.bingoWonAt);
+  const winningLines = useMemo(
+    () => (marked.length === CELL_COUNT ? detectBingoWin(marked) : []),
+    [marked]
+  );
+  const winningIndices = useMemo(() => {
+    const set = new Set<number>();
+    for (const line of winningLines) for (const i of line) set.add(i);
+    return set;
+  }, [winningLines]);
+
+  async function toggle(index: number) {
+    if (pendingIndex !== null) return;
+    if (card.length !== CELL_COUNT) return;
+    const nextMarked = [...marked];
+    if (nextMarked.length !== CELL_COUNT) {
+      while (nextMarked.length < CELL_COUNT) nextMarked.push(false);
+    }
+    nextMarked[index] = !nextMarked[index];
+
+    setPendingIndex(index);
+    setError(null);
+    try {
+      const db = await getFirestore();
+      const { doc, setDoc, serverTimestamp } = await import(
+        "firebase/firestore"
+      );
+      const ref = doc(
+        db,
+        `events/${slug}/minigames/${instanceId}/participants/${uid}`
+      );
+      const justWon = !hasWonBefore && detectBingoWin(nextMarked).length > 0;
+      const payload: Record<string, unknown> = { bingoMarked: nextMarked };
+      if (justWon) payload.bingoWonAt = serverTimestamp();
+      await setDoc(ref, payload, { merge: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No pudimos guardar");
+    } finally {
+      setPendingIndex(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-8 text-sm text-gray-500">
+        Cargando tu cartón...
+      </div>
+    );
+  }
+
+  if (card.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-gray-500">
+        No tienes un cartón de bingo asignado todavía. Cierra esta pestaña y
+        vuelve a entrar a la página del evento.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-primary text-2xl font-semibold">{title}</h2>
+        {hasWonBefore && (
+          <span className="rounded-full bg-yellow-100 px-3 py-1 text-sm font-semibold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+            🎉 ¡Bingo!
+          </span>
+        )}
+      </div>
+      {error && (
+        <p className="mb-3 text-sm text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+      <div
+        className="grid gap-2"
+        style={{ gridTemplateColumns: `repeat(${CARD_SIZE}, minmax(0, 1fr))` }}
+        role="grid"
+        aria-label="Cartón de bingo"
+      >
+        {card.map((term, index) => {
+          const isMarked = marked[index] === true;
+          const isWinning = winningIndices.has(index);
+          return (
+            <button
+              key={index}
+              type="button"
+              onClick={() => toggle(index)}
+              disabled={pendingIndex === index}
+              aria-pressed={isMarked}
+              className={`flex aspect-square items-center justify-center rounded-lg border p-2 text-center text-xs font-medium transition disabled:opacity-50 sm:text-sm ${
+                isMarked
+                  ? isWinning
+                    ? "border-yellow-400 bg-yellow-200 text-yellow-900 dark:bg-yellow-500/30 dark:text-yellow-100"
+                    : "border-blue-400 bg-blue-100 text-blue-900 dark:bg-blue-500/30 dark:text-blue-100"
+                  : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+              }`}
+            >
+              <span className="line-clamp-3 break-words">{term}</span>
+            </button>
+          );
+        })}
+      </div>
+      <p className="mt-3 text-center text-xs text-gray-500 dark:text-gray-400">
+        Toca una celda cuando el speaker mencione el término.
+      </p>
+    </div>
+  );
+}

--- a/src/components/react/event/MiniGamesRoot.tsx
+++ b/src/components/react/event/MiniGamesRoot.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "@/lib/api";
 import { signInAnonymouslyIfNeeded } from "@/lib/firebase";
+import { BingoCardView } from "./BingoCardView";
 import { JoinModal } from "./JoinModal";
 import { useLiveMinigames } from "./useLiveMinigames";
+import { WordCloudView } from "./WordCloudView";
 import { LOCAL_STORAGE_ALIAS_KEY, type LiveInstance } from "./types";
 
 interface Props {
@@ -37,6 +39,7 @@ function readForcePlay(): boolean {
 
 export function MiniGamesRoot({ slug }: Props) {
   const [authReady, setAuthReady] = useState(false);
+  const [uid, setUid] = useState<string | null>(null);
   const [step, setStep] = useState<Step>("init");
   const [alias, setAlias] = useState<string | null>(() =>
     typeof window === "undefined" ? null : readStoredAlias(slug)
@@ -45,13 +48,18 @@ export function MiniGamesRoot({ slug }: Props) {
 
   const { loading, liveInstances } = useLiveMinigames(authReady ? slug : null);
 
-  // Sign in anonymously (or reuse current user) on mount.
+  // Sign in anonymously (or reuse current user) on mount. We capture the
+  // resulting uid so the gameplay components (bingo card, word cloud)
+  // can subscribe to the correct participant doc.
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        await signInAnonymouslyIfNeeded();
-        if (!cancelled) setAuthReady(true);
+        const user = await signInAnonymouslyIfNeeded();
+        if (!cancelled) {
+          setUid(user?.uid ?? null);
+          setAuthReady(true);
+        }
       } catch {
         if (!cancelled) setAuthReady(true); // proceed; /join will fail loudly
       }
@@ -119,6 +127,17 @@ export function MiniGamesRoot({ slug }: Props) {
     [step, alias]
   );
 
+  // Global games (wordcloud + bingo) play inline once the participant is
+  // joined. PR6 will add overlays for the realtime modes (poll + quiz),
+  // which are intentionally ignored here.
+  const globalLive = useMemo(
+    () =>
+      (liveInstances as LiveInstance[]).filter(
+        (inst) => inst.mode === "global"
+      ),
+    [liveInstances]
+  );
+
   if (!authReady || loading || step === "init") return null;
   if (step === "no_live") return null;
 
@@ -144,6 +163,46 @@ export function MiniGamesRoot({ slug }: Props) {
             </span>
           </div>
         </div>
+      )}
+
+      {step === "joined" && uid && globalLive.length > 0 && (
+        <section className="container my-8" aria-label="Participación en vivo">
+          <h2 className="text-primary mb-4 text-2xl font-semibold">
+            Participación en vivo
+          </h2>
+          <div className="space-y-6">
+            {globalLive.map((inst) => (
+              <div
+                key={inst.id}
+                className="border-gray-custom rounded-lg border p-6 shadow-sm"
+              >
+                {inst.type === "wordcloud" && (
+                  <WordCloudView
+                    slug={slug}
+                    instanceId={inst.id}
+                    uid={uid}
+                    title={inst.title}
+                    prompt={
+                      (inst.config?.prompt as string | undefined) ??
+                      "Comparte tu palabra"
+                    }
+                    maxWordsPerUser={
+                      (inst.config?.maxWordsPerUser as number | undefined) ?? 3
+                    }
+                  />
+                )}
+                {inst.type === "bingo" && (
+                  <BingoCardView
+                    slug={slug}
+                    instanceId={inst.id}
+                    uid={uid}
+                    title={inst.title}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
       )}
     </>
   );

--- a/src/components/react/event/WordCloudView.tsx
+++ b/src/components/react/event/WordCloudView.tsx
@@ -1,0 +1,190 @@
+import { useMemo, useState } from "react";
+import { getFirestore } from "@/lib/firebase";
+import { isCleanWord, normalizeWord, WORD_MAX_LENGTH } from "@/lib/wordcloud";
+import { useWordCloud } from "./useWordCloud";
+
+interface Props {
+  slug: string;
+  instanceId: string;
+  uid: string;
+  title: string;
+  prompt: string;
+  maxWordsPerUser: number;
+}
+
+const MIN_FONT_REM = 0.85;
+const SCALE_PER_LOG = 0.6;
+
+function localStorageKey(slug: string, instanceId: string): string {
+  return `gdg_wordcloud_count_${slug}_${instanceId}`;
+}
+
+function readSentCount(slug: string, instanceId: string): number {
+  if (typeof window === "undefined") return 0;
+  try {
+    const v = window.localStorage.getItem(localStorageKey(slug, instanceId));
+    return v ? Number(v) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeSentCount(slug: string, instanceId: string, n: number) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(localStorageKey(slug, instanceId), String(n));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function WordCloudView({
+  slug,
+  instanceId,
+  title,
+  prompt,
+  maxWordsPerUser,
+}: Props) {
+  const { words, loading } = useWordCloud(slug, instanceId);
+  const [input, setInput] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sentCount, setSentCount] = useState<number>(() =>
+    readSentCount(slug, instanceId)
+  );
+
+  const remaining = Math.max(0, maxWordsPerUser - sentCount);
+  const trimmed = input.trim();
+
+  const maxCount = useMemo(
+    () => words.reduce((acc, w) => Math.max(acc, w.count), 1),
+    [words]
+  );
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+    if (remaining <= 0) {
+      setError(`Ya enviaste tus ${maxWordsPerUser} palabras para este juego.`);
+      return;
+    }
+    const normalized = normalizeWord(trimmed);
+    if (!normalized) {
+      setError("Escribe al menos una palabra.");
+      return;
+    }
+    if (!isCleanWord(trimmed)) {
+      setError("Por favor, elige una palabra respetuosa.");
+      return;
+    }
+    if (trimmed.length > WORD_MAX_LENGTH) {
+      setError(`Máximo ${WORD_MAX_LENGTH} caracteres.`);
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const db = await getFirestore();
+      const { doc, increment, serverTimestamp, setDoc } = await import(
+        "firebase/firestore"
+      );
+      const ref = doc(
+        db,
+        `events/${slug}/minigames/${instanceId}/words/${normalized}`
+      );
+      await setDoc(
+        ref,
+        {
+          text: trimmed,
+          normalized,
+          count: increment(1),
+          lastSubmittedAt: serverTimestamp(),
+          firstSubmittedAt: serverTimestamp(),
+        },
+        { merge: true }
+      );
+      const next = sentCount + 1;
+      setSentCount(next);
+      writeSentCount(slug, instanceId, next);
+      setInput("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No pudimos enviar.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-4">
+        <h2 className="text-primary text-2xl font-semibold">{title}</h2>
+        <p className="text-secondary mt-1 text-sm">{prompt}</p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="mb-4 flex flex-col gap-2 sm:flex-row"
+      >
+        <input
+          type="text"
+          value={input}
+          maxLength={WORD_MAX_LENGTH}
+          onChange={(e) => {
+            setInput(e.target.value);
+            setError(null);
+          }}
+          placeholder="Tu palabra..."
+          className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+          disabled={remaining === 0}
+        />
+        <button
+          type="submit"
+          disabled={submitting || remaining === 0 || trimmed.length === 0}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {submitting ? "Enviando..." : "Enviar"}
+        </button>
+      </form>
+      <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
+        Te quedan <strong>{remaining}</strong> de {maxWordsPerUser} palabras.
+      </p>
+      {error && (
+        <p className="mb-3 text-sm text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/30">
+        {loading && (
+          <p className="text-center text-sm text-gray-500">Cargando nube...</p>
+        )}
+        {!loading && words.length === 0 && (
+          <p className="text-center text-sm text-gray-500">
+            Sé el primero en escribir una palabra.
+          </p>
+        )}
+        {!loading && words.length > 0 && (
+          <ul className="flex flex-wrap items-baseline justify-center gap-x-4 gap-y-2">
+            {words.map((w) => {
+              const ratio = Math.log(w.count + 1) / Math.log(maxCount + 1);
+              const fontSize = Math.max(
+                MIN_FONT_REM,
+                MIN_FONT_REM + ratio * SCALE_PER_LOG * 2
+              );
+              return (
+                <li
+                  key={w.id}
+                  className="text-blue-700 dark:text-blue-300"
+                  style={{ fontSize: `${fontSize}rem`, lineHeight: 1.2 }}
+                >
+                  {w.text}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/event/__tests__/BingoCardView.test.tsx
+++ b/src/components/react/event/__tests__/BingoCardView.test.tsx
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mocks = vi.hoisted(() => ({
+  setDoc: vi.fn(),
+  serverTimestamp: vi.fn(() => "__TS__"),
+  getFirestore: vi.fn(),
+  doc: vi.fn(() => ({ __ref: true })),
+  useParticipantDoc: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  getFirestore: mocks.getFirestore,
+}));
+
+vi.mock("firebase/firestore", () => ({
+  doc: mocks.doc,
+  setDoc: mocks.setDoc,
+  serverTimestamp: mocks.serverTimestamp,
+}));
+
+vi.mock("../useParticipantDoc", () => ({
+  useParticipantDoc: mocks.useParticipantDoc,
+}));
+
+import { BingoCardView } from "../BingoCardView";
+
+function card(): string[] {
+  return Array.from({ length: 16 }, (_, i) => `term-${i + 1}`);
+}
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) {
+    if (
+      typeof (m as unknown as { mockReset?: () => void }).mockReset ===
+      "function"
+    ) {
+      (m as unknown as { mockReset: () => void }).mockReset();
+    }
+  }
+  mocks.serverTimestamp.mockReturnValue("__TS__");
+  mocks.getFirestore.mockResolvedValue({});
+  mocks.doc.mockImplementation(() => ({ __ref: true }));
+  mocks.setDoc.mockResolvedValue(undefined);
+});
+
+afterEach(() => cleanup());
+
+describe("BingoCardView", () => {
+  it("renders the 16 terms once the participant doc loads", () => {
+    mocks.useParticipantDoc.mockReturnValue({
+      doc: { uid: "u1", alias: "Ana", bingoCard: card() },
+      loading: false,
+      error: null,
+    });
+    render(<BingoCardView slug="x" instanceId="i" uid="u1" title="My bingo" />);
+    expect(screen.getByText("My bingo")).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(16);
+    expect(screen.getByText("term-1")).toBeInTheDocument();
+  });
+
+  it("shows an empty-state message when the user has no card", () => {
+    mocks.useParticipantDoc.mockReturnValue({
+      doc: null,
+      loading: false,
+      error: null,
+    });
+    render(<BingoCardView slug="x" instanceId="i" uid="u1" title="B" />);
+    expect(screen.getByText(/no tienes un cartón/i)).toBeInTheDocument();
+  });
+
+  it("toggles a cell via setDoc with the new bingoMarked array", async () => {
+    mocks.useParticipantDoc.mockReturnValue({
+      doc: {
+        uid: "u1",
+        alias: "Ana",
+        bingoCard: card(),
+        bingoMarked: Array.from({ length: 16 }, () => false),
+      },
+      loading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(<BingoCardView slug="x" instanceId="i" uid="u1" title="B" />);
+    const buttons = screen.getAllByRole("button");
+    await user.click(buttons[0]);
+    await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(1));
+    const args = mocks.setDoc.mock.calls[0];
+    const payload = args[1] as { bingoMarked: boolean[] };
+    expect(payload.bingoMarked[0]).toBe(true);
+    expect(payload.bingoMarked.slice(1)).toEqual(
+      Array.from({ length: 15 }, () => false)
+    );
+  });
+
+  it("writes bingoWonAt when a row gets completed", async () => {
+    const baseMarked = Array.from({ length: 16 }, () => false);
+    // Pre-mark cells 1, 2, 3 — clicking 0 completes the top row.
+    baseMarked[1] = true;
+    baseMarked[2] = true;
+    baseMarked[3] = true;
+    mocks.useParticipantDoc.mockReturnValue({
+      doc: {
+        uid: "u1",
+        alias: "Ana",
+        bingoCard: card(),
+        bingoMarked: baseMarked,
+      },
+      loading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(<BingoCardView slug="x" instanceId="i" uid="u1" title="B" />);
+    await user.click(screen.getAllByRole("button")[0]);
+    await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(1));
+    const payload = mocks.setDoc.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.bingoWonAt).toBe("__TS__");
+  });
+
+  it("does not re-write bingoWonAt if already won", async () => {
+    const winning = Array.from({ length: 16 }, (_, i) => i < 4);
+    mocks.useParticipantDoc.mockReturnValue({
+      doc: {
+        uid: "u1",
+        alias: "Ana",
+        bingoCard: card(),
+        bingoMarked: winning,
+        bingoWonAt: { seconds: 1 },
+      },
+      loading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(<BingoCardView slug="x" instanceId="i" uid="u1" title="B" />);
+    // Clicking another cell while already won should still update marks
+    // but NOT rewrite bingoWonAt.
+    await user.click(screen.getAllByRole("button")[15]);
+    await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(1));
+    const payload = mocks.setDoc.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.bingoWonAt).toBeUndefined();
+  });
+
+  it("renders the 'Bingo!' badge when the participant has won", () => {
+    mocks.useParticipantDoc.mockReturnValue({
+      doc: {
+        uid: "u1",
+        alias: "Ana",
+        bingoCard: card(),
+        bingoMarked: Array.from({ length: 16 }, (_, i) => i < 4),
+        bingoWonAt: { seconds: 5 },
+      },
+      loading: false,
+      error: null,
+    });
+    render(<BingoCardView slug="x" instanceId="i" uid="u1" title="B" />);
+    expect(screen.getByText(/¡Bingo!/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/react/event/__tests__/WordCloudView.test.tsx
+++ b/src/components/react/event/__tests__/WordCloudView.test.tsx
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mocks = vi.hoisted(() => ({
+  setDoc: vi.fn(),
+  increment: vi.fn((n: number) => ({ __increment: n })),
+  serverTimestamp: vi.fn(() => "__TS__"),
+  getFirestore: vi.fn(),
+  doc: vi.fn(() => ({ __ref: true })),
+  useWordCloud: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  getFirestore: mocks.getFirestore,
+}));
+
+vi.mock("firebase/firestore", () => ({
+  doc: mocks.doc,
+  setDoc: mocks.setDoc,
+  increment: mocks.increment,
+  serverTimestamp: mocks.serverTimestamp,
+}));
+
+vi.mock("../useWordCloud", () => ({
+  useWordCloud: mocks.useWordCloud,
+}));
+
+import { WordCloudView } from "../WordCloudView";
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) {
+    if (
+      typeof (m as unknown as { mockReset?: () => void }).mockReset ===
+      "function"
+    ) {
+      (m as unknown as { mockReset: () => void }).mockReset();
+    }
+  }
+  mocks.increment.mockImplementation((n: number) => ({ __increment: n }));
+  mocks.serverTimestamp.mockReturnValue("__TS__");
+  mocks.getFirestore.mockResolvedValue({});
+  mocks.doc.mockImplementation(() => ({ __ref: true }));
+  mocks.setDoc.mockResolvedValue(undefined);
+  mocks.useWordCloud.mockReturnValue({
+    words: [],
+    loading: false,
+    error: null,
+  });
+  if (typeof window !== "undefined") {
+    window.localStorage.clear();
+  }
+});
+
+afterEach(() => cleanup());
+
+describe("WordCloudView", () => {
+  it("renders the prompt and the empty cloud", () => {
+    render(
+      <WordCloudView
+        slug="x"
+        instanceId="i"
+        uid="u"
+        title="What is AI?"
+        prompt="One word"
+        maxWordsPerUser={3}
+      />
+    );
+    expect(screen.getByText("What is AI?")).toBeInTheDocument();
+    expect(screen.getByText("One word")).toBeInTheDocument();
+    expect(screen.getByText(/sé el primero/i)).toBeInTheDocument();
+  });
+
+  it("submits a normalised word via setDoc with merge", async () => {
+    const user = userEvent.setup();
+    render(
+      <WordCloudView
+        slug="x"
+        instanceId="i"
+        uid="u"
+        title="t"
+        prompt="p"
+        maxWordsPerUser={3}
+      />
+    );
+    await user.type(screen.getByPlaceholderText(/tu palabra/i), "Hola Mundo");
+    await user.click(screen.getByRole("button", { name: /Enviar/i }));
+    await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(1));
+    const [, payload, options] = mocks.setDoc.mock.calls[0];
+    const data = payload as Record<string, unknown>;
+    expect(data.text).toBe("Hola Mundo");
+    expect(data.normalized).toBe("hola mundo");
+    expect(options).toEqual({ merge: true });
+  });
+
+  it("blocks submit on profanity", async () => {
+    const user = userEvent.setup();
+    render(
+      <WordCloudView
+        slug="x"
+        instanceId="i"
+        uid="u"
+        title="t"
+        prompt="p"
+        maxWordsPerUser={3}
+      />
+    );
+    await user.type(screen.getByPlaceholderText(/tu palabra/i), "fuck");
+    await user.click(screen.getByRole("button", { name: /Enviar/i }));
+    expect(mocks.setDoc).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/respetuosa/i);
+  });
+
+  it("does not double-submit on rapid clicks", async () => {
+    mocks.setDoc.mockImplementation(
+      () => new Promise((r) => setTimeout(() => r(undefined), 50))
+    );
+    const user = userEvent.setup();
+    render(
+      <WordCloudView
+        slug="x"
+        instanceId="i"
+        uid="u"
+        title="t"
+        prompt="p"
+        maxWordsPerUser={3}
+      />
+    );
+    await user.type(screen.getByPlaceholderText(/tu palabra/i), "Hola");
+    const btn = screen.getByRole("button", { name: /Enviar/i });
+    await user.click(btn);
+    await user.click(btn);
+    expect(mocks.setDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it("decrements remaining count and persists in localStorage", async () => {
+    const user = userEvent.setup();
+    render(
+      <WordCloudView
+        slug="evt"
+        instanceId="i1"
+        uid="u"
+        title="t"
+        prompt="p"
+        maxWordsPerUser={2}
+      />
+    );
+    expect(screen.getByText(/te quedan/i)).toHaveTextContent("2");
+    await user.type(screen.getByPlaceholderText(/tu palabra/i), "Hola");
+    await user.click(screen.getByRole("button", { name: /Enviar/i }));
+    await waitFor(() =>
+      expect(window.localStorage.getItem("gdg_wordcloud_count_evt_i1")).toBe(
+        "1"
+      )
+    );
+    expect(screen.getByText(/te quedan/i)).toHaveTextContent("1");
+  });
+
+  it("blocks submit after the per-user limit is reached", async () => {
+    window.localStorage.setItem("gdg_wordcloud_count_x_i", "3");
+    const user = userEvent.setup();
+    render(
+      <WordCloudView
+        slug="x"
+        instanceId="i"
+        uid="u"
+        title="t"
+        prompt="p"
+        maxWordsPerUser={3}
+      />
+    );
+    expect(screen.getByPlaceholderText(/tu palabra/i)).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Enviar/i })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: /Enviar/i }));
+    expect(mocks.setDoc).not.toHaveBeenCalled();
+  });
+
+  it("renders submitted words sized by frequency", () => {
+    mocks.useWordCloud.mockReturnValue({
+      loading: false,
+      error: null,
+      words: [
+        { id: "hola", text: "hola", normalized: "hola", count: 5 },
+        { id: "mundo", text: "mundo", normalized: "mundo", count: 1 },
+      ],
+    });
+    render(
+      <WordCloudView
+        slug="x"
+        instanceId="i"
+        uid="u"
+        title="t"
+        prompt="p"
+        maxWordsPerUser={3}
+      />
+    );
+    expect(screen.getByText("hola")).toBeInTheDocument();
+    expect(screen.getByText("mundo")).toBeInTheDocument();
+  });
+});

--- a/src/components/react/event/useParticipantDoc.ts
+++ b/src/components/react/event/useParticipantDoc.ts
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import { getFirestore } from "@/lib/firebase";
+
+export interface ParticipantDoc {
+  uid: string;
+  alias: string;
+  bingoCard?: string[];
+  bingoMarked?: boolean[];
+  bingoWonAt?: { seconds: number } | null;
+}
+
+interface State {
+  doc: ParticipantDoc | null;
+  loading: boolean;
+  error: string | null;
+}
+
+// Subscribes to events/{slug}/minigames/{instanceId}/participants/{uid}
+// in real time. Returns null doc until the first snapshot arrives or if
+// the participant has not joined yet (the rules allow public reads, so
+// this works for everyone — the spectator badge in MiniGamesRoot also
+// consumes it).
+export function useParticipantDoc(
+  slug: string | null,
+  instanceId: string | null,
+  uid: string | null
+): State {
+  const [state, setState] = useState<State>({
+    doc: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!slug || !instanceId || !uid) {
+      setState({ doc: null, loading: false, error: null });
+      return;
+    }
+    let unsub: (() => void) | null = null;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const db = await getFirestore();
+        const { doc, onSnapshot } = await import("firebase/firestore");
+        if (cancelled) return;
+        const ref = doc(
+          db,
+          `events/${slug}/minigames/${instanceId}/participants/${uid}`
+        );
+        unsub = onSnapshot(
+          ref,
+          (snap) => {
+            if (!snap.exists()) {
+              setState({ doc: null, loading: false, error: null });
+              return;
+            }
+            setState({
+              doc: { uid, ...(snap.data() as Omit<ParticipantDoc, "uid">) },
+              loading: false,
+              error: null,
+            });
+          },
+          (err) => {
+            setState({ doc: null, loading: false, error: err.message });
+          }
+        );
+      } catch (err) {
+        setState({
+          doc: null,
+          loading: false,
+          error: err instanceof Error ? err.message : "Listener error",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (unsub) unsub();
+    };
+  }, [slug, instanceId, uid]);
+
+  return state;
+}

--- a/src/components/react/event/useWordCloud.ts
+++ b/src/components/react/event/useWordCloud.ts
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { getFirestore } from "@/lib/firebase";
+
+export interface CloudWord {
+  id: string;
+  text: string;
+  normalized: string;
+  count: number;
+  hidden?: boolean;
+}
+
+interface State {
+  words: CloudWord[];
+  loading: boolean;
+  error: string | null;
+}
+
+// Subscribes to the words subcollection of a wordcloud instance,
+// ordered by count desc. Hidden words are filtered client-side because
+// Firestore != queries on booleans require composite indexes that we
+// don't otherwise need.
+export function useWordCloud(
+  slug: string | null,
+  instanceId: string | null,
+  limitCount = 50
+): State {
+  const [state, setState] = useState<State>({
+    words: [],
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!slug || !instanceId) {
+      setState({ words: [], loading: false, error: null });
+      return;
+    }
+    let unsub: (() => void) | null = null;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const db = await getFirestore();
+        const { collection, query, orderBy, limit, onSnapshot } = await import(
+          "firebase/firestore"
+        );
+        if (cancelled) return;
+        const q = query(
+          collection(db, `events/${slug}/minigames/${instanceId}/words`),
+          orderBy("count", "desc"),
+          limit(limitCount)
+        );
+        unsub = onSnapshot(
+          q,
+          (snap) => {
+            const all = snap.docs.map(
+              (d) => ({ id: d.id, ...d.data() }) as CloudWord
+            );
+            setState({
+              words: all.filter((w) => !w.hidden),
+              loading: false,
+              error: null,
+            });
+          },
+          (err) => {
+            setState({ words: [], loading: false, error: err.message });
+          }
+        );
+      } catch (err) {
+        setState({
+          words: [],
+          loading: false,
+          error: err instanceof Error ? err.message : "Listener error",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (unsub) unsub();
+    };
+  }, [slug, instanceId, limitCount]);
+
+  return state;
+}

--- a/src/lib/__tests__/bingo.test.ts
+++ b/src/lib/__tests__/bingo.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { CELL_COUNT, detectBingoWin, emptyMarked, hasBingoWin } from "../bingo";
+
+function withIndices(indices: number[]): boolean[] {
+  const m = emptyMarked();
+  for (const i of indices) m[i] = true;
+  return m;
+}
+
+describe("detectBingoWin", () => {
+  it("returns empty array for an empty card", () => {
+    expect(detectBingoWin(emptyMarked())).toEqual([]);
+    expect(hasBingoWin(emptyMarked())).toBe(false);
+  });
+
+  it("detects every row", () => {
+    for (const row of [0, 1, 2, 3]) {
+      const indices = [row * 4, row * 4 + 1, row * 4 + 2, row * 4 + 3];
+      const marks = withIndices(indices);
+      const wins = detectBingoWin(marks);
+      expect(wins).toHaveLength(1);
+      expect(wins[0]).toEqual(indices);
+    }
+  });
+
+  it("detects every column", () => {
+    for (const col of [0, 1, 2, 3]) {
+      const indices = [col, col + 4, col + 8, col + 12];
+      const wins = detectBingoWin(withIndices(indices));
+      expect(wins).toHaveLength(1);
+      expect(wins[0]).toEqual(indices);
+    }
+  });
+
+  it("detects the main diagonal", () => {
+    const wins = detectBingoWin(withIndices([0, 5, 10, 15]));
+    expect(wins).toEqual([[0, 5, 10, 15]]);
+  });
+
+  it("detects the anti-diagonal", () => {
+    const wins = detectBingoWin(withIndices([3, 6, 9, 12]));
+    expect(wins).toEqual([[3, 6, 9, 12]]);
+  });
+
+  it("returns multiple lines when the card is fully marked", () => {
+    const all = Array.from({ length: CELL_COUNT }, () => true);
+    const wins = detectBingoWin(all);
+    // 4 rows + 4 cols + 2 diags = 10 lines.
+    expect(wins).toHaveLength(10);
+  });
+
+  it("does not declare a win for 3-in-a-row", () => {
+    expect(detectBingoWin(withIndices([0, 1, 2]))).toEqual([]);
+  });
+
+  it("throws if the marked length is wrong", () => {
+    expect(() => detectBingoWin([true, false, true])).toThrowError(
+      /length 16/i
+    );
+  });
+});

--- a/src/lib/__tests__/wordcloud.test.ts
+++ b/src/lib/__tests__/wordcloud.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { isCleanWord, normalizeWord, WORD_MAX_LENGTH } from "../wordcloud";
+
+describe("normalizeWord", () => {
+  it("lowercases", () => {
+    expect(normalizeWord("HOLA")).toBe("hola");
+  });
+
+  it("strips diacritics", () => {
+    expect(normalizeWord("Coñito")).toBe("conito");
+    expect(normalizeWord("ÁÉÍÓÚ")).toBe("aeiou");
+  });
+
+  it("collapses internal whitespace and trims", () => {
+    expect(normalizeWord("   Hola   Mundo   ")).toBe("hola mundo");
+  });
+
+  it("strips most punctuation but keeps single spaces", () => {
+    expect(normalizeWord("Hola, mundo!!!")).toBe("hola mundo");
+    expect(normalizeWord("buena-vibra")).toBe("buena vibra");
+  });
+
+  it("returns empty for whitespace/punctuation-only input", () => {
+    expect(normalizeWord("   ")).toBe("");
+    expect(normalizeWord("!!!")).toBe("");
+    expect(normalizeWord("")).toBe("");
+  });
+
+  it("truncates to max length", () => {
+    const long = "a".repeat(WORD_MAX_LENGTH + 20);
+    expect(normalizeWord(long)).toHaveLength(WORD_MAX_LENGTH);
+  });
+
+  it("treats different casings as the same canonical id", () => {
+    expect(normalizeWord("Hola")).toBe(normalizeWord("HOLA"));
+    expect(normalizeWord("Hola")).toBe(normalizeWord("hola "));
+    expect(normalizeWord("Hola")).toBe(normalizeWord(" hOlA  "));
+  });
+});
+
+describe("isCleanWord", () => {
+  it("accepts ordinary words", () => {
+    expect(isCleanWord("hola")).toBe(true);
+    expect(isCleanWord("Aprender")).toBe(true);
+    expect(isCleanWord("Build with AI")).toBe(true);
+  });
+
+  it("rejects empty input", () => {
+    expect(isCleanWord("")).toBe(false);
+    expect(isCleanWord("   ")).toBe(false);
+  });
+
+  it("rejects denylisted terms regardless of case", () => {
+    expect(isCleanWord("FUCK")).toBe(false);
+    expect(isCleanWord("Mierda con queso")).toBe(false);
+  });
+
+  it("rejects bypasses with whitespace/punctuation", () => {
+    expect(isCleanWord("p.u.t.a")).toBe(false);
+    expect(isCleanWord("f u c k")).toBe(false);
+  });
+
+  it("does not flag innocuous substrings", () => {
+    expect(isCleanWord("Catarina")).toBe(true);
+    expect(isCleanWord("Pedro")).toBe(true);
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -133,6 +133,28 @@ const realApi = {
       }[];
     }>("POST", `/events/${encodeURIComponent(slug)}/minigames/join`, data),
 
+  // Wordcloud moderation + bingo winners (admin-only)
+  listEventMinigameWords: (slug: string, id: string) =>
+    request("GET", `/events/${encodeURIComponent(slug)}/minigames/${id}/words`),
+  setMinigameWordHidden: (
+    slug: string,
+    id: string,
+    wordId: string,
+    hidden: boolean
+  ) =>
+    request(
+      "PATCH",
+      `/events/${encodeURIComponent(slug)}/minigames/${id}/words/${encodeURIComponent(
+        wordId
+      )}/hidden`,
+      { hidden }
+    ),
+  listMinigameBingoWinners: (slug: string, id: string) =>
+    request(
+      "GET",
+      `/events/${encodeURIComponent(slug)}/minigames/${id}/winners`
+    ),
+
   // Rebuild
   triggerRebuild: () => request("POST", "/rebuild"),
 };

--- a/src/lib/bingo.ts
+++ b/src/lib/bingo.ts
@@ -1,0 +1,56 @@
+// Pure win detection for a 4x4 bingo card stored as a length-16
+// boolean array (row-major). The participant doc uses
+// `bingoMarked: boolean[16]`, so this lives in src/lib so both the
+// card UI and any future server-side verifier can share it.
+
+export const CARD_SIZE = 4;
+export const CELL_COUNT = CARD_SIZE * CARD_SIZE;
+
+const ROWS: number[][] = [
+  [0, 1, 2, 3],
+  [4, 5, 6, 7],
+  [8, 9, 10, 11],
+  [12, 13, 14, 15],
+];
+const COLS: number[][] = [
+  [0, 4, 8, 12],
+  [1, 5, 9, 13],
+  [2, 6, 10, 14],
+  [3, 7, 11, 15],
+];
+const DIAGS: number[][] = [
+  [0, 5, 10, 15],
+  [3, 6, 9, 12],
+];
+
+export const ALL_LINES: ReadonlyArray<ReadonlyArray<number>> = [
+  ...ROWS,
+  ...COLS,
+  ...DIAGS,
+];
+
+// Returns the list of fully-marked lines (rows / cols / diagonals).
+// Empty array means the user has not won yet. The list is included so
+// the UI can highlight every winning line, not just the first.
+export function detectBingoWin(marked: ReadonlyArray<boolean>): number[][] {
+  if (marked.length !== CELL_COUNT) {
+    throw new Error(
+      `bingoMarked must have length ${CELL_COUNT} (got ${marked.length})`
+    );
+  }
+  const wins: number[][] = [];
+  for (const line of ALL_LINES) {
+    if (line.every((idx) => marked[idx])) {
+      wins.push([...line]);
+    }
+  }
+  return wins;
+}
+
+export function hasBingoWin(marked: ReadonlyArray<boolean>): boolean {
+  return detectBingoWin(marked).length > 0;
+}
+
+export function emptyMarked(): boolean[] {
+  return Array.from({ length: CELL_COUNT }, () => false);
+}

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -72,5 +72,14 @@ export const mockApi = {
   joinEventMinigames: (_slug: string, data: { alias: string }) =>
     ok({ alias: data.alias, instances: [] }),
 
+  listEventMinigameWords: () => ok([]),
+  setMinigameWordHidden: (
+    _slug: string,
+    _id: string,
+    wordId: string,
+    hidden: boolean
+  ) => ok({ id: wordId, hidden }),
+  listMinigameBingoWinners: () => ok([]),
+
   triggerRebuild: () => ok(null),
 };

--- a/src/lib/wordcloud.ts
+++ b/src/lib/wordcloud.ts
@@ -1,0 +1,86 @@
+// Public-side helpers for the word cloud mini-game.
+//
+// `normalizeWord` produces the canonical doc id we use under
+// events/{slug}/minigames/{id}/words/{normalized}. Same canonical form
+// = same doc, so duplicates merge naturally via FieldValue.increment(1).
+//
+// `isCleanWord` mirrors `functions/src/services/profanity.ts` so the
+// client surfaces obvious rejections before round-tripping. Server is
+// still source of truth (Firestore rules and admin moderation).
+
+const MAX_LENGTH = 60;
+
+const DENYLIST: ReadonlyArray<string> = [
+  // Spanish
+  "cabron",
+  "carajo",
+  "chinga",
+  "concha",
+  "coño",
+  "culiao",
+  "joto",
+  "marica",
+  "maricon",
+  "mierda",
+  "pendejo",
+  "puta",
+  "puto",
+  "verga",
+  // English
+  "asshole",
+  "bastard",
+  "bitch",
+  "cunt",
+  "dick",
+  "fag",
+  "fuck",
+  "nigger",
+  "nigga",
+  "pussy",
+  "shit",
+  "slut",
+  "twat",
+  "whore",
+];
+
+const DIACRITICS_RE = /[̀-ͯ]/g;
+const NON_ASCII_ALNUM_RE = /[^a-z0-9]/g;
+
+function fold(raw: string): string {
+  return raw
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(DIACRITICS_RE, "")
+    .replace(NON_ASCII_ALNUM_RE, "");
+}
+
+const NORMALIZED_DENYLIST: ReadonlyArray<string> = DENYLIST.map(fold).filter(
+  (s) => s.length > 0
+);
+
+// Display-friendly normalisation: collapse whitespace, lowercase, trim,
+// strip diacritics so "Hola" / "HOLA" / "hólà" all share the same
+// bucket. Returns "" when the input collapses to empty.
+export function normalizeWord(raw: string): string {
+  if (!raw) return "";
+  const collapsed = raw
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(DIACRITICS_RE, "")
+    .replace(/[^a-z0-9 ]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return collapsed.slice(0, MAX_LENGTH);
+}
+
+export function isCleanWord(text: string): boolean {
+  if (!text) return false;
+  const folded = fold(text);
+  if (!folded) return false;
+  for (const term of NORMALIZED_DENYLIST) {
+    if (folded.includes(term)) return false;
+  }
+  return true;
+}
+
+export const WORD_MAX_LENGTH = MAX_LENGTH;

--- a/tests/rules/minigame-instances.test.ts
+++ b/tests/rules/minigame-instances.test.ts
@@ -132,3 +132,277 @@ describe("firestore.rules — events/{slug}/minigames", () => {
     );
   });
 });
+
+// ---- PR5 rules: bingo card marking + word submissions -----------------
+
+const BINGO_INSTANCE_ID = "instance-bingo";
+const WORDCLOUD_INSTANCE_ID = "instance-wordcloud";
+
+const BINGO_INSTANCE = {
+  eventSlug: SLUG,
+  templateId: "tpl-bingo",
+  templateVersion: 1,
+  type: "bingo",
+  mode: "global",
+  state: "live",
+  title: "Sample bingo",
+  config: { terms: [], cardSize: 4, freeCenter: false },
+  order: 0,
+  createdBy: "admin-uid",
+  createdAt: 0,
+};
+
+const WORDCLOUD_INSTANCE = {
+  eventSlug: SLUG,
+  templateId: "tpl-wc",
+  templateVersion: 1,
+  type: "wordcloud",
+  mode: "global",
+  state: "live",
+  title: "Sample wordcloud",
+  config: { prompt: "Say a word", maxWordsPerUser: 3, maxLength: 60 },
+  order: 1,
+  createdBy: "admin-uid",
+  createdAt: 0,
+};
+
+const SEED_PARTICIPANT_BINGO = {
+  uid: "user-1",
+  alias: "Ana",
+  joinedAt: 0,
+  bingoCard: Array.from({ length: 16 }, (_, i) => `term-${i}`),
+};
+
+async function seedBingoState(env: Awaited<ReturnType<typeof getTestEnv>>) {
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    await setDoc(
+      doc(db, `events/${SLUG}/minigames/${BINGO_INSTANCE_ID}`),
+      BINGO_INSTANCE
+    );
+    await setDoc(
+      doc(
+        db,
+        `events/${SLUG}/minigames/${BINGO_INSTANCE_ID}/participants/user-1`
+      ),
+      SEED_PARTICIPANT_BINGO
+    );
+  });
+}
+
+async function seedWordCloudState(
+  env: Awaited<ReturnType<typeof getTestEnv>>,
+  options: { state?: string; type?: string; participantUid?: string } = {}
+) {
+  const state = options.state ?? "live";
+  const type = options.type ?? "wordcloud";
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    await setDoc(doc(db, `events/${SLUG}/minigames/${WORDCLOUD_INSTANCE_ID}`), {
+      ...WORDCLOUD_INSTANCE,
+      state,
+      type,
+    });
+    if (options.participantUid) {
+      await setDoc(
+        doc(
+          db,
+          `events/${SLUG}/minigames/${WORDCLOUD_INSTANCE_ID}/participants/${options.participantUid}`
+        ),
+        { uid: options.participantUid, alias: "tester", joinedAt: 0 }
+      );
+    }
+  });
+}
+
+describe("firestore.rules — PR5 bingo marking", () => {
+  beforeAll(async () => {
+    await getTestEnv();
+  });
+
+  afterEach(async () => {
+    await clearAll();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it("allows the owner to update only bingoMarked", async () => {
+    const env = await getTestEnv();
+    await seedBingoState(env);
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertSucceeds(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${BINGO_INSTANCE_ID}/participants/user-1`
+        ),
+        { bingoMarked: Array.from({ length: 16 }, () => false) },
+        { merge: true }
+      )
+    );
+  });
+
+  it("rejects bingoMarked of wrong length", async () => {
+    const env = await getTestEnv();
+    await seedBingoState(env);
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${BINGO_INSTANCE_ID}/participants/user-1`
+        ),
+        { bingoMarked: [true, false, true] },
+        { merge: true }
+      )
+    );
+  });
+
+  it("rejects updates that change the alias", async () => {
+    const env = await getTestEnv();
+    await seedBingoState(env);
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${BINGO_INSTANCE_ID}/participants/user-1`
+        ),
+        { alias: "Hacked" },
+        { merge: true }
+      )
+    );
+  });
+
+  it("rejects another user updating someone else's participant", async () => {
+    const env = await getTestEnv();
+    await seedBingoState(env);
+    const stranger = env.authenticatedContext("user-2").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          stranger,
+          `events/${SLUG}/minigames/${BINGO_INSTANCE_ID}/participants/user-1`
+        ),
+        { bingoMarked: Array.from({ length: 16 }, () => true) },
+        { merge: true }
+      )
+    );
+  });
+
+  it("allows setting bingoWonAt alongside bingoMarked", async () => {
+    const env = await getTestEnv();
+    await seedBingoState(env);
+    const auth = env.authenticatedContext("user-1").firestore();
+    const win = Array.from({ length: 16 }, (_, i) => i < 4);
+    await assertSucceeds(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${BINGO_INSTANCE_ID}/participants/user-1`
+        ),
+        { bingoMarked: win, bingoWonAt: new Date() },
+        { merge: true }
+      )
+    );
+  });
+});
+
+describe("firestore.rules — PR5 word submissions", () => {
+  beforeAll(async () => {
+    await getTestEnv();
+  });
+
+  afterEach(async () => {
+    await clearAll();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it("allows a joined participant to write a word while live", async () => {
+    const env = await getTestEnv();
+    await seedWordCloudState(env, { participantUid: "user-1" });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertSucceeds(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${WORDCLOUD_INSTANCE_ID}/words/hola`
+        ),
+        { text: "hola", normalized: "hola", count: 1 },
+        { merge: true }
+      )
+    );
+  });
+
+  it("rejects writes when the participant doc is missing", async () => {
+    const env = await getTestEnv();
+    await seedWordCloudState(env);
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${WORDCLOUD_INSTANCE_ID}/words/hola`
+        ),
+        { text: "hola", normalized: "hola", count: 1 },
+        { merge: true }
+      )
+    );
+  });
+
+  it("rejects writes when the instance is not live", async () => {
+    const env = await getTestEnv();
+    await seedWordCloudState(env, {
+      state: "closed",
+      participantUid: "user-1",
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${WORDCLOUD_INSTANCE_ID}/words/hola`
+        ),
+        { text: "hola", normalized: "hola", count: 1 },
+        { merge: true }
+      )
+    );
+  });
+
+  it("rejects writes when the instance is not a wordcloud", async () => {
+    const env = await getTestEnv();
+    await seedWordCloudState(env, { type: "poll", participantUid: "user-1" });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${WORDCLOUD_INSTANCE_ID}/words/hola`
+        ),
+        { text: "hola", normalized: "hola", count: 1 },
+        { merge: true }
+      )
+    );
+  });
+
+  it("rejects writes whose doc id does not match the normalized field", async () => {
+    const env = await getTestEnv();
+    await seedWordCloudState(env, { participantUid: "user-1" });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${WORDCLOUD_INSTANCE_ID}/words/hola`
+        ),
+        { text: "hola", normalized: "MISMATCH", count: 1 },
+        { merge: true }
+      )
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Brings the word cloud and bingo mini-games to life. When a participant has joined an event, live wordcloud and bingo instances render inline in \`/eventos/{slug}\`; admins moderate words and view bingo winners from the admin panel.

## What's new

### Backend
- **Admin-only word/winner endpoints** (\`functions/src/handlers/minigameWords.ts\`):
  - \`GET /api/events/:slug/minigames/:id/words\` — full list including hidden, ordered by count desc.
  - \`PATCH /api/events/:slug/minigames/:id/words/:wordId/hidden\` — toggles \`hidden\` with audit log (\`minigame_word.hide\` / \`.unhide\`).
  - \`GET /api/events/:slug/minigames/:id/winners\` — bingo winners sorted by \`bingoWonAt\` ascending.
- New \`minigameWordHiddenSchema\` (Zod, \`.strict()\`).

### Firestore rules
- \`participants/{uid}\`: self-update limited to \`bingoMarked\` + \`bingoWonAt\` via \`diff().affectedKeys().hasOnly\`. Enforces \`bingoMarked.size() == 16\`.
- \`words/{wordId}\`: merge writes allowed only when the parent instance is \`live\`, type is \`wordcloud\`, the participant doc exists for the user, and the doc id matches \`request.resource.data.normalized\` so duplicate words collapse via \`FieldValue.increment\`.

### Pure utilities
- \`src/lib/wordcloud.ts\`: \`normalizeWord\` (canonical doc id) + \`isCleanWord\` (denylist with diacritic folding so \"p u t a\", \"PUTA\" and \"pútä\" all hit the same entry).
- \`src/lib/bingo.ts\`: \`detectBingoWin\` returns every winning row/col/diag for a length-16 boolean array. \`CARD_SIZE\` / \`CELL_COUNT\` exposed for UI grid layout.

### Public-side components
- **BingoCardView**: subscribes to the participant doc via the new \`useParticipantDoc\` hook, renders a 4×4 grid, toggles cells via \`setDoc(merge: true)\`, and writes \`bingoWonAt: serverTimestamp()\` the first time a line completes (idempotent on later clicks).
- **WordCloudView**: subscribes via \`useWordCloud\` (orderBy \`count\` desc, limit 50), submits client-direct with \`FieldValue.increment(1)\`, enforces a localStorage soft limit per (slug, instanceId), filters hidden words client-side.
- **MiniGamesRoot** extended: renders a \"Participación en vivo\" section with one bordered card per live global instance once the user is joined.

### Admin panel
- **WordModerationPanel** modal: every word + count + Mostrar/Ocultar toggle.
- **BingoWinnersPanel** modal: ordered list with podium emojis and formatted timestamps.
- **InstanceCard**: surfaces a \"Ver moderación\" / \"Ver ganadores\" button when the instance is wordcloud/bingo and not scheduled.
- **EventMinigameManager**: opens the matching panel for the selected instance.

## Behaviour decisions
- **Word cloud moderation is admin-only** — no user \"Reportar\" button. Admin moderates from the panel.
- **Bingo wins are client-detected**: the participant writes \`bingoWonAt: serverTimestamp()\` themselves the first time a line completes. Trust + leaderboard simplicity for community events.
- **Alias / bingo card stay immutable** post-join — only \`bingoMarked\` and \`bingoWonAt\` can be self-updated, enforced by Firestore rules.

## Test plan

- [x] \`pnpm test\` — 74 root tests (8 \`bingo.ts\`, 11 \`wordcloud.ts\`, 6 \`BingoCardView\`, 7 \`WordCloudView\`, 4 \`WordModerationPanel\`, plus existing).
- [x] \`pnpm test:functions\` — 78 functions tests (5 \`minigameWords\` handler, plus existing).
- [x] \`pnpm test:rules\` — 29 rules tests (10 new for bingo self-marking + word writes, plus existing).
- [x] \`pnpm lint\`, \`pnpm build\`, \`cd functions && npm run build\` — clean.
- [ ] CI green.
- [ ] Smoke with emulators: attach wordcloud + bingo to a test event, activate both, open \`/eventos/{slug}?play=1\` in incognito, submit words, mark a row to win bingo, then in admin verify the moderation panel and winners list.