### PR TITLE
fix(firestore): add composite index for minigames(order, createdAt)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,14 @@
         { "fieldPath": "state", "order": "ASCENDING" },
         { "fieldPath": "order", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "minigames",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "order", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary

\`GET /api/events/:slug/minigames\` is returning **500** in production. Cloud Function logs surface the actual cause:

> The query requires an index. You can create it here: ...

The handler runs:

\`\`\`ts
events/{slug}/minigames
  .orderBy(\"order\", \"asc\")
  .orderBy(\"createdAt\", \"asc\")
\`\`\`

Two-\`orderBy\` queries always need a composite index in production Firestore. The Firestore emulator auto-creates indexes on demand, which is why our tests didn't catch it.

## Diff

\`\`\`diff
+    {
+      \"collectionGroup\": \"minigames\",
+      \"queryScope\": \"COLLECTION\",
+      \"fields\": [
+        { \"fieldPath\": \"order\", \"order\": \"ASCENDING\" },
+        { \"fieldPath\": \"createdAt\", \"order\": \"ASCENDING\" }
+      ]
+    }
\`\`\`

## What you'll see when this merges

The deploy job will run \`firebase deploy --only firestore:rules\` (which also pushes \`firestore.indexes.json\`). Firebase will start **building** the new index — this takes a few minutes for a fresh collection. While it builds, the admin page may still 500. Once Firebase Console shows the index as **\"Enabled\"** the panel works.

You can watch it here: https://console.firebase.google.com/project/appgdgica/firestore/indexes

## Follow-up (out of scope)

The current \`safeError()\` helper strips the URL Firestore embeds in the index-required error message, so the client only sees \"An internal error occurred\". Worth surfacing a more specific error code or a 503 with a typed reason later, so missing indexes are obvious from the browser tab.

## Test plan

- [ ] CI green.
- [ ] After deploy, wait for the index to finish building in Firebase Console.
- [ ] Reload \`/admin/eventos/minigames?slug=build-with-ai-ica-2026\` and confirm the page renders the attached templates.