### PR TITLE
fix(ci): bump Java to 21 for firebase-tools emulator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0


### PR DESCRIPTION
## Summary

The \`pnpm test:rules\` step in CI started failing with:

\`\`\`
Error: firebase-tools no longer supports Java version before 21.
Please install a JDK at version 21 or above to get a compatible runtime.
\`\`\`

\`firebase-tools\` dropped Java <21 support. The test job spins up the Firestore emulator via \`firebase emulators:exec\`, which needs a compatible JDK. This PR bumps the temurin distribution from 17 to 21 in the test job.

## Diff

\`\`\`diff
-          java-version: \"17\"
+          java-version: \"21\"
\`\`\`

## Test plan

- [ ] CI green on this PR.