### PR TITLE
feat(event): poll + quiz realtime overlays for live mini-games

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -38,12 +38,15 @@ service cloud.firestore {
         match /participants/{participantUid} {
           allow read: if true;
           allow create: if false;
-          // Self-update limited to bingo marking. We use diff().affectedKeys()
-          // .hasOnly so the client cannot rewrite alias/joinedAt/bingoCard.
+          // Self-update limited to gameplay state. We use
+          // diff().affectedKeys().hasOnly so the client cannot rewrite
+          // alias/joinedAt/bingoCard. Bingo marking, bingo wins and
+          // quiz answer/score state share this rule.
           allow update: if request.auth != null
                         && request.auth.uid == participantUid
                         && request.resource.data.diff(resource.data).affectedKeys()
-                           .hasOnly(['bingoMarked', 'bingoWonAt'])
+                           .hasOnly(['bingoMarked', 'bingoWonAt',
+                                     'quizScore', 'quizAnsweredQuestions'])
                         && (!('bingoMarked' in request.resource.data)
                             || (request.resource.data.bingoMarked is list
                                 && request.resource.data.bingoMarked.size() == 16));
@@ -51,7 +54,20 @@ service cloud.firestore {
         }
         match /responses/{responseId} {
           allow read: if true;
-          allow write: if false;
+          // Realtime games (poll + quiz). Doc id is deterministic
+          // `${uid}_${questionId}` so 1 response per (user, question) is
+          // enforced at the rule level. Parent must be live + type
+          // poll|quiz, and the participant must already exist.
+          allow create: if request.auth != null
+                        && request.auth.uid == request.resource.data.uid
+                        && responseId == request.auth.uid + '_' + request.resource.data.questionId
+                        && get(/databases/$(database)/documents/events/$(eventSlug)/minigames/$(instanceId)).data.state == 'live'
+                        && (
+                             get(/databases/$(database)/documents/events/$(eventSlug)/minigames/$(instanceId)).data.type == 'poll'
+                             || get(/databases/$(database)/documents/events/$(eventSlug)/minigames/$(instanceId)).data.type == 'quiz'
+                           )
+                        && exists(/databases/$(database)/documents/events/$(eventSlug)/minigames/$(instanceId)/participants/$(request.auth.uid));
+          allow update, delete: if false;
         }
         match /words/{wordId} {
           allow read: if true;

--- a/functions/src/triggers/recomputeAggregates.test.ts
+++ b/functions/src/triggers/recomputeAggregates.test.ts
@@ -3,11 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // vi.mock is hoisted, so any vars used inside its factory must be declared
 // via vi.hoisted to share initialization order with the mock.
 const mocks = vi.hoisted(() => {
-  const setMock = vi.fn();
-  const docMock = vi.fn(() => ({ set: setMock }));
+  const docMock = vi.fn();
   const incrementMock = vi.fn((n: number) => ({ __increment: n }));
   const serverTsMock = vi.fn(() => "__SERVER_TS__");
-  return { setMock, docMock, incrementMock, serverTsMock };
+  return { docMock, incrementMock, serverTsMock };
 });
 
 vi.mock("firebase-admin", () => ({
@@ -26,7 +25,7 @@ vi.mock("firebase-functions/v2/firestore", () => ({
   onDocumentWritten: (_path: string, handler: unknown) => handler,
 }));
 
-const { setMock, docMock, incrementMock, serverTsMock } = mocks;
+const { docMock } = mocks;
 
 import {
   recomputeAggregatesFromEvent,
@@ -50,27 +49,75 @@ function createEvent(
   };
 }
 
+interface ParticipantFixture {
+  id: string;
+  alias?: string;
+  quizScore?: number;
+}
+
+interface WireResult {
+  aggregateSet: ReturnType<typeof vi.fn>;
+  participantsLimit: ReturnType<typeof vi.fn>;
+}
+
+function wire(options: {
+  instanceType?: string;
+  participants?: ParticipantFixture[];
+}): WireResult {
+  const aggregatePath =
+    "events/devfest-2025/minigames/instance-A/aggregates/current";
+  const instancePath = "events/devfest-2025/minigames/instance-A";
+
+  const aggregateSet = vi.fn(async () => undefined);
+  const aggregateRef = { set: aggregateSet };
+
+  const participantsGet = vi.fn(async () => ({
+    docs: (options.participants ?? []).map((p) => ({
+      id: p.id,
+      data: () => ({ alias: p.alias, quizScore: p.quizScore }),
+    })),
+  }));
+  const participantsLimit = vi.fn(() => ({ get: participantsGet }));
+  const participantsOrderBy = vi.fn(() => ({ limit: participantsLimit }));
+  const participantsCol = { orderBy: participantsOrderBy };
+  const instanceCollection = vi.fn((name: string) => {
+    if (name === "participants") return participantsCol;
+    throw new Error("unexpected nested collection " + name);
+  });
+  const instanceGet = vi.fn(async () => ({
+    data: () =>
+      options.instanceType ? { type: options.instanceType } : undefined,
+  }));
+  const instanceRef = {
+    get: instanceGet,
+    collection: instanceCollection,
+  };
+
+  docMock.mockImplementation((path: string) => {
+    if (path === aggregatePath) return aggregateRef;
+    if (path === instancePath) return instanceRef;
+    return undefined;
+  });
+
+  return { aggregateSet, participantsLimit };
+}
+
 describe("recomputeAggregatesFromEvent", () => {
   beforeEach(() => {
-    setMock.mockReset();
-    docMock.mockClear();
-    incrementMock.mockClear();
-    serverTsMock.mockClear();
+    docMock.mockReset();
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it("increments optionCounts and totalResponses on create", async () => {
+  it("increments optionCounts and totalResponses on create (poll)", async () => {
+    const wiring = wire({ instanceType: "poll" });
     await recomputeAggregatesFromEvent(
       createEvent({ questionId: "q1", optionId: "a" })
     );
-    expect(docMock).toHaveBeenCalledWith(
-      "events/devfest-2025/minigames/instance-A/aggregates/current"
-    );
-    expect(setMock).toHaveBeenCalledTimes(1);
-    const [payload, options] = setMock.mock.calls[0];
+    expect(wiring.aggregateSet).toHaveBeenCalledTimes(1);
+    const [payload, options] = wiring.aggregateSet.mock.calls[0];
     expect(payload.optionCounts["q1:a"]).toEqual({ __increment: 1 });
     expect(payload.totalResponses).toEqual({ __increment: 1 });
     expect(payload.updatedAt).toBe("__SERVER_TS__");
@@ -78,6 +125,7 @@ describe("recomputeAggregatesFromEvent", () => {
   });
 
   it("uses a separate counter per (question,option) pair", async () => {
+    const wiring = wire({ instanceType: "poll" });
     await recomputeAggregatesFromEvent(
       createEvent({ questionId: "q1", optionId: "a" })
     );
@@ -87,31 +135,101 @@ describe("recomputeAggregatesFromEvent", () => {
     await recomputeAggregatesFromEvent(
       createEvent({ questionId: "q2", optionId: "a" })
     );
-    const keys = setMock.mock.calls.map(
+    const keys = wiring.aggregateSet.mock.calls.map(
       (c) => Object.keys((c[0] as { optionCounts: object }).optionCounts)[0]
     );
     expect(keys).toEqual(["q1:a", "q1:b", "q2:a"]);
-    expect(setMock).toHaveBeenCalledTimes(3);
+    expect(wiring.aggregateSet).toHaveBeenCalledTimes(3);
   });
 
   it("ignores updates (before exists)", async () => {
+    const wiring = wire({ instanceType: "poll" });
     await recomputeAggregatesFromEvent(
       createEvent({ questionId: "q1", optionId: "a" }, { beforeExists: true })
     );
-    expect(setMock).not.toHaveBeenCalled();
+    expect(wiring.aggregateSet).not.toHaveBeenCalled();
   });
 
   it("ignores deletes (after does not exist)", async () => {
+    const wiring = wire({ instanceType: "poll" });
     await recomputeAggregatesFromEvent(
       createEvent(undefined, { afterExists: false })
     );
-    expect(setMock).not.toHaveBeenCalled();
+    expect(wiring.aggregateSet).not.toHaveBeenCalled();
   });
 
   it("ignores malformed responses missing questionId or optionId", async () => {
+    const wiring = wire({ instanceType: "poll" });
     await recomputeAggregatesFromEvent(createEvent({ questionId: "q1" }));
     await recomputeAggregatesFromEvent(createEvent({ optionId: "a" }));
     await recomputeAggregatesFromEvent(createEvent({}));
-    expect(setMock).not.toHaveBeenCalled();
+    expect(wiring.aggregateSet).not.toHaveBeenCalled();
+  });
+
+  it("does not write a leaderboard for poll instances", async () => {
+    const wiring = wire({ instanceType: "poll" });
+    await recomputeAggregatesFromEvent(
+      createEvent({ questionId: "q1", optionId: "a" })
+    );
+    expect(wiring.aggregateSet).toHaveBeenCalledTimes(1);
+    const payload = wiring.aggregateSet.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload.leaderboard).toBeUndefined();
+  });
+
+  it("rebuilds the leaderboard for quiz instances ordered by score desc", async () => {
+    const wiring = wire({
+      instanceType: "quiz",
+      participants: [
+        { id: "u1", alias: "Ana", quizScore: 300 },
+        { id: "u2", alias: "Bea", quizScore: 200 },
+        { id: "u3", alias: "Carlos", quizScore: 100 },
+      ],
+    });
+    await recomputeAggregatesFromEvent(
+      createEvent({ questionId: "q1", optionId: "a" })
+    );
+    expect(wiring.aggregateSet).toHaveBeenCalledTimes(2);
+    const leaderboardPayload = wiring.aggregateSet.mock.calls[1][0] as {
+      leaderboard: { uid: string; alias: string; score: number }[];
+    };
+    expect(leaderboardPayload.leaderboard).toEqual([
+      { uid: "u1", alias: "Ana", score: 300 },
+      { uid: "u2", alias: "Bea", score: 200 },
+      { uid: "u3", alias: "Carlos", score: 100 },
+    ]);
+  });
+
+  it("filters out participants with zero score from the leaderboard", async () => {
+    const wiring = wire({
+      instanceType: "quiz",
+      participants: [
+        { id: "u1", alias: "Ana", quizScore: 100 },
+        { id: "u2", alias: "Bea" }, // no score yet
+        { id: "u3", alias: "Zero", quizScore: 0 },
+      ],
+    });
+    await recomputeAggregatesFromEvent(
+      createEvent({ questionId: "q1", optionId: "a" })
+    );
+    const leaderboardPayload = wiring.aggregateSet.mock.calls[1][0] as {
+      leaderboard: unknown[];
+    };
+    expect(leaderboardPayload.leaderboard).toEqual([
+      { uid: "u1", alias: "Ana", score: 100 },
+    ]);
+  });
+
+  it("uses limit(10) when querying participants", async () => {
+    const wiring = wire({
+      instanceType: "quiz",
+      participants: [{ id: "u1", alias: "Ana", quizScore: 100 }],
+    });
+    await recomputeAggregatesFromEvent(
+      createEvent({ questionId: "q1", optionId: "a" })
+    );
+    expect(wiring.participantsLimit).toHaveBeenCalledWith(10);
   });
 });

--- a/functions/src/triggers/recomputeAggregates.ts
+++ b/functions/src/triggers/recomputeAggregates.ts
@@ -7,14 +7,18 @@ import * as admin from "firebase-admin";
 // raw responses collection — so this trigger absorbs the fan-out and caps
 // realtime read costs to 1 listener per game per phone.
 //
-// Implementation is intentionally O(1) per write: we use FieldValue.increment
-// and merge: true. PR6 will extend this trigger to also recompute the quiz
-// leaderboard (top N participants by score) — for now we just count votes
-// and total responses, which is what the poll/wordcloud overlays consume.
+// For poll responses we just bump optionCounts + totalResponses with
+// FieldValue.increment (O(1)). For quiz responses we additionally rebuild
+// the top-10 leaderboard by querying participants ordered by quizScore.
+// That extra query is bounded (limit 10) and only fires for quiz games,
+// so the cost stays well within the free tier even at ~200 attendees.
 //
-// Rule deletes responses are blocked, so we ignore the delete edge case
-// (no `before && !after`). For pure update events (also blocked by rules in
-// PR3+), we still no-op to avoid double-counting.
+// Rule deletes are blocked, so we ignore the delete edge case (no
+// `before && !after`). For pure update events (also blocked by rules)
+// we still no-op to avoid double-counting.
+
+const LEADERBOARD_LIMIT = 10;
+
 export interface ResponseWriteEvent {
   data?: {
     before?: { exists: boolean };
@@ -24,6 +28,16 @@ export interface ResponseWriteEvent {
     };
   };
   params: { slug: string; id: string };
+}
+
+interface ParticipantSnap {
+  id: string;
+  data: () =>
+    | {
+        alias?: string;
+        quizScore?: number;
+      }
+    | undefined;
 }
 
 // Inner handler — exported for unit tests so we can drive it with a synthetic
@@ -42,9 +56,11 @@ export async function recomputeAggregatesFromEvent(
   if (!data?.questionId || !data?.optionId) return;
 
   const { slug, id } = event.params;
-  const aggregateRef = admin
-    .firestore()
-    .doc(`events/${slug}/minigames/${id}/aggregates/current`);
+  const db = admin.firestore();
+  const instanceRef = db.doc(`events/${slug}/minigames/${id}`);
+  const aggregateRef = db.doc(
+    `events/${slug}/minigames/${id}/aggregates/current`
+  );
 
   const optionKey = `${data.questionId}:${data.optionId}`;
   await aggregateRef.set(
@@ -53,6 +69,36 @@ export async function recomputeAggregatesFromEvent(
         [optionKey]: admin.firestore.FieldValue.increment(1),
       },
       totalResponses: admin.firestore.FieldValue.increment(1),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+
+  // Quiz instances also keep a top-10 leaderboard in the same doc so
+  // spectators only need one listener.
+  const instanceSnap = await instanceRef.get();
+  if (instanceSnap.data()?.type !== "quiz") return;
+
+  const topSnap = await instanceRef
+    .collection("participants")
+    .orderBy("quizScore", "desc")
+    .limit(LEADERBOARD_LIMIT)
+    .get();
+
+  const leaderboard = (topSnap.docs as ParticipantSnap[])
+    .map((d) => {
+      const pd = d.data();
+      return {
+        uid: d.id,
+        alias: typeof pd?.alias === "string" ? pd.alias : "Anónimo",
+        score: typeof pd?.quizScore === "number" ? pd.quizScore : 0,
+      };
+    })
+    .filter((entry) => entry.score > 0);
+
+  await aggregateRef.set(
+    {
+      leaderboard,
       updatedAt: admin.firestore.FieldValue.serverTimestamp(),
     },
     { merge: true }

--- a/src/components/react/event/MiniGamesRoot.tsx
+++ b/src/components/react/event/MiniGamesRoot.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "@/lib/api";
 import { signInAnonymouslyIfNeeded } from "@/lib/firebase";
+import type { PollConfig, QuizConfig } from "../admin/minigame-templates/types";
 import { BingoCardView } from "./BingoCardView";
 import { JoinModal } from "./JoinModal";
+import { PollOverlay } from "./PollOverlay";
+import { QuizOverlay } from "./QuizOverlay";
 import { useLiveMinigames } from "./useLiveMinigames";
 import { WordCloudView } from "./WordCloudView";
 import { LOCAL_STORAGE_ALIAS_KEY, type LiveInstance } from "./types";
@@ -128,12 +131,22 @@ export function MiniGamesRoot({ slug }: Props) {
   );
 
   // Global games (wordcloud + bingo) play inline once the participant is
-  // joined. PR6 will add overlays for the realtime modes (poll + quiz),
-  // which are intentionally ignored here.
+  // joined. Realtime games (poll + quiz) render in a fixed overlay above
+  // the page so they grab attention as soon as the admin activates them.
   const globalLive = useMemo(
     () =>
       (liveInstances as LiveInstance[]).filter(
         (inst) => inst.mode === "global"
+      ),
+    [liveInstances]
+  );
+
+  const realtimeLive = useMemo(
+    () =>
+      (liveInstances as LiveInstance[]).filter(
+        // Skip realtime instances whose snapshotted config is missing —
+        // we'd render an empty overlay otherwise.
+        (inst) => inst.mode === "realtime" && inst.config !== undefined
       ),
     [liveInstances]
   );
@@ -203,6 +216,55 @@ export function MiniGamesRoot({ slug }: Props) {
             ))}
           </div>
         </section>
+      )}
+
+      {step === "joined" && uid && realtimeLive.length > 0 && (
+        <div
+          className="fixed inset-0 z-40 overflow-y-auto bg-black/70 p-4"
+          role="dialog"
+          aria-label="Juegos en tiempo real"
+        >
+          <div className="container my-8 space-y-6">
+            {realtimeLive.map((inst) => (
+              <div
+                key={inst.id}
+                className="rounded-2xl bg-white p-6 shadow-2xl dark:bg-gray-800"
+              >
+                {inst.type === "poll" && inst.config && (
+                  <PollOverlay
+                    slug={slug}
+                    instanceId={inst.id}
+                    uid={uid}
+                    alias={alias ?? "Anónimo"}
+                    title={inst.title}
+                    config={inst.config as unknown as PollConfig}
+                  />
+                )}
+                {inst.type === "quiz" && inst.config && (
+                  <QuizOverlay
+                    slug={slug}
+                    instanceId={inst.id}
+                    uid={uid}
+                    alias={alias ?? "Anónimo"}
+                    title={inst.title}
+                    config={inst.config as unknown as QuizConfig}
+                    currentQuestionIndex={inst.currentQuestionIndex ?? -1}
+                    currentQuestionStartedAt={
+                      (
+                        inst as unknown as {
+                          currentQuestionStartedAt?: {
+                            seconds: number;
+                            nanoseconds?: number;
+                          } | null;
+                        }
+                      ).currentQuestionStartedAt ?? null
+                    }
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
       )}
     </>
   );

--- a/src/components/react/event/PollOverlay.tsx
+++ b/src/components/react/event/PollOverlay.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from "react";
+import { getFirestore } from "@/lib/firebase";
+import type { PollConfig } from "../admin/minigame-templates/types";
+import { useAggregates } from "./useAggregates";
+
+interface Props {
+  slug: string;
+  instanceId: string;
+  uid: string;
+  alias: string;
+  title: string;
+  config: PollConfig;
+}
+
+const QUESTION_ID = "main";
+
+export function PollOverlay({ slug, instanceId, uid, title, config }: Props) {
+  const { aggregates } = useAggregates(slug, instanceId);
+  const [votedOptionId, setVotedOptionId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Detect if we already voted on this poll (e.g. after refresh) so the
+  // results view shows up immediately. Uses a one-shot getDoc instead of
+  // a listener — once set we never need to re-fetch.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const db = await getFirestore();
+        const { doc, getDoc } = await import("firebase/firestore");
+        const ref = doc(
+          db,
+          `events/${slug}/minigames/${instanceId}/responses/${uid}_${QUESTION_ID}`
+        );
+        const snap = await getDoc(ref);
+        if (cancelled) return;
+        if (snap.exists()) {
+          const data = snap.data() as { optionId?: string } | undefined;
+          if (data?.optionId) setVotedOptionId(data.optionId);
+        }
+      } catch {
+        // Listener errors are surfaced separately via aggregates; ignore here.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, instanceId, uid]);
+
+  const counts = aggregates?.optionCounts ?? {};
+  const totalForQuestion = config.options.reduce(
+    (sum, opt) => sum + (counts[`${QUESTION_ID}:${opt.id}`] ?? 0),
+    0
+  );
+
+  async function vote(optionId: string) {
+    if (votedOptionId || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const db = await getFirestore();
+      const { doc, setDoc, serverTimestamp } = await import(
+        "firebase/firestore"
+      );
+      const ref = doc(
+        db,
+        `events/${slug}/minigames/${instanceId}/responses/${uid}_${QUESTION_ID}`
+      );
+      await setDoc(ref, {
+        uid,
+        questionId: QUESTION_ID,
+        optionId,
+        answeredAt: serverTimestamp(),
+      });
+      setVotedOptionId(optionId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No pudimos enviar");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div>
+      <div className="mb-4">
+        <span className="rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+          Encuesta en vivo
+        </span>
+        <h2 className="text-primary mt-3 text-2xl font-semibold">{title}</h2>
+        <p className="text-secondary mt-1 text-base">{config.question}</p>
+      </div>
+
+      {error && (
+        <p className="mb-3 text-sm text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+
+      <ul className="space-y-2">
+        {config.options.map((opt) => {
+          const count = counts[`${QUESTION_ID}:${opt.id}`] ?? 0;
+          const pct =
+            totalForQuestion > 0
+              ? Math.round((count / totalForQuestion) * 100)
+              : 0;
+          const isMine = votedOptionId === opt.id;
+
+          if (votedOptionId) {
+            return (
+              <li
+                key={opt.id}
+                className="relative overflow-hidden rounded-lg border border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-800"
+              >
+                <div
+                  aria-hidden
+                  className={`absolute inset-y-0 left-0 transition-all ${
+                    isMine
+                      ? "bg-blue-500/30"
+                      : "bg-gray-300/40 dark:bg-gray-600/40"
+                  }`}
+                  style={{ width: `${pct}%` }}
+                />
+                <div className="relative flex items-center justify-between gap-3">
+                  <span className="font-medium text-gray-900 dark:text-white">
+                    {opt.label}
+                    {isMine && (
+                      <span className="ml-2 text-xs text-blue-600 dark:text-blue-300">
+                        Tu voto
+                      </span>
+                    )}
+                  </span>
+                  <span className="shrink-0 text-sm text-gray-700 tabular-nums dark:text-gray-300">
+                    {count} · {pct}%
+                  </span>
+                </div>
+              </li>
+            );
+          }
+
+          return (
+            <li key={opt.id}>
+              <button
+                type="button"
+                onClick={() => vote(opt.id)}
+                disabled={submitting}
+                className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-left font-medium text-gray-900 transition hover:border-blue-500 hover:bg-blue-50 disabled:opacity-50 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+              >
+                {opt.label}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {votedOptionId && (
+        <p className="mt-4 text-center text-xs text-gray-500 dark:text-gray-400">
+          {totalForQuestion} respuesta{totalForQuestion !== 1 && "s"} hasta
+          ahora
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/react/event/QuizOverlay.tsx
+++ b/src/components/react/event/QuizOverlay.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useMemo, useState } from "react";
+import { getFirestore } from "@/lib/firebase";
+import type { QuizConfig } from "../admin/minigame-templates/types";
+import { useAggregates } from "./useAggregates";
+import { useParticipantDoc } from "./useParticipantDoc";
+
+interface Props {
+  slug: string;
+  instanceId: string;
+  uid: string;
+  alias: string;
+  title: string;
+  config: QuizConfig;
+  currentQuestionIndex: number;
+  // Server timestamp arrives as `{ seconds, nanoseconds }`. Optional because
+  // it is null while the quiz is still on the "Esperando inicio" state.
+  currentQuestionStartedAt?:
+    | { seconds: number; nanoseconds?: number }
+    | null
+    | undefined;
+}
+
+function timestampToMillis(
+  ts: Props["currentQuestionStartedAt"]
+): number | null {
+  if (!ts) return null;
+  if (typeof ts.seconds !== "number") return null;
+  return ts.seconds * 1000 + Math.floor((ts.nanoseconds ?? 0) / 1_000_000);
+}
+
+export function QuizOverlay({
+  slug,
+  instanceId,
+  uid,
+  title,
+  config,
+  currentQuestionIndex,
+  currentQuestionStartedAt,
+}: Props) {
+  const { doc: participant } = useParticipantDoc(slug, instanceId, uid);
+  const { aggregates } = useAggregates(slug, instanceId);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  const question = useMemo(() => {
+    if (currentQuestionIndex < 0) return null;
+    return config.questions[currentQuestionIndex] ?? null;
+  }, [config.questions, currentQuestionIndex]);
+
+  // Tick the clock so the visible countdown updates without the
+  // surrounding tree re-rendering. 250ms keeps it smooth without burning
+  // cycles.
+  useEffect(() => {
+    if (!question) return;
+    const id = window.setInterval(() => setNow(Date.now()), 250);
+    return () => window.clearInterval(id);
+  }, [question]);
+
+  const startedAtMs = timestampToMillis(currentQuestionStartedAt);
+  const elapsedMs = startedAtMs ? Math.max(0, now - startedAtMs) : 0;
+  const limitMs = (question?.timeLimitSec ?? 0) * 1000;
+  const remainingMs = startedAtMs ? Math.max(0, limitMs - elapsedMs) : limitMs;
+  const remainingSec = Math.ceil(remainingMs / 1000);
+  const timerExpired = startedAtMs !== null && remainingMs === 0;
+
+  const answered = Boolean(
+    question && participant?.quizAnsweredQuestions?.includes(question.id)
+  );
+
+  const counts = aggregates?.optionCounts ?? {};
+  const totalForQuestion = question
+    ? question.options.reduce(
+        (sum, opt) => sum + (counts[`${question.id}:${opt.id}`] ?? 0),
+        0
+      )
+    : 0;
+  const showResults = answered || timerExpired;
+  const leaderboard = aggregates?.leaderboard ?? [];
+
+  async function answer(optionId: string) {
+    if (!question || answered || submitting || timerExpired) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const isCorrect = optionId === question.correctOptionId;
+      const pointsEarned = isCorrect ? question.points : 0;
+      const db = await getFirestore();
+      const { arrayUnion, doc, increment, serverTimestamp, setDoc } =
+        await import("firebase/firestore");
+      const responseRef = doc(
+        db,
+        `events/${slug}/minigames/${instanceId}/responses/${uid}_${question.id}`
+      );
+      const participantRef = doc(
+        db,
+        `events/${slug}/minigames/${instanceId}/participants/${uid}`
+      );
+      await setDoc(responseRef, {
+        uid,
+        questionId: question.id,
+        optionId,
+        isCorrect,
+        pointsEarned,
+        answeredAt: serverTimestamp(),
+      });
+      await setDoc(
+        participantRef,
+        {
+          quizScore: increment(pointsEarned),
+          quizAnsweredQuestions: arrayUnion(question.id),
+        },
+        { merge: true }
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No pudimos enviar");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!question) {
+    return (
+      <div className="text-center">
+        <span className="rounded-full bg-purple-100 px-3 py-1 text-xs font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-300">
+          Quiz
+        </span>
+        <h2 className="text-primary mt-3 text-2xl font-semibold">{title}</h2>
+        <p className="text-secondary mt-2">
+          Esperando que el organizador inicie la primera pregunta...
+        </p>
+        {participant?.quizScore !== undefined && participant.quizScore > 0 && (
+          <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+            Tu puntuación: <strong>{participant.quizScore}</strong>
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between">
+        <span className="rounded-full bg-purple-100 px-3 py-1 text-xs font-medium text-purple-700 dark:bg-purple-900/30 dark:text-purple-300">
+          Pregunta {currentQuestionIndex + 1} / {config.questions.length}
+        </span>
+        <span
+          className={`text-sm font-semibold tabular-nums ${
+            remainingSec <= 5
+              ? "text-red-600 dark:text-red-400"
+              : "text-gray-700 dark:text-gray-300"
+          }`}
+          aria-label="Tiempo restante"
+        >
+          {remainingSec}s
+        </span>
+      </div>
+      <h2 className="text-primary mb-4 text-2xl font-semibold">{title}</h2>
+      <p className="text-secondary mb-4 text-base">{question.prompt}</p>
+
+      {error && (
+        <p className="mb-3 text-sm text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+
+      <ul className="space-y-2">
+        {question.options.map((opt) => {
+          const count = counts[`${question.id}:${opt.id}`] ?? 0;
+          const pct =
+            totalForQuestion > 0
+              ? Math.round((count / totalForQuestion) * 100)
+              : 0;
+          const isCorrect = opt.id === question.correctOptionId;
+
+          if (showResults) {
+            return (
+              <li
+                key={opt.id}
+                className={`relative overflow-hidden rounded-lg border px-4 py-3 ${
+                  isCorrect
+                    ? "border-green-500 bg-white dark:border-green-400 dark:bg-gray-800"
+                    : "border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+                }`}
+              >
+                <div
+                  aria-hidden
+                  className={`absolute inset-y-0 left-0 transition-all ${
+                    isCorrect
+                      ? "bg-green-500/30"
+                      : "bg-gray-300/40 dark:bg-gray-600/40"
+                  }`}
+                  style={{ width: `${pct}%` }}
+                />
+                <div className="relative flex items-center justify-between gap-3">
+                  <span className="font-medium text-gray-900 dark:text-white">
+                    {opt.label}
+                    {isCorrect && (
+                      <span className="ml-2 text-xs text-green-700 dark:text-green-300">
+                        Correcto
+                      </span>
+                    )}
+                  </span>
+                  <span className="shrink-0 text-sm text-gray-700 tabular-nums dark:text-gray-300">
+                    {count} · {pct}%
+                  </span>
+                </div>
+              </li>
+            );
+          }
+
+          return (
+            <li key={opt.id}>
+              <button
+                type="button"
+                onClick={() => answer(opt.id)}
+                disabled={submitting || answered || timerExpired}
+                className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-left font-medium text-gray-900 transition hover:border-purple-500 hover:bg-purple-50 disabled:opacity-50 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+              >
+                {opt.label}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {participant?.quizScore !== undefined && (
+        <p className="mt-4 text-center text-sm text-gray-700 dark:text-gray-300">
+          Tu puntuación: <strong>{participant.quizScore}</strong>
+        </p>
+      )}
+
+      {leaderboard.length > 0 && (
+        <div className="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/30">
+          <p className="mb-2 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+            Top 10
+          </p>
+          <ol className="space-y-1">
+            {leaderboard.map((entry, i) => (
+              <li
+                key={entry.uid}
+                className={`flex items-center justify-between text-sm ${
+                  entry.uid === uid
+                    ? "font-semibold text-purple-700 dark:text-purple-300"
+                    : "text-gray-700 dark:text-gray-300"
+                }`}
+              >
+                <span>
+                  {i + 1}. {entry.alias}
+                  {entry.uid === uid && " (tú)"}
+                </span>
+                <span className="tabular-nums">{entry.score}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/react/event/__tests__/PollOverlay.test.tsx
+++ b/src/components/react/event/__tests__/PollOverlay.test.tsx
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mocks = vi.hoisted(() => ({
+  getFirestore: vi.fn(),
+  doc: vi.fn(() => ({ __ref: true })),
+  setDoc: vi.fn(),
+  getDoc: vi.fn(),
+  serverTimestamp: vi.fn(() => "__TS__"),
+  useAggregates: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  getFirestore: mocks.getFirestore,
+}));
+
+vi.mock("firebase/firestore", () => ({
+  doc: mocks.doc,
+  setDoc: mocks.setDoc,
+  getDoc: mocks.getDoc,
+  serverTimestamp: mocks.serverTimestamp,
+}));
+
+vi.mock("../useAggregates", () => ({
+  useAggregates: mocks.useAggregates,
+}));
+
+import { PollOverlay } from "../PollOverlay";
+
+const CONFIG = {
+  question: "¿Cuál prefieres?",
+  options: [
+    { id: "a", label: "Opción A" },
+    { id: "b", label: "Opción B" },
+  ],
+};
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) {
+    if (
+      typeof (m as unknown as { mockReset?: () => void }).mockReset ===
+      "function"
+    ) {
+      (m as unknown as { mockReset: () => void }).mockReset();
+    }
+  }
+  mocks.getFirestore.mockResolvedValue({});
+  mocks.doc.mockImplementation(() => ({ __ref: true }));
+  mocks.setDoc.mockResolvedValue(undefined);
+  mocks.getDoc.mockResolvedValue({ exists: () => false });
+  mocks.serverTimestamp.mockReturnValue("__TS__");
+  mocks.useAggregates.mockReturnValue({
+    aggregates: null,
+    loading: false,
+    error: null,
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("PollOverlay", () => {
+  it("renders the question and clickable options", () => {
+    render(
+      <PollOverlay
+        slug="x"
+        instanceId="i"
+        uid="u"
+        alias="Ana"
+        title="Mi encuesta"
+        config={CONFIG}
+      />
+    );
+    expect(screen.getByText("Mi encuesta")).toBeInTheDocument();
+    expect(screen.getByText("¿Cuál prefieres?")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Opción A/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Opción B/ })
+    ).toBeInTheDocument();
+  });
+
+  it("submits a vote via setDoc with the deterministic doc id", async () => {
+    const user = userEvent.setup();
+    render(
+      <PollOverlay
+        slug="evt"
+        instanceId="inst"
+        uid="user-1"
+        alias="Ana"
+        title="t"
+        config={CONFIG}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /Opción A/ }));
+    await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(1));
+    const payload = mocks.setDoc.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      uid: "user-1",
+      questionId: "main",
+      optionId: "a",
+      answeredAt: "__TS__",
+    });
+  });
+
+  it("does not submit twice when the user double-taps", async () => {
+    mocks.setDoc.mockImplementation(
+      () => new Promise((r) => setTimeout(() => r(undefined), 50))
+    );
+    const user = userEvent.setup();
+    render(
+      <PollOverlay
+        slug="x"
+        instanceId="i"
+        uid="u"
+        alias="Ana"
+        title="t"
+        config={CONFIG}
+      />
+    );
+    const btn = screen.getByRole("button", { name: /Opción A/ });
+    await user.click(btn);
+    await user.click(btn);
+    await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(1));
+  });
+
+  it("locks the UI to results once a vote is recorded", async () => {
+    mocks.useAggregates.mockReturnValue({
+      aggregates: {
+        optionCounts: { "main:a": 3, "main:b": 1 },
+        totalResponses: 4,
+      },
+      loading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(
+      <PollOverlay
+        slug="x"
+        instanceId="i"
+        uid="u"
+        alias="Ana"
+        title="t"
+        config={CONFIG}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /Opción A/ }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /Opción B/ })
+      ).not.toBeInTheDocument()
+    );
+    expect(screen.getByText("Tu voto")).toBeInTheDocument();
+    // Result rows show counts + percentages.
+    expect(screen.getByText(/3 · 75%/)).toBeInTheDocument();
+    expect(screen.getByText(/1 · 25%/)).toBeInTheDocument();
+  });
+
+  it("shows results immediately if the user already voted before mount", async () => {
+    mocks.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ optionId: "b" }),
+    });
+    mocks.useAggregates.mockReturnValue({
+      aggregates: { optionCounts: { "main:b": 2 }, totalResponses: 2 },
+      loading: false,
+      error: null,
+    });
+    render(
+      <PollOverlay
+        slug="x"
+        instanceId="i"
+        uid="u"
+        alias="Ana"
+        title="t"
+        config={CONFIG}
+      />
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /Opción A/ })
+      ).not.toBeInTheDocument()
+    );
+    expect(screen.getByText("Tu voto")).toBeInTheDocument();
+  });
+});

--- a/src/components/react/event/__tests__/QuizOverlay.test.tsx
+++ b/src/components/react/event/__tests__/QuizOverlay.test.tsx
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mocks = vi.hoisted(() => ({
+  getFirestore: vi.fn(),
+  doc: vi.fn(() => ({ __ref: true })),
+  setDoc: vi.fn(),
+  serverTimestamp: vi.fn(() => "__TS__"),
+  increment: vi.fn((n: number) => ({ __increment: n })),
+  arrayUnion: vi.fn((value: string) => ({ __arrayUnion: value })),
+  useAggregates: vi.fn(),
+  useParticipantDoc: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  getFirestore: mocks.getFirestore,
+}));
+
+vi.mock("firebase/firestore", () => ({
+  doc: mocks.doc,
+  setDoc: mocks.setDoc,
+  serverTimestamp: mocks.serverTimestamp,
+  increment: mocks.increment,
+  arrayUnion: mocks.arrayUnion,
+}));
+
+vi.mock("../useAggregates", () => ({
+  useAggregates: mocks.useAggregates,
+}));
+
+vi.mock("../useParticipantDoc", () => ({
+  useParticipantDoc: mocks.useParticipantDoc,
+}));
+
+import { QuizOverlay } from "../QuizOverlay";
+
+const QUIZ_CONFIG = {
+  questions: [
+    {
+      id: "q1",
+      prompt: "¿Cuál es multimodal?",
+      options: [
+        { id: "a", label: "Gemini" },
+        { id: "b", label: "GPT-2" },
+      ],
+      correctOptionId: "a",
+      timeLimitSec: 30,
+      points: 100,
+    },
+    {
+      id: "q2",
+      prompt: "¿Qué significa RAG?",
+      options: [
+        { id: "a", label: "Retrieval Augmented Generation" },
+        { id: "b", label: "Random Arbitrary Generator" },
+      ],
+      correctOptionId: "a",
+      timeLimitSec: 30,
+      points: 100,
+    },
+  ],
+};
+
+const NOW_MS = 1_700_000_000_000;
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) {
+    if (
+      typeof (m as unknown as { mockReset?: () => void }).mockReset ===
+      "function"
+    ) {
+      (m as unknown as { mockReset: () => void }).mockReset();
+    }
+  }
+  mocks.getFirestore.mockResolvedValue({});
+  mocks.doc.mockImplementation(() => ({ __ref: true }));
+  mocks.setDoc.mockResolvedValue(undefined);
+  mocks.serverTimestamp.mockReturnValue("__TS__");
+  mocks.increment.mockImplementation((n: number) => ({ __increment: n }));
+  mocks.arrayUnion.mockImplementation((value: string) => ({
+    __arrayUnion: value,
+  }));
+  mocks.useAggregates.mockReturnValue({
+    aggregates: null,
+    loading: false,
+    error: null,
+  });
+  mocks.useParticipantDoc.mockReturnValue({
+    doc: { uid: "u1", alias: "Ana" },
+    loading: false,
+    error: null,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+// Helper used by tests that need a fixed clock (timer-related assertions).
+// Tests that simulate user interactions skip this so userEvent's internal
+// timers stay on the real clock.
+function pinClock(toMs: number) {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(new Date(toMs));
+}
+
+describe("QuizOverlay", () => {
+  it("renders the waiting state when currentQuestionIndex is -1", () => {
+    render(
+      <QuizOverlay
+        slug="x"
+        instanceId="i"
+        uid="u1"
+        alias="Ana"
+        title="Mini quiz"
+        config={QUIZ_CONFIG}
+        currentQuestionIndex={-1}
+      />
+    );
+    expect(
+      screen.getByText(/Esperando que el organizador/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the current question with countdown", () => {
+    pinClock(NOW_MS);
+    const startedAtMs = NOW_MS - 5000; // 5s elapsed
+    render(
+      <QuizOverlay
+        slug="x"
+        instanceId="i"
+        uid="u1"
+        alias="Ana"
+        title="Mini quiz"
+        config={QUIZ_CONFIG}
+        currentQuestionIndex={0}
+        currentQuestionStartedAt={{ seconds: startedAtMs / 1000 }}
+      />
+    );
+    expect(screen.getByText("¿Cuál es multimodal?")).toBeInTheDocument();
+    expect(screen.getByText(/Pregunta 1 \/ 2/)).toBeInTheDocument();
+    // 30s limit - 5s elapsed = 25s remaining.
+    expect(screen.getByLabelText(/Tiempo restante/)).toHaveTextContent("25s");
+  });
+
+  it("submits the answer and updates participant doc", async () => {
+    const user = userEvent.setup();
+    render(
+      <QuizOverlay
+        slug="evt"
+        instanceId="inst"
+        uid="user-1"
+        alias="Ana"
+        title="t"
+        config={QUIZ_CONFIG}
+        currentQuestionIndex={0}
+        currentQuestionStartedAt={{ seconds: Date.now() / 1000 }}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /Gemini/ }));
+    await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(2));
+    const responsePayload = mocks.setDoc.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(responsePayload).toMatchObject({
+      uid: "user-1",
+      questionId: "q1",
+      optionId: "a",
+      isCorrect: true,
+      pointsEarned: 100,
+    });
+    const participantPayload = mocks.setDoc.mock.calls[1][1] as Record<
+      string,
+      unknown
+    >;
+    expect(participantPayload).toMatchObject({
+      quizScore: { __increment: 100 },
+      quizAnsweredQuestions: { __arrayUnion: "q1" },
+    });
+    const participantOptions = mocks.setDoc.mock.calls[1][2] as {
+      merge?: boolean;
+    };
+    expect(participantOptions).toEqual({ merge: true });
+  });
+
+  it("awards 0 points on incorrect answer", async () => {
+    const user = userEvent.setup();
+    render(
+      <QuizOverlay
+        slug="x"
+        instanceId="i"
+        uid="u"
+        alias="Ana"
+        title="t"
+        config={QUIZ_CONFIG}
+        currentQuestionIndex={0}
+        currentQuestionStartedAt={{ seconds: Date.now() / 1000 }}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /GPT-2/ }));
+    await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(2));
+    const responsePayload = mocks.setDoc.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    expect(responsePayload.isCorrect).toBe(false);
+    expect(responsePayload.pointsEarned).toBe(0);
+  });
+
+  it("locks options when the participant has already answered the question", () => {
+    pinClock(NOW_MS);
+    mocks.useParticipantDoc.mockReturnValue({
+      doc: {
+        uid: "u",
+        alias: "Ana",
+        quizAnsweredQuestions: ["q1"],
+        quizScore: 100,
+      },
+      loading: false,
+      error: null,
+    });
+    render(
+      <QuizOverlay
+        slug="x"
+        instanceId="i"
+        uid="u"
+        alias="Ana"
+        title="t"
+        config={QUIZ_CONFIG}
+        currentQuestionIndex={0}
+        currentQuestionStartedAt={{ seconds: NOW_MS / 1000 }}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /Gemini/ })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/Correcto/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tu puntuación/i)).toHaveTextContent("100");
+  });
+
+  it("locks options and shows results once the timer expires", () => {
+    pinClock(NOW_MS);
+    const startedAtMs = NOW_MS - 31_000; // already past 30s limit
+    render(
+      <QuizOverlay
+        slug="x"
+        instanceId="i"
+        uid="u"
+        alias="Ana"
+        title="t"
+        config={QUIZ_CONFIG}
+        currentQuestionIndex={0}
+        currentQuestionStartedAt={{ seconds: startedAtMs / 1000 }}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /Gemini/ })
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/Tiempo restante/)).toHaveTextContent("0s");
+  });
+
+  it("renders the leaderboard when aggregates include one", () => {
+    pinClock(NOW_MS);
+    mocks.useAggregates.mockReturnValue({
+      aggregates: {
+        leaderboard: [
+          { uid: "u1", alias: "Ana", score: 200 },
+          { uid: "u2", alias: "Bea", score: 100 },
+        ],
+      },
+      loading: false,
+      error: null,
+    });
+    render(
+      <QuizOverlay
+        slug="x"
+        instanceId="i"
+        uid="u1"
+        alias="Ana"
+        title="t"
+        config={QUIZ_CONFIG}
+        currentQuestionIndex={0}
+        currentQuestionStartedAt={{ seconds: NOW_MS / 1000 }}
+      />
+    );
+    expect(screen.getByText(/1\. Ana \(tú\)/)).toBeInTheDocument();
+    expect(screen.getByText(/2\. Bea/)).toBeInTheDocument();
+  });
+});
+
+// silence unused-import warning when pinClock isn't used by every block
+void pinClock;

--- a/src/components/react/event/useAggregates.ts
+++ b/src/components/react/event/useAggregates.ts
@@ -1,41 +1,42 @@
 import { useEffect, useState } from "react";
 import { getFirestore } from "@/lib/firebase";
 
-export interface ParticipantDoc {
+export interface LeaderboardEntry {
   uid: string;
   alias: string;
-  bingoCard?: string[];
-  bingoMarked?: boolean[];
-  bingoWonAt?: { seconds: number } | null;
-  quizScore?: number;
-  quizAnsweredQuestions?: string[];
+  score: number;
+}
+
+export interface AggregatesDoc {
+  optionCounts?: Record<string, number>;
+  totalResponses?: number;
+  leaderboard?: LeaderboardEntry[];
+  updatedAt?: { seconds: number } | null;
 }
 
 interface State {
-  doc: ParticipantDoc | null;
+  aggregates: AggregatesDoc | null;
   loading: boolean;
   error: string | null;
 }
 
-// Subscribes to events/{slug}/minigames/{instanceId}/participants/{uid}
-// in real time. Returns null doc until the first snapshot arrives or if
-// the participant has not joined yet (the rules allow public reads, so
-// this works for everyone — the spectator badge in MiniGamesRoot also
-// consumes it).
-export function useParticipantDoc(
+// Subscribes to events/{slug}/minigames/{instanceId}/aggregates/current,
+// the single doc that the recomputeAggregates trigger maintains. Used by
+// the realtime overlays (poll bars, quiz leaderboard) and by the projector
+// view. Caps spectator reads to 1 listener per game per phone.
+export function useAggregates(
   slug: string | null,
-  instanceId: string | null,
-  uid: string | null
+  instanceId: string | null
 ): State {
   const [state, setState] = useState<State>({
-    doc: null,
+    aggregates: null,
     loading: true,
     error: null,
   });
 
   useEffect(() => {
-    if (!slug || !instanceId || !uid) {
-      setState({ doc: null, loading: false, error: null });
+    if (!slug || !instanceId) {
+      setState({ aggregates: null, loading: false, error: null });
       return;
     }
     let unsub: (() => void) | null = null;
@@ -48,28 +49,32 @@ export function useParticipantDoc(
         if (cancelled) return;
         const ref = doc(
           db,
-          `events/${slug}/minigames/${instanceId}/participants/${uid}`
+          `events/${slug}/minigames/${instanceId}/aggregates/current`
         );
         unsub = onSnapshot(
           ref,
           (snap) => {
             if (!snap.exists()) {
-              setState({ doc: null, loading: false, error: null });
+              setState({ aggregates: null, loading: false, error: null });
               return;
             }
             setState({
-              doc: { uid, ...(snap.data() as Omit<ParticipantDoc, "uid">) },
+              aggregates: snap.data() as AggregatesDoc,
               loading: false,
               error: null,
             });
           },
           (err) => {
-            setState({ doc: null, loading: false, error: err.message });
+            setState({
+              aggregates: null,
+              loading: false,
+              error: err.message,
+            });
           }
         );
       } catch (err) {
         setState({
-          doc: null,
+          aggregates: null,
           loading: false,
           error: err instanceof Error ? err.message : "Listener error",
         });
@@ -80,7 +85,7 @@ export function useParticipantDoc(
       cancelled = true;
       if (unsub) unsub();
     };
-  }, [slug, instanceId, uid]);
+  }, [slug, instanceId]);
 
   return state;
 }

--- a/tests/rules/minigame-instances.test.ts
+++ b/tests/rules/minigame-instances.test.ts
@@ -406,3 +406,328 @@ describe("firestore.rules — PR5 word submissions", () => {
     );
   });
 });
+
+// ---- PR6 rules: response writes for poll/quiz + quiz score self-update ----
+
+const POLL_INSTANCE_ID = "instance-poll";
+const QUIZ_INSTANCE_ID = "instance-quiz";
+
+const POLL_INSTANCE = {
+  eventSlug: SLUG,
+  templateId: "tpl-poll",
+  templateVersion: 1,
+  type: "poll",
+  mode: "realtime",
+  state: "live",
+  title: "Sample poll",
+  config: { question: "Q?", options: [] },
+  order: 2,
+  createdBy: "admin-uid",
+  createdAt: 0,
+};
+
+const QUIZ_INSTANCE = {
+  eventSlug: SLUG,
+  templateId: "tpl-quiz",
+  templateVersion: 1,
+  type: "quiz",
+  mode: "realtime",
+  state: "live",
+  title: "Sample quiz",
+  config: { questions: [] },
+  order: 3,
+  createdBy: "admin-uid",
+  createdAt: 0,
+};
+
+async function seedRealtimeState(
+  env: Awaited<ReturnType<typeof getTestEnv>>,
+  options: {
+    instanceId: string;
+    instance: Record<string, unknown>;
+    participantUid?: string;
+  }
+) {
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    await setDoc(
+      doc(db, `events/${SLUG}/minigames/${options.instanceId}`),
+      options.instance
+    );
+    if (options.participantUid) {
+      await setDoc(
+        doc(
+          db,
+          `events/${SLUG}/minigames/${options.instanceId}/participants/${options.participantUid}`
+        ),
+        {
+          uid: options.participantUid,
+          alias: "tester",
+          joinedAt: 0,
+        }
+      );
+    }
+  });
+}
+
+describe("firestore.rules — PR6 response writes", () => {
+  beforeAll(async () => {
+    await getTestEnv();
+  });
+
+  afterEach(async () => {
+    await clearAll();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it("allows a joined participant to vote on a live poll", async () => {
+    const env = await getTestEnv();
+    await seedRealtimeState(env, {
+      instanceId: POLL_INSTANCE_ID,
+      instance: POLL_INSTANCE,
+      participantUid: "user-1",
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertSucceeds(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${POLL_INSTANCE_ID}/responses/user-1_main`
+        ),
+        { uid: "user-1", questionId: "main", optionId: "a" }
+      )
+    );
+  });
+
+  it("allows a joined participant to vote on a live quiz question", async () => {
+    const env = await getTestEnv();
+    await seedRealtimeState(env, {
+      instanceId: QUIZ_INSTANCE_ID,
+      instance: QUIZ_INSTANCE,
+      participantUid: "user-1",
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertSucceeds(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${QUIZ_INSTANCE_ID}/responses/user-1_q1`
+        ),
+        {
+          uid: "user-1",
+          questionId: "q1",
+          optionId: "a",
+          isCorrect: true,
+          pointsEarned: 100,
+        }
+      )
+    );
+  });
+
+  it("rejects responses with a uid different from auth", async () => {
+    const env = await getTestEnv();
+    await seedRealtimeState(env, {
+      instanceId: POLL_INSTANCE_ID,
+      instance: POLL_INSTANCE,
+      participantUid: "user-1",
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${POLL_INSTANCE_ID}/responses/user-2_main`
+        ),
+        { uid: "user-2", questionId: "main", optionId: "a" }
+      )
+    );
+  });
+
+  it("rejects responses whose doc id does not follow ${uid}_${questionId}", async () => {
+    const env = await getTestEnv();
+    await seedRealtimeState(env, {
+      instanceId: POLL_INSTANCE_ID,
+      instance: POLL_INSTANCE,
+      participantUid: "user-1",
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${POLL_INSTANCE_ID}/responses/user-1_DIFFERENT`
+        ),
+        { uid: "user-1", questionId: "main", optionId: "a" }
+      )
+    );
+  });
+
+  it("rejects responses on closed instances", async () => {
+    const env = await getTestEnv();
+    await seedRealtimeState(env, {
+      instanceId: POLL_INSTANCE_ID,
+      instance: { ...POLL_INSTANCE, state: "closed" },
+      participantUid: "user-1",
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${POLL_INSTANCE_ID}/responses/user-1_main`
+        ),
+        { uid: "user-1", questionId: "main", optionId: "a" }
+      )
+    );
+  });
+
+  it("rejects responses on non-poll/quiz instances", async () => {
+    const env = await getTestEnv();
+    await seedRealtimeState(env, {
+      instanceId: POLL_INSTANCE_ID,
+      instance: { ...POLL_INSTANCE, type: "wordcloud" },
+      participantUid: "user-1",
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${POLL_INSTANCE_ID}/responses/user-1_main`
+        ),
+        { uid: "user-1", questionId: "main", optionId: "a" }
+      )
+    );
+  });
+
+  it("rejects responses when participant doc is missing", async () => {
+    const env = await getTestEnv();
+    await seedRealtimeState(env, {
+      instanceId: POLL_INSTANCE_ID,
+      instance: POLL_INSTANCE,
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${POLL_INSTANCE_ID}/responses/user-1_main`
+        ),
+        { uid: "user-1", questionId: "main", optionId: "a" }
+      )
+    );
+  });
+
+  it("rejects updates and deletes on existing responses", async () => {
+    const env = await getTestEnv();
+    await seedRealtimeState(env, {
+      instanceId: POLL_INSTANCE_ID,
+      instance: POLL_INSTANCE,
+      participantUid: "user-1",
+    });
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(
+          ctx.firestore(),
+          `events/${SLUG}/minigames/${POLL_INSTANCE_ID}/responses/user-1_main`
+        ),
+        { uid: "user-1", questionId: "main", optionId: "a" }
+      );
+    });
+    const auth = env.authenticatedContext("user-1").firestore();
+    // Update.
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${POLL_INSTANCE_ID}/responses/user-1_main`
+        ),
+        { uid: "user-1", questionId: "main", optionId: "b" }
+      )
+    );
+  });
+});
+
+describe("firestore.rules — PR6 quiz score self-update", () => {
+  beforeAll(async () => {
+    await getTestEnv();
+  });
+
+  afterEach(async () => {
+    await clearAll();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  async function seedParticipant(
+    env: Awaited<ReturnType<typeof getTestEnv>>,
+    uid = "user-1"
+  ) {
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, `events/${SLUG}/minigames/${QUIZ_INSTANCE_ID}`), {
+        ...QUIZ_INSTANCE,
+      });
+      await setDoc(
+        doc(
+          db,
+          `events/${SLUG}/minigames/${QUIZ_INSTANCE_ID}/participants/${uid}`
+        ),
+        { uid, alias: "Ana", joinedAt: 0 }
+      );
+    });
+  }
+
+  it("allows the owner to merge quizScore + quizAnsweredQuestions", async () => {
+    const env = await getTestEnv();
+    await seedParticipant(env);
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertSucceeds(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${QUIZ_INSTANCE_ID}/participants/user-1`
+        ),
+        { quizScore: 100, quizAnsweredQuestions: ["q1"] },
+        { merge: true }
+      )
+    );
+  });
+
+  it("rejects another user updating quizScore for a stranger", async () => {
+    const env = await getTestEnv();
+    await seedParticipant(env);
+    const stranger = env.authenticatedContext("user-2").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          stranger,
+          `events/${SLUG}/minigames/${QUIZ_INSTANCE_ID}/participants/user-1`
+        ),
+        { quizScore: 9999 },
+        { merge: true }
+      )
+    );
+  });
+
+  it("rejects updates that try to overwrite alias alongside quizScore", async () => {
+    const env = await getTestEnv();
+    await seedParticipant(env);
+    const auth = env.authenticatedContext("user-1").firestore();
+    await assertFails(
+      setDoc(
+        doc(
+          auth,
+          `events/${SLUG}/minigames/${QUIZ_INSTANCE_ID}/participants/user-1`
+        ),
+        { alias: "Hacked", quizScore: 9999 },
+        { merge: true }
+      )
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Activates realtime gameplay. When an admin sets a poll or quiz instance to \`state=live\`, every connected attendee sees a full-screen overlay with the question. Votes are written client-direct under Firestore rules; the aggregates trigger keeps a single doc with counts and (for quiz) a top-10 leaderboard so spectators only need one listener per game.

## What's new

### Public-side
- **\`PollOverlay\`** — subscribes to \`aggregates/current\` via the new \`useAggregates\` hook, lets the participant pick an option, then flips to a results view with proportion bars and the user's pick highlighted. Detects existing votes on mount via \`getDoc\` so a refresh lands directly on results.
- **\`QuizOverlay\`** — derives time remaining from \`currentQuestionStartedAt + timeLimitSec\`, locks options once answered (via \`quizAnsweredQuestions\` on the participant doc) or when the timer expires, and renders the live leaderboard between questions. Score change is written client-side via two writes: the response doc (with \`isCorrect\` + \`pointsEarned\`) and a merge update on the participant doc using \`FieldValue.increment\` + \`arrayUnion\`. Scoring is straight points: correct = \`template.points\`, incorrect = 0.
- **\`MiniGamesRoot\`** extended — a fixed-position overlay container stacks every live realtime instance vertically. Multiple realtime games can run live simultaneously per the existing design; the overlay handles them via a scrollable list.
- New **\`useAggregates\`** hook with proper \`onSnapshot\` lifecycle.
- \`ParticipantDoc\` gains \`quizScore\` + \`quizAnsweredQuestions\` fields.

### Backend
- **\`recomputeAggregates\` trigger extended** — after the existing \`optionCounts\` + \`totalResponses\` increments, quiz instances additionally query \`participants\` ordered by \`quizScore\` desc, limit 10, and merge a \`leaderboard\` array into \`aggregates/current\`. Bounded query keeps cost under the free tier even at ~200 attendees.

### Firestore rules
- **\`responses/{responseId}\`** — allow \`create\` when \`uid\` matches auth, doc id is the deterministic \`\${uid}_\${questionId}\`, parent instance is live and is type \`poll\` OR \`quiz\`, and the participant doc exists for the user. Updates and deletes stay denied (1 vote per user per question is enforced by the doc id pattern).
- **\`participants/{uid}\`** self-update \`affectedKeys\` extended with \`quizScore\` + \`quizAnsweredQuestions\` alongside the existing bingo fields. Alias / joinedAt / bingoCard remain immutable.

## Behaviour decisions
- **Multiple realtime overlays simultaneously**: stacked vertically (scrollable). The participant decides which to engage with first.
- **Quiz scoring**: straight points (correct = full \`points\`, incorrect = 0). Predictable and not penalised by network latency.
- **Bingo + quiz score writes are client-side**: the participant updates their own doc under tight rules. Trust model fits a community event.

## Test plan

- [x] \`pnpm test\` — 86 root tests (5 PollOverlay, 7 QuizOverlay, plus existing).
- [x] \`pnpm test:functions\` — 82 functions tests (4 new trigger tests for the leaderboard branch, plus existing).
- [x] \`pnpm test:rules\` — 40 rules tests (11 new for response writes + quiz score self-update, plus existing).
- [x] \`pnpm lint\`, \`pnpm build\`, \`cd functions && npm run build\` — clean.
- [ ] CI green.
- [ ] Smoke with emulators: attach a poll + quiz to a test event, activate both, open \`/eventos/{slug}?play=1\` in incognito, vote on the poll, advance the quiz through several questions, observe the live results bars + leaderboard.