### PR TITLE
fix(ci): deploy Firestore indexes in CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
-          firebase deploy --only "hosting:gdgica,functions,firestore:rules" --force
+          firebase deploy --only "hosting:gdgica,functions,firestore:rules,firestore:indexes" --force
 
       - name: Cleanup old hosting versions
         env:


### PR DESCRIPTION
## Summary

- El comando `firebase deploy` en el workflow sólo incluía `firestore:rules` y omitía `firestore:indexes`
- El índice compuesto `(order, createdAt)` sobre la colección `minigames` existía en `firestore.indexes.json` pero nunca se desplegaba en producción
- Esto causaba el error `9 FAILED_PRECONDITION: The query requires an index` en `GET /api/events/:slug/minigames`

## Test plan

- [ ] Verificar que el workflow pasa en CI tras mergear
- [ ] Confirmar que `GET /api/events/build-with-ai-ica-2026/minigames` responde 200 (puede tardar unos minutos mientras Firestore construye el índice)