### PR TITLE
refactor: remove dead types and deduplicate AdminApp page switch

### DIFF
--- a/functions/src/types/users.ts
+++ b/functions/src/types/users.ts
@@ -9,12 +9,3 @@ export interface UserDocument {
   createdAt: import("firebase-admin/firestore").Timestamp;
   lastLoginAt: import("firebase-admin/firestore").Timestamp;
 }
-
-export interface AuditLogEntry {
-  action: string;
-  performedBy: string;
-  targetId: string;
-  targetType: string;
-  details: Record<string, unknown>;
-  timestamp: import("firebase-admin/firestore").Timestamp;
-}

--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { AuthProvider, DevAuthProvider, useAuth } from "./AuthProvider";
 import { LoginScreen } from "./LoginScreen";
 import { isDevPreview } from "@/lib/api";
@@ -19,6 +20,55 @@ import { EventMinigameManager } from "./event-minigames/EventMinigameManager";
 interface Props {
   page: string;
   currentPath: string;
+}
+
+function renderPage(
+  page: string,
+  guards: { isAdmin: boolean; role: string | null; signOut: () => void } | null
+) {
+  const adminPage = (component: React.ReactNode) => {
+    if (!guards) return component;
+    return guards.isAdmin ? (
+      component
+    ) : (
+      <AccessDenied role={guards.role} signOut={guards.signOut} />
+    );
+  };
+
+  switch (page) {
+    case "dashboard":
+      return <Dashboard />;
+    case "events":
+      return <EventList />;
+    case "event-form":
+      return <EventForm />;
+    case "team":
+      return <TeamList />;
+    case "speakers":
+      return <SpeakerList />;
+    case "sponsors":
+      return <SponsorList />;
+    case "stats":
+      return adminPage(<StatsEditor />);
+    case "users":
+      return adminPage(<UserDirectory />);
+    case "forms":
+      return adminPage(<FormRegistry />);
+    case "form-viewer":
+      return adminPage(<FormViewer />);
+    case "ubicaciones":
+      return <LocationList />;
+    case "minigame-templates":
+      return <MinigameTemplateList />;
+    case "event-minigames":
+      return <EventMinigameManager />;
+    default:
+      return (
+        <p className="text-gray-500 dark:text-gray-400">
+          Pagina en construccion
+        </p>
+      );
+  }
 }
 
 function AdminContent({ page, currentPath }: Props) {
@@ -70,106 +120,20 @@ function AdminContent({ page, currentPath }: Props) {
     );
   }
 
-  const pageContent = () => {
-    switch (page) {
-      case "dashboard":
-        return <Dashboard />;
-      case "events":
-        return <EventList />;
-      case "event-form":
-        return <EventForm />;
-      case "team":
-        return <TeamList />;
-      case "speakers":
-        return <SpeakerList />;
-      case "sponsors":
-        return <SponsorList />;
-      case "stats":
-        return isAdmin ? (
-          <StatsEditor />
-        ) : (
-          <AccessDenied role={role} signOut={signOut} />
-        );
-      case "users":
-        return isAdmin ? (
-          <UserDirectory />
-        ) : (
-          <AccessDenied role={role} signOut={signOut} />
-        );
-      case "forms":
-        return isAdmin ? (
-          <FormRegistry />
-        ) : (
-          <AccessDenied role={role} signOut={signOut} />
-        );
-      case "form-viewer":
-        return isAdmin ? (
-          <FormViewer />
-        ) : (
-          <AccessDenied role={role} signOut={signOut} />
-        );
-      case "ubicaciones":
-        return <LocationList />;
-      case "minigame-templates":
-        return <MinigameTemplateList />;
-      case "event-minigames":
-        return <EventMinigameManager />;
-      default:
-        return (
-          <p className="text-gray-500 dark:text-gray-400">
-            Pagina en construccion
-          </p>
-        );
-    }
-  };
-
-  return <AdminShell currentPage={currentPath}>{pageContent()}</AdminShell>;
+  return (
+    <AdminShell currentPage={currentPath}>
+      {renderPage(page, { isAdmin, role, signOut })}
+    </AdminShell>
+  );
 }
 
 function DevContent({ page, currentPath }: Props) {
-  const pageContent = () => {
-    switch (page) {
-      case "dashboard":
-        return <Dashboard />;
-      case "events":
-        return <EventList />;
-      case "event-form":
-        return <EventForm />;
-      case "team":
-        return <TeamList />;
-      case "speakers":
-        return <SpeakerList />;
-      case "sponsors":
-        return <SponsorList />;
-      case "stats":
-        return <StatsEditor />;
-      case "users":
-        return <UserDirectory />;
-      case "forms":
-        return <FormRegistry />;
-      case "form-viewer":
-        return <FormViewer />;
-      case "ubicaciones":
-        return <LocationList />;
-      case "minigame-templates":
-        return <MinigameTemplateList />;
-      case "event-minigames":
-        return <EventMinigameManager />;
-      default:
-        return (
-          <p className="text-gray-500 dark:text-gray-400">
-            Pagina en construccion
-          </p>
-        );
-    }
-  };
-
   return (
     <AdminShell currentPage={currentPath}>
       <div className="mb-4 rounded-lg border border-yellow-300 bg-yellow-50 px-4 py-2 text-sm text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-400">
         PREVIEW MODE — datos de ejemplo, sin auth
       </div>
-      {pageContent()}
+      {renderPage(page, null)}
     </AdminShell>
   );
 }

--- a/src/components/react/event/types.ts
+++ b/src/components/react/event/types.ts
@@ -21,15 +21,5 @@ export interface LiveInstance {
   currentQuestionIndex?: number;
 }
 
-export interface JoinResult {
-  alias: string;
-  instances: {
-    id: string;
-    type: string;
-    joined: boolean;
-    bingoCard?: string[];
-  }[];
-}
-
 export const LOCAL_STORAGE_ALIAS_KEY = (slug: string) =>
   `gdg_minigame_alias_${slug}`;


### PR DESCRIPTION
## Cambios

### 1. Eliminar `AuditLogEntry` (`functions/src/types/users.ts`)

Tipo exportado pero nunca importado en ningún handler ni middleware. Los handlers que escriben al `audit_log` de Firestore usan objetos inline.

### 2. Eliminar `JoinResult` (`src/components/react/event/types.ts`)

Interfaz exportada pero sin ningún consumidor. El comentario `// PR4 + PR5/PR6` en el archivo sugiere que fue planificada para un PR futuro que no llegó a usarla.

### 3. Deduplicar switch de routing en `AdminApp.tsx`

`AdminContent` y `DevContent` tenían el mismo switch de 13 casos copiado. Cada nueva página requería actualizar ambos.

Extraído a `renderPage(page, guards)`:
- `guards = { isAdmin, role, signOut }` → aplica guards de rol (usado por `AdminContent`)  
- `guards = null` → renderiza todo sin restricciones (usado por `DevContent` en preview mode)

La lógica de `adminPage()` dentro de `renderPage` centraliza los guards de las 4 páginas admin-only.

## Verificación

- 96/96 tests pasan (`pnpm test`)
- TypeScript sin errores en el lado Astro/React (`tsc --noEmit`)