### PR TITLE
feat(event): venue projector view + admin convenience controls + runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,42 @@ El servidor de desarrollo corre en `http://localhost:4321`.
 | `pnpm lint`    | Ejecutar ESLint                            |
 | `pnpm format`  | Formatear con Prettier                     |
 
+## Mini-juegos en eventos
+
+Esta sección guía al equipo organizador para correr mini-juegos en vivo durante un evento (encuestas, quiz, nube de palabras, bingo).
+
+### Pre-evento
+
+1. **Plantillas** — desde `/admin/minigame-templates` crea las plantillas que vas a usar (poll, quiz, wordcloud, bingo). Las plantillas son reutilizables entre eventos.
+2. **Adjuntar al evento** — desde `/admin/eventos`, haz click en "🎮 Mini-juegos" en la fila del evento para abrir `/admin/eventos/minigames?slug=<id>`. Adjunta cada plantilla que vayas a usar.
+3. **Anonymous Authentication** — confirma que está habilitado en Firebase Console (Authentication → Sign-in method → Anonymous). Sin esto los participantes no se pueden unir en producción. El emulador local lo activa solo.
+4. **Smoke test** — abre `https://gdgica.com/eventos/<slug>?play=1` en una pestaña incognito antes del evento y verifica que aparezca el modal de unión.
+
+### Durante el evento
+
+1. **Conecta el proyector** — desde el panel admin del evento, click en "📺 Abrir proyector". Se abre `/eventos/<slug>/proyector` en una nueva pestaña; muévela a la pantalla del venue.
+2. **Activa los juegos globales** (bingo + wordcloud) al inicio. Están pensados para correr durante todo el evento.
+3. **Activa polls / quizzes** en momentos puntuales:
+   - Click "▶ Iniciar" en la card del juego cuando quieras lanzarlo.
+   - Para quiz, "⏭ Avanzar pregunta" controla el timer y la siguiente pregunta.
+   - Click "⏹ Cerrar" cuando termine.
+4. **Comparte la URL de unión** — el botón "📋 Copiar URL de unión" copia `https://gdgica.com/eventos/<slug>?play=1` al portapapeles; pégalo en el WhatsApp del evento o cualquier canal.
+5. **Modera el wordcloud** — el botón "Ver moderación" en cada card de wordcloud abre un panel donde admin oculta palabras inapropiadas. Los cambios se reflejan en el proyector y en los celulares en <1s.
+6. **Quiz en vivo** — la pantalla del proyector muestra timer, opciones, y leaderboard top-10. Los participantes ven lo mismo en sus celulares.
+
+### Post-evento
+
+1. **Cierra los juegos** (state=closed) desde el panel admin para detener escrituras.
+2. **Premia a los ganadores** — botón "Ver ganadores" en la card de bingo lista los participantes con `bingoWonAt` ordenados por timestamp.
+3. Los datos quedan en Firestore para análisis posterior — no es necesario borrar nada.
+
+### Solución de problemas comunes
+
+- **El modal no aparece para los participantes**: verifica que el juego esté en `live` y que Anonymous Authentication esté habilitado en Firebase Console.
+- **El QR del proyector apunta al dominio incorrecto**: el QR se genera al build con `https://gdgica.com`. Re-deployar después de cambios de dominio.
+- **"Demasiados intentos"** al unirse: el rate limiter por IP es 10/min. Para eventos grandes en una misma red WiFi, ajusta `joinLimiter` en `functions/src/index.ts`.
+- **Borrar una plantilla adjuntada**: solo se puede borrar una instancia en `state=scheduled`. Cierra el juego primero (`live` → `closed`) y luego archívalo visualmente; los datos históricos quedan.
+
 ## Estructura del proyecto
 
 ```plaintext

--- a/src/components/react/admin/event-minigames/EventMinigameManager.tsx
+++ b/src/components/react/admin/event-minigames/EventMinigameManager.tsx
@@ -54,6 +54,27 @@ export function EventMinigameManager({ initialSlug }: Props) {
     [instances]
   );
 
+  function buildJoinUrl(): string | null {
+    if (!slug) return null;
+    return `https://gdgica.com/eventos/${encodeURIComponent(slug)}?play=1`;
+  }
+
+  function openProjector() {
+    if (!slug || typeof window === "undefined") return;
+    window.open(`/eventos/${encodeURIComponent(slug)}/proyector`, "_blank");
+  }
+
+  async function copyJoinUrl() {
+    const url = buildJoinUrl();
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      setToast({ message: "URL copiada al portapapeles", type: "success" });
+    } catch {
+      setToast({ message: "No se pudo copiar la URL", type: "error" });
+    }
+  }
+
   async function handleSetState(id: string, state: InstanceState) {
     if (!slug) return;
     setBusyId(id);
@@ -129,13 +150,29 @@ export function EventMinigameManager({ initialSlug }: Props) {
             Mini-juegos · <span className="font-mono">{slug}</span>
           </h1>
         </div>
-        <button
-          type="button"
-          onClick={() => setAttaching(true)}
-          className="shrink-0 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-        >
-          + Adjuntar plantilla
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={openProjector}
+            className="rounded-lg border border-purple-500 px-3 py-2 text-sm font-medium text-purple-700 hover:bg-purple-50 dark:border-purple-400 dark:text-purple-300 dark:hover:bg-purple-900/20"
+          >
+            📺 Abrir proyector
+          </button>
+          <button
+            type="button"
+            onClick={copyJoinUrl}
+            className="rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            📋 Copiar URL de unión
+          </button>
+          <button
+            type="button"
+            onClick={() => setAttaching(true)}
+            className="shrink-0 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            + Adjuntar plantilla
+          </button>
+        </div>
       </div>
 
       {loading && (

--- a/src/components/react/admin/event-minigames/__tests__/EventMinigameManager.test.tsx
+++ b/src/components/react/admin/event-minigames/__tests__/EventMinigameManager.test.tsx
@@ -137,4 +137,29 @@ describe("EventMinigameManager", () => {
       })
     );
   });
+
+  it("opens the projector view in a new tab", async () => {
+    const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(<EventMinigameManager initialSlug="devfest-2025" />);
+    await screen.findByText("First poll");
+    await user.click(screen.getByRole("button", { name: /Abrir proyector/i }));
+    expect(openSpy).toHaveBeenCalledWith(
+      "/eventos/devfest-2025/proyector",
+      "_blank"
+    );
+    openSpy.mockRestore();
+  });
+
+  it("copies the join URL to the clipboard", async () => {
+    // userEvent.setup() installs an in-memory Clipboard, so we can read
+    // back what the handler wrote without touching the real navigator.
+    const user = userEvent.setup();
+    render(<EventMinigameManager initialSlug="devfest-2025" />);
+    await screen.findByText("First poll");
+    await user.click(screen.getByRole("button", { name: /Copiar URL/i }));
+    expect(await screen.findByText(/URL copiada/i)).toBeInTheDocument();
+    const written = await navigator.clipboard.readText();
+    expect(written).toBe("https://gdgica.com/eventos/devfest-2025?play=1");
+  });
 });

--- a/src/components/react/event/ProjectorView.tsx
+++ b/src/components/react/event/ProjectorView.tsx
@@ -1,0 +1,438 @@
+import { useEffect, useMemo, useState } from "react";
+import type {
+  PollConfig,
+  QuizConfig,
+  WordCloudConfig,
+} from "../admin/minigame-templates/types";
+import { useAggregates } from "./useAggregates";
+import { useBingoWinners } from "./useBingoWinners";
+import { useLiveMinigames } from "./useLiveMinigames";
+import { useWordCloud } from "./useWordCloud";
+import type { LiveInstance } from "./types";
+
+interface Props {
+  slug: string;
+  eventName: string;
+  joinUrl: string;
+  qrSvg: string;
+}
+
+export function ProjectorView({ slug, eventName, joinUrl, qrSvg }: Props) {
+  const { liveInstances } = useLiveMinigames(slug);
+  // Skip realtime instances whose snapshotted config is missing — same
+  // guard the participant overlay uses.
+  const visible = useMemo(
+    () =>
+      liveInstances.filter(
+        (inst) =>
+          inst.mode === "global" || (inst.mode === "realtime" && inst.config)
+      ),
+    [liveInstances]
+  );
+
+  const hasLive = visible.length > 0;
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="flex items-center justify-between border-b border-white/10 px-8 py-4">
+        <div>
+          <p className="text-xs tracking-widest text-white/50 uppercase">
+            GDG ICA · En vivo
+          </p>
+          <h1 className="text-2xl font-semibold">{eventName}</h1>
+        </div>
+        <div className="text-right">
+          <p className="text-xs tracking-widest text-white/50 uppercase">
+            Únete escaneando el QR
+          </p>
+          <p className="font-mono text-sm text-white/80">{joinUrl}</p>
+        </div>
+      </header>
+
+      {!hasLive && <HeroQr qrSvg={qrSvg} joinUrl={joinUrl} />}
+
+      {hasLive && (
+        <main className="flex-1 p-8">
+          <div className="grid [grid-template-columns:repeat(auto-fit,minmax(420px,1fr))] gap-6">
+            {visible.map((inst) => (
+              <article
+                key={inst.id}
+                className="rounded-2xl border border-white/10 bg-white/5 p-8 backdrop-blur"
+              >
+                {inst.type === "poll" && inst.config && (
+                  <ProjectorPoll slug={slug} instance={inst} />
+                )}
+                {inst.type === "quiz" && inst.config && (
+                  <ProjectorQuiz slug={slug} instance={inst} />
+                )}
+                {inst.type === "wordcloud" && (
+                  <ProjectorWordCloud slug={slug} instance={inst} />
+                )}
+                {inst.type === "bingo" && (
+                  <ProjectorBingo slug={slug} instance={inst} />
+                )}
+              </article>
+            ))}
+          </div>
+        </main>
+      )}
+
+      {hasLive && (
+        <footer className="border-t border-white/10 px-8 py-4">
+          <div className="flex items-center justify-end gap-4">
+            <p className="text-right text-sm text-white/70">
+              ¿Recién llegando?
+              <br />
+              <span className="font-mono text-white">{joinUrl}</span>
+            </p>
+            <div
+              className="h-24 w-24 rounded bg-white p-1"
+              dangerouslySetInnerHTML={{ __html: qrSvg }}
+              aria-label="QR para unirse"
+            />
+          </div>
+        </footer>
+      )}
+    </div>
+  );
+}
+
+export default ProjectorView;
+
+function HeroQr({ qrSvg, joinUrl }: { qrSvg: string; joinUrl: string }) {
+  return (
+    <main className="flex flex-1 flex-col items-center justify-center gap-8 p-8 text-center">
+      <p className="text-2xl text-white/70">Escanea para participar</p>
+      <div
+        className="h-[60vh] max-h-[640px] w-[60vh] max-w-[640px] rounded-2xl bg-white p-6"
+        dangerouslySetInnerHTML={{ __html: qrSvg }}
+        aria-label="QR de unión"
+      />
+      <p className="font-mono text-xl text-white/80">{joinUrl}</p>
+    </main>
+  );
+}
+
+// ---- Poll --------------------------------------------------------------
+
+const POLL_QUESTION_ID = "main";
+
+function ProjectorPoll({
+  slug,
+  instance,
+}: {
+  slug: string;
+  instance: LiveInstance;
+}) {
+  const config = instance.config as unknown as PollConfig;
+  const { aggregates } = useAggregates(slug, instance.id);
+  const counts = aggregates?.optionCounts ?? {};
+  const total = config.options.reduce(
+    (sum, opt) => sum + (counts[`${POLL_QUESTION_ID}:${opt.id}`] ?? 0),
+    0
+  );
+
+  return (
+    <div>
+      <Badge color="blue">Encuesta</Badge>
+      <h2 className="mt-3 text-3xl font-bold">{instance.title}</h2>
+      <p className="mt-2 text-xl text-white/80">{config.question}</p>
+      <ul className="mt-6 space-y-3">
+        {config.options.map((opt) => {
+          const count = counts[`${POLL_QUESTION_ID}:${opt.id}`] ?? 0;
+          const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+          return (
+            <li
+              key={opt.id}
+              className="relative overflow-hidden rounded-xl border border-white/10 bg-black/40 px-5 py-3"
+            >
+              <div
+                aria-hidden
+                className="absolute inset-y-0 left-0 bg-blue-500/40 transition-all"
+                style={{ width: `${pct}%` }}
+              />
+              <div className="relative flex items-center justify-between gap-3">
+                <span className="text-xl font-medium">{opt.label}</span>
+                <span className="text-lg text-white/80 tabular-nums">
+                  {count} · {pct}%
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+      <p className="mt-4 text-sm text-white/60">
+        {total} respuesta{total !== 1 && "s"}
+      </p>
+    </div>
+  );
+}
+
+// ---- Quiz --------------------------------------------------------------
+
+function ProjectorQuiz({
+  slug,
+  instance,
+}: {
+  slug: string;
+  instance: LiveInstance;
+}) {
+  const config = instance.config as unknown as QuizConfig;
+  const { aggregates } = useAggregates(slug, instance.id);
+  const startedAt = (
+    instance as unknown as {
+      currentQuestionStartedAt?: { seconds: number } | null;
+    }
+  ).currentQuestionStartedAt;
+  const idx = instance.currentQuestionIndex ?? -1;
+  const question = idx >= 0 ? config.questions[idx] : null;
+
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!question) return;
+    const id = window.setInterval(() => setNow(Date.now()), 250);
+    return () => window.clearInterval(id);
+  }, [question]);
+
+  const startedMs = startedAt?.seconds ? startedAt.seconds * 1000 : null;
+  const elapsedMs = startedMs ? Math.max(0, now - startedMs) : 0;
+  const limitMs = (question?.timeLimitSec ?? 0) * 1000;
+  const remainingSec = startedMs
+    ? Math.max(0, Math.ceil((limitMs - elapsedMs) / 1000))
+    : Math.ceil(limitMs / 1000);
+
+  const counts = aggregates?.optionCounts ?? {};
+  const totalForQuestion = question
+    ? question.options.reduce(
+        (sum, opt) => sum + (counts[`${question.id}:${opt.id}`] ?? 0),
+        0
+      )
+    : 0;
+
+  return (
+    <div>
+      <Badge color="purple">Quiz</Badge>
+      <h2 className="mt-3 text-3xl font-bold">{instance.title}</h2>
+
+      {!question && (
+        <p className="mt-6 text-xl text-white/70">
+          Esperando que el organizador inicie la primera pregunta...
+        </p>
+      )}
+
+      {question && (
+        <>
+          <div className="mt-2 flex items-center justify-between">
+            <span className="text-base text-white/70">
+              Pregunta {idx + 1} / {config.questions.length}
+            </span>
+            <span
+              className={`text-2xl font-bold tabular-nums ${
+                remainingSec <= 5 ? "text-red-400" : "text-white"
+              }`}
+              aria-label="Tiempo restante"
+            >
+              {remainingSec}s
+            </span>
+          </div>
+          <p className="mt-2 text-2xl">{question.prompt}</p>
+          <ul className="mt-6 space-y-2">
+            {question.options.map((opt) => {
+              const count = counts[`${question.id}:${opt.id}`] ?? 0;
+              const pct =
+                totalForQuestion > 0
+                  ? Math.round((count / totalForQuestion) * 100)
+                  : 0;
+              const isCorrect = opt.id === question.correctOptionId;
+              return (
+                <li
+                  key={opt.id}
+                  className={`relative overflow-hidden rounded-xl border px-5 py-3 ${
+                    isCorrect
+                      ? "border-green-400 bg-black/40"
+                      : "border-white/10 bg-black/40"
+                  }`}
+                >
+                  <div
+                    aria-hidden
+                    className={`absolute inset-y-0 left-0 transition-all ${
+                      isCorrect ? "bg-green-500/40" : "bg-purple-500/40"
+                    }`}
+                    style={{ width: `${pct}%` }}
+                  />
+                  <div className="relative flex items-center justify-between gap-3">
+                    <span className="text-lg font-medium">
+                      {opt.label}
+                      {isCorrect && (
+                        <span className="ml-2 text-sm text-green-300">
+                          Correcto
+                        </span>
+                      )}
+                    </span>
+                    <span className="text-base text-white/80 tabular-nums">
+                      {count} · {pct}%
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+
+      {aggregates?.leaderboard && aggregates.leaderboard.length > 0 && (
+        <div className="mt-6 rounded-xl border border-white/10 bg-black/40 p-4">
+          <p className="text-xs tracking-widest text-white/50 uppercase">
+            Top 10
+          </p>
+          <ol className="mt-2 space-y-1 text-base">
+            {aggregates.leaderboard.map((entry, i) => (
+              <li key={entry.uid} className="flex items-center justify-between">
+                <span>
+                  {i + 1}. {entry.alias}
+                </span>
+                <span className="tabular-nums">{entry.score}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Word cloud ---------------------------------------------------------
+
+const MIN_WC_FONT_REM = 1.4;
+const WC_SCALE = 0.9;
+
+function ProjectorWordCloud({
+  slug,
+  instance,
+}: {
+  slug: string;
+  instance: LiveInstance;
+}) {
+  const config = instance.config as unknown as WordCloudConfig | undefined;
+  const { words } = useWordCloud(slug, instance.id);
+  const maxCount = useMemo(
+    () => words.reduce((acc, w) => Math.max(acc, w.count), 1),
+    [words]
+  );
+
+  return (
+    <div>
+      <Badge color="amber">Nube de palabras</Badge>
+      <h2 className="mt-3 text-3xl font-bold">{instance.title}</h2>
+      {config?.prompt && (
+        <p className="mt-2 text-xl text-white/80">{config.prompt}</p>
+      )}
+      <div className="mt-6 rounded-xl border border-white/10 bg-black/40 p-6">
+        {words.length === 0 ? (
+          <p className="text-center text-white/60">
+            Aún no hay palabras enviadas.
+          </p>
+        ) : (
+          <ul className="flex flex-wrap items-baseline justify-center gap-x-6 gap-y-2">
+            {words.map((w) => {
+              const ratio = Math.log(w.count + 1) / Math.log(maxCount + 1);
+              const fontSize = Math.max(
+                MIN_WC_FONT_REM,
+                MIN_WC_FONT_REM + ratio * WC_SCALE * 2
+              );
+              return (
+                <li
+                  key={w.id}
+                  className="text-amber-200"
+                  style={{ fontSize: `${fontSize}rem`, lineHeight: 1.1 }}
+                >
+                  {w.text}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---- Bingo --------------------------------------------------------------
+
+function formatWinTime(value: { seconds?: number } | null | undefined): string {
+  if (!value?.seconds) return "—";
+  return new Date(value.seconds * 1000).toLocaleTimeString("es-PE", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function ProjectorBingo({
+  slug,
+  instance,
+}: {
+  slug: string;
+  instance: LiveInstance;
+}) {
+  const { winners } = useBingoWinners(slug, instance.id);
+  return (
+    <div>
+      <Badge color="green">Bingo</Badge>
+      <h2 className="mt-3 text-3xl font-bold">{instance.title}</h2>
+      <p className="mt-2 text-xl text-white/80">
+        Marca tu cartón cuando el speaker mencione un término.
+      </p>
+      <div className="mt-6 rounded-xl border border-white/10 bg-black/40 p-6">
+        <p className="text-xs tracking-widest text-white/50 uppercase">
+          Ganadores
+        </p>
+        {winners.length === 0 ? (
+          <p className="mt-3 text-white/60">Aún no hay ganadores.</p>
+        ) : (
+          <ol className="mt-3 space-y-2 text-lg">
+            {winners.map((w, i) => (
+              <li
+                key={w.uid}
+                className="flex items-center justify-between gap-4"
+              >
+                <span>
+                  <span aria-hidden className="mr-2">
+                    {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : "🎉"}
+                  </span>
+                  {w.alias}
+                </span>
+                <span className="text-sm text-white/60 tabular-nums">
+                  {formatWinTime(w.bingoWonAt)}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---- Shared --------------------------------------------------------------
+
+function Badge({
+  color,
+  children,
+}: {
+  color: "blue" | "purple" | "amber" | "green";
+  children: React.ReactNode;
+}) {
+  const palette: Record<typeof color, string> = {
+    blue: "bg-blue-500/20 text-blue-200",
+    purple: "bg-purple-500/20 text-purple-200",
+    amber: "bg-amber-500/20 text-amber-200",
+    green: "bg-green-500/20 text-green-200",
+  };
+  return (
+    <span
+      className={`inline-block rounded-full px-3 py-1 text-xs font-semibold tracking-widest uppercase ${palette[color]}`}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/react/event/__tests__/ProjectorView.test.tsx
+++ b/src/components/react/event/__tests__/ProjectorView.test.tsx
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  useLiveMinigames: vi.fn(),
+  useAggregates: vi.fn(),
+  useWordCloud: vi.fn(),
+  useBingoWinners: vi.fn(),
+}));
+
+vi.mock("../useLiveMinigames", () => ({
+  useLiveMinigames: mocks.useLiveMinigames,
+}));
+vi.mock("../useAggregates", () => ({
+  useAggregates: mocks.useAggregates,
+}));
+vi.mock("../useWordCloud", () => ({
+  useWordCloud: mocks.useWordCloud,
+}));
+vi.mock("../useBingoWinners", () => ({
+  useBingoWinners: mocks.useBingoWinners,
+}));
+
+import { ProjectorView } from "../ProjectorView";
+
+const QR_SVG = '<svg data-testid="qr-svg"><rect /></svg>';
+const JOIN_URL = "https://gdgica.com/eventos/x?play=1";
+const NOW_MS = 1_700_000_000_000;
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+  mocks.useLiveMinigames.mockReturnValue({
+    loading: false,
+    liveInstances: [],
+    error: null,
+  });
+  mocks.useAggregates.mockReturnValue({
+    aggregates: null,
+    loading: false,
+    error: null,
+  });
+  mocks.useWordCloud.mockReturnValue({
+    words: [],
+    loading: false,
+    error: null,
+  });
+  mocks.useBingoWinners.mockReturnValue({
+    winners: [],
+    loading: false,
+    error: null,
+  });
+});
+
+afterEach(() => cleanup());
+
+function renderProjector() {
+  return render(
+    <ProjectorView
+      slug="x"
+      eventName="DevFest ICA 2026"
+      joinUrl={JOIN_URL}
+      qrSvg={QR_SVG}
+    />
+  );
+}
+
+describe("ProjectorView", () => {
+  it("renders the hero QR + URL when no game is live", () => {
+    renderProjector();
+    expect(screen.getByText("DevFest ICA 2026")).toBeInTheDocument();
+    expect(screen.getByText(/Escanea para participar/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("QR de unión")).toBeInTheDocument();
+    expect(screen.getAllByText(JOIN_URL)).not.toHaveLength(0);
+  });
+
+  it("renders an event header with the join URL on the right", () => {
+    renderProjector();
+    expect(screen.getByText(/GDG ICA · En vivo/)).toBeInTheDocument();
+    expect(screen.getByText(/Únete escaneando el QR/)).toBeInTheDocument();
+  });
+
+  it("renders a poll instance with options and counts", () => {
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [
+        {
+          id: "i-poll",
+          type: "poll",
+          mode: "realtime",
+          state: "live",
+          title: "Mi poll",
+          order: 0,
+          config: {
+            question: "¿Cuál prefieres?",
+            options: [
+              { id: "a", label: "Opción A" },
+              { id: "b", label: "Opción B" },
+            ],
+          },
+        },
+      ],
+      error: null,
+    });
+    mocks.useAggregates.mockReturnValue({
+      aggregates: { optionCounts: { "main:a": 6, "main:b": 2 } },
+      loading: false,
+      error: null,
+    });
+    renderProjector();
+    expect(screen.getByText("Mi poll")).toBeInTheDocument();
+    expect(screen.getByText("¿Cuál prefieres?")).toBeInTheDocument();
+    expect(screen.getByText(/6 · 75%/)).toBeInTheDocument();
+    expect(screen.getByText(/2 · 25%/)).toBeInTheDocument();
+  });
+
+  it("renders a quiz instance with countdown + leaderboard", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(NOW_MS));
+    try {
+      mocks.useLiveMinigames.mockReturnValue({
+        loading: false,
+        liveInstances: [
+          {
+            id: "i-quiz",
+            type: "quiz",
+            mode: "realtime",
+            state: "live",
+            title: "Mi quiz",
+            order: 0,
+            currentQuestionIndex: 0,
+            currentQuestionStartedAt: { seconds: NOW_MS / 1000 - 10 },
+            config: {
+              questions: [
+                {
+                  id: "q1",
+                  prompt: "¿Cuál es multimodal?",
+                  options: [
+                    { id: "a", label: "Gemini" },
+                    { id: "b", label: "GPT-2" },
+                  ],
+                  correctOptionId: "a",
+                  timeLimitSec: 30,
+                  points: 100,
+                },
+              ],
+            },
+          },
+        ],
+        error: null,
+      });
+      mocks.useAggregates.mockReturnValue({
+        aggregates: {
+          leaderboard: [
+            { uid: "u1", alias: "Ana", score: 200 },
+            { uid: "u2", alias: "Bea", score: 100 },
+          ],
+        },
+        loading: false,
+        error: null,
+      });
+      renderProjector();
+      expect(screen.getByText("¿Cuál es multimodal?")).toBeInTheDocument();
+      // 30s limit - 10s elapsed = 20s remaining.
+      expect(screen.getByLabelText(/Tiempo restante/)).toHaveTextContent("20s");
+      expect(screen.getByText("Top 10")).toBeInTheDocument();
+      expect(screen.getByText(/1\. Ana/)).toBeInTheDocument();
+      expect(screen.getByText(/2\. Bea/)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("renders a wordcloud instance with submitted words", () => {
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [
+        {
+          id: "i-wc",
+          type: "wordcloud",
+          mode: "global",
+          state: "live",
+          title: "Nube",
+          order: 0,
+          config: {
+            prompt: "¿Qué te interesa?",
+            maxWordsPerUser: 3,
+            maxLength: 60,
+          },
+        },
+      ],
+      error: null,
+    });
+    mocks.useWordCloud.mockReturnValue({
+      loading: false,
+      error: null,
+      words: [
+        { id: "ai", text: "ai", normalized: "ai", count: 5 },
+        { id: "ml", text: "ml", normalized: "ml", count: 2 },
+      ],
+    });
+    renderProjector();
+    expect(screen.getByText("Nube")).toBeInTheDocument();
+    expect(screen.getByText("¿Qué te interesa?")).toBeInTheDocument();
+    expect(screen.getByText("ai")).toBeInTheDocument();
+    expect(screen.getByText("ml")).toBeInTheDocument();
+  });
+
+  it("renders a bingo instance with the winners list", () => {
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [
+        {
+          id: "i-bingo",
+          type: "bingo",
+          mode: "global",
+          state: "live",
+          title: "Bingo!",
+          order: 0,
+        },
+      ],
+      error: null,
+    });
+    mocks.useBingoWinners.mockReturnValue({
+      loading: false,
+      error: null,
+      winners: [
+        { uid: "u1", alias: "Ana", bingoWonAt: { seconds: 1700000000 } },
+        { uid: "u2", alias: "Bea", bingoWonAt: { seconds: 1700000060 } },
+      ],
+    });
+    renderProjector();
+    expect(screen.getByText("Bingo!")).toBeInTheDocument();
+    expect(screen.getByText("Ana")).toBeInTheDocument();
+    expect(screen.getByText("Bea")).toBeInTheDocument();
+  });
+
+  it("shows a small QR + URL footer when there are live games", () => {
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [
+        {
+          id: "i-bingo",
+          type: "bingo",
+          mode: "global",
+          state: "live",
+          title: "Bingo!",
+          order: 0,
+        },
+      ],
+      error: null,
+    });
+    renderProjector();
+    expect(screen.getByLabelText("QR para unirse")).toBeInTheDocument();
+    expect(screen.getByText(/Recién llegando/i)).toBeInTheDocument();
+  });
+
+  it("renders no interactive buttons (read-only view)", () => {
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [
+        {
+          id: "i-poll",
+          type: "poll",
+          mode: "realtime",
+          state: "live",
+          title: "Encuesta",
+          order: 0,
+          config: { question: "?", options: [{ id: "a", label: "A" }] },
+        },
+      ],
+      error: null,
+    });
+    renderProjector();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/react/event/useBingoWinners.ts
+++ b/src/components/react/event/useBingoWinners.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { getFirestore } from "@/lib/firebase";
+
+export interface BingoWinner {
+  uid: string;
+  alias: string;
+  bingoWonAt: { seconds: number; nanoseconds?: number } | null;
+}
+
+interface State {
+  winners: BingoWinner[];
+  loading: boolean;
+  error: string | null;
+}
+
+// Subscribes to events/{slug}/minigames/{instanceId}/participants in
+// real time and surfaces those who have won bingo (bingoWonAt != null),
+// ordered by win timestamp ascending so the projector ticker shows the
+// first winner first. Public Firestore reads make this work without
+// authentication — the venue laptop just needs network access.
+export function useBingoWinners(
+  slug: string | null,
+  instanceId: string | null,
+  limitCount = 20
+): State {
+  const [state, setState] = useState<State>({
+    winners: [],
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!slug || !instanceId) {
+      setState({ winners: [], loading: false, error: null });
+      return;
+    }
+    let unsub: (() => void) | null = null;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const db = await getFirestore();
+        const { collection, query, where, orderBy, limit, onSnapshot } =
+          await import("firebase/firestore");
+        if (cancelled) return;
+        // We use `where != null` rather than ">=" or "==" so docs with no
+        // bingoWonAt are excluded. Firestore creates the necessary
+        // single-field index automatically for this kind of inequality.
+        const q = query(
+          collection(db, `events/${slug}/minigames/${instanceId}/participants`),
+          where("bingoWonAt", "!=", null),
+          orderBy("bingoWonAt", "asc"),
+          limit(limitCount)
+        );
+        unsub = onSnapshot(
+          q,
+          (snap) => {
+            const winners = snap.docs.map(
+              (d) =>
+                ({
+                  uid: d.id,
+                  ...(d.data() as Omit<BingoWinner, "uid">),
+                }) as BingoWinner
+            );
+            setState({ winners, loading: false, error: null });
+          },
+          (err) => {
+            setState({ winners: [], loading: false, error: err.message });
+          }
+        );
+      } catch (err) {
+        setState({
+          winners: [],
+          loading: false,
+          error: err instanceof Error ? err.message : "Listener error",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (unsub) unsub();
+    };
+  }, [slug, instanceId, limitCount]);
+
+  return state;
+}

--- a/src/layouts/ProjectorLayout.astro
+++ b/src/layouts/ProjectorLayout.astro
@@ -1,0 +1,27 @@
+---
+// Minimal full-screen layout for the venue projector view. No header,
+// no footer, dark theme locked in (the projector lives at the front
+// of the room and shouldn't switch with user preferences). Marked as
+// noindex so search engines don't surface this URL.
+import "@/styles/global.css";
+
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<!doctype html>
+<html lang="es" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>{title}</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+  </head>
+  <body class="min-h-screen bg-black text-white">
+    <slot />
+  </body>
+</html>

--- a/src/pages/eventos/[slug]/proyector.astro
+++ b/src/pages/eventos/[slug]/proyector.astro
@@ -1,0 +1,39 @@
+---
+import { getCollection } from "astro:content";
+import QRCode from "qrcode";
+import ProjectorLayout from "@/layouts/ProjectorLayout.astro";
+import { ProjectorView } from "@/components/react/event/ProjectorView";
+
+export async function getStaticPaths() {
+  const events = await getCollection("events");
+  return events.map((event) => ({
+    params: { slug: event.id },
+    props: { event },
+  }));
+}
+
+const { slug } = Astro.params;
+const { event } = Astro.props;
+const joinUrl = `https://gdgica.com/eventos/${slug}?play=1`;
+
+// QR is rendered server-side at build time so the projector page
+// works the moment it's served — even before the React island
+// hydrates. White-on-black so the SVG is legible against the dark
+// projector backdrop without inverting it client-side.
+const qrSvg = await QRCode.toString(joinUrl, {
+  type: "svg",
+  errorCorrectionLevel: "H",
+  margin: 1,
+  color: { dark: "#ffffff", light: "#000000" },
+});
+---
+
+<ProjectorLayout title={`Proyector · ${event.data.name}`}>
+  <ProjectorView
+    client:load
+    slug={slug!}
+    eventName={event.data.name}
+    joinUrl={joinUrl}
+    qrSvg={qrSvg}
+  />
+</ProjectorLayout>


### PR DESCRIPTION
## Summary

Adds the projector view for the venue's screen plus operational tooling for organisers running mini-games during events. The projector renders a giant join QR when no game is live and switches to a responsive grid of read-only game cards once activations begin.

## What's new

### Public-side
- **\`ProjectorLayout.astro\`** — minimal full-screen dark layout, no header/footer, \`noindex\`.
- **Dynamic route \`/eventos/[slug]/proyector\`** generated for every event in the collection. The QR SVG is rendered server-side at build via \`QRCode.toString\` so the page works the moment it's served, before any JS hydrates.
- **\`ProjectorView\`** React island reads the existing public hooks (\`useLiveMinigames\`, \`useAggregates\`, \`useWordCloud\`) plus a new **\`useBingoWinners\`** hook subscribed to \`participants where bingoWonAt != null\`. Read-only — no Firestore writes, no buttons.
  - Hero QR + join URL when there are no live games.
  - Responsive auto-grid of game cards otherwise:
    - **Poll**: question + live result bars.
    - **Quiz**: current question, server-derived countdown, top-10 leaderboard.
    - **Word cloud**: scaled words sized by \`log(count+1)\`.
    - **Bingo**: ordered winners ticker with podium emojis.
  - Small QR + join URL footer for late joiners while games are running.

### Admin
- \`EventMinigameManager\` toolbar grows two utility buttons:
  - **📺 Abrir proyector** opens \`/eventos/{slug}/proyector\` in a new tab.
  - **📋 Copiar URL de unión** copies \`https://gdgica.com/eventos/{slug}?play=1\` to the clipboard with a toast confirmation.

### Documentation
- README adds a **\"Mini-juegos en eventos\"** section with pre/during/post-event checklists and a troubleshooting list (anonymous auth, rate limiter, scheduled-only delete).

## Test plan

- [x] \`pnpm test\` — 96 root tests (8 new ProjectorView, 2 new admin toolbar tests, plus existing).
- [x] \`pnpm test:functions\` — 82 functions tests (unchanged in this PR).
- [x] \`pnpm test:rules\` — 40 rules tests (unchanged in this PR).
- [x] \`pnpm lint\`, \`cd functions && npm run build\` — clean.
- [x] \`pnpm build\` — generates 34 pages (was 28): one \`/eventos/{slug}/proyector\` per event.
- [ ] CI green.
- [ ] Smoke with emulators: open the projector view in one window, the admin panel in another, and a participant tab in incognito. Activate poll, quiz, wordcloud, and bingo and confirm the projector reflects each in real time.