### PR TITLE
fix(ci): pin setup-java to SHA and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+
+  - package-ecosystem: npm
+    directory: "/functions"
+    schedule:
+      interval: weekly
+      day: monday
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: "22.15.0"
 
       - name: Setup Java (for Firestore emulator)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: "21"


### PR DESCRIPTION
## Cambios

### 1. Pin `actions/setup-java` a SHA completo

`actions/setup-java@v4` usaba un tag mutable. Un release comprometido podía inyectar código en el entorno de CI que tiene acceso al secret `FIREBASE_TOKEN`.

Fijado al commit SHA `c1e323688fd81a25caa38c78aa6df2d33d3e20d9` (tag `v4` actual).

### 2. Dependabot habilitado

Agrega `.github/dependabot.yml` con actualizaciones semanales (lunes) para:
- npm en `/` (dependencias del sitio)
- npm en `/functions` (dependencias de Cloud Functions)
- GitHub Actions (el propio workflow)

Esto hubiera detectado automáticamente la vulnerabilidad crítica de `protobufjs` resuelta en #167.