### PR TITLE
fix(event): stop modal loop when joining via ?play=1 URL

### DIFF
--- a/src/components/react/event/MiniGamesRoot.tsx
+++ b/src/components/react/event/MiniGamesRoot.tsx
@@ -99,7 +99,7 @@ export function MiniGamesRoot({ slug }: Props) {
       return;
     }
 
-    if (step === "joined" && !forcePlay) return;
+    if (step === "joined") return;
     if (step === "dismissed" && !forcePlay) return;
 
     if (alias && !forcePlay) {


### PR DESCRIPTION
## Problema

Cuando un participante abría la página del evento con `?play=1` en la URL, el modal de unión volvía a aparecer inmediatamente después de hacer click en **Conectarme**, en loop infinito. El join llegaba a completarse en el backend (HTTP 200) pero la app nunca avanzaba al estado `joined`.

**Causa raíz:** `MiniGamesRoot` tiene un effect que maneja la máquina de estados. El guard que protege el estado `joined` dependía de `!forcePlay`:

```ts
if (step === "joined" && !forcePlay) return;
```

Con `?play=1` en la URL, `forcePlay = true`, por lo que el guard no frenaba el effect. El effect caía hasta `setStep("modal")` en cada re-render, volviendo a abrir el modal.

## Fix

Quitar la dependencia de `forcePlay` del guard del estado `joined`. Una vez que el usuario se unió exitosamente en esta sesión, el estado es terminal:

```ts
// antes
if (step === "joined" && !forcePlay) return;

// después
if (step === "joined") return;
```

`?play=1` está pensado para forzar el modal en visitantes que tienen alias guardado en localStorage (auto-rejoin silencioso → modal explícito). No tiene sentido interrumpir a alguien que acaba de unirse en la sesión actual.

## Test plan

- [ ] Abrir `/eventos/{slug}?play=1` sin alias guardado → aparece modal → unirse → modal cierra y aparece el overlay del juego activo
- [ ] Abrir `/eventos/{slug}?play=1` con alias guardado en localStorage → aparece modal (comportamiento de `forcePlay` preservado)
- [ ] Abrir `/eventos/{slug}` sin `?play=1` y con alias guardado → auto-rejoin silencioso (sin cambios)
- [ ] 6/6 tests de `MiniGamesRoot` pasan (`pnpm test`)