### PR TITLE
feat(projector): QR toggle button to expand/collapse during live games

### DIFF
--- a/src/components/react/event/ProjectorView.tsx
+++ b/src/components/react/event/ProjectorView.tsx
@@ -19,6 +19,8 @@ interface Props {
 
 export function ProjectorView({ slug, eventName, joinUrl, qrSvg }: Props) {
   const { liveInstances } = useLiveMinigames(slug);
+  const [qrExpanded, setQrExpanded] = useState(false);
+
   // Skip realtime instances whose snapshotted config is missing — same
   // guard the participant overlay uses.
   const visible = useMemo(
@@ -85,13 +87,38 @@ export function ProjectorView({ slug, eventName, joinUrl, qrSvg }: Props) {
               <br />
               <span className="font-mono text-white">{joinUrl}</span>
             </p>
-            <div
-              className="h-24 w-24 rounded bg-white p-1"
-              dangerouslySetInnerHTML={{ __html: qrSvg }}
-              aria-label="QR para unirse"
-            />
+            <button
+              type="button"
+              onClick={() => setQrExpanded(true)}
+              className="h-24 w-24 rounded bg-white p-1 transition hover:ring-2 hover:ring-white/60"
+              aria-label="Agrandar QR"
+            >
+              <div dangerouslySetInnerHTML={{ __html: qrSvg }} />
+            </button>
           </div>
         </footer>
+      )}
+
+      {qrExpanded && (
+        <div
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-8 bg-black/90 p-8"
+          onClick={() => setQrExpanded(false)}
+        >
+          <button
+            type="button"
+            onClick={() => setQrExpanded(false)}
+            className="absolute top-6 right-8 rounded-lg border border-white/20 px-4 py-2 text-sm text-white/70 hover:bg-white/10"
+            aria-label="Cerrar QR grande"
+          >
+            ✕ Achicar
+          </button>
+          <div
+            className="h-[60vh] max-h-[640px] w-[60vh] max-w-[640px] rounded-2xl bg-white p-6"
+            dangerouslySetInnerHTML={{ __html: qrSvg }}
+            aria-label="QR de unión ampliado"
+          />
+          <p className="font-mono text-xl text-white/80">{joinUrl}</p>
+        </div>
       )}
     </div>
   );

--- a/src/components/react/event/__tests__/ProjectorView.test.tsx
+++ b/src/components/react/event/__tests__/ProjectorView.test.tsx
@@ -250,11 +250,11 @@ describe("ProjectorView", () => {
       error: null,
     });
     renderProjector();
-    expect(screen.getByLabelText("QR para unirse")).toBeInTheDocument();
+    expect(screen.getByLabelText("Agrandar QR")).toBeInTheDocument();
     expect(screen.getByText(/Recién llegando/i)).toBeInTheDocument();
   });
 
-  it("renders no interactive buttons (read-only view)", () => {
+  it("renders no interactive buttons in game content (read-only view)", () => {
     mocks.useLiveMinigames.mockReturnValue({
       loading: false,
       liveInstances: [
@@ -271,6 +271,10 @@ describe("ProjectorView", () => {
       error: null,
     });
     renderProjector();
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    // The only button allowed in the projector is the QR toggle (presenter
+    // control). Game content itself must not render interactive elements.
+    const buttons = screen.queryAllByRole("button");
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toHaveAttribute("aria-label", "Agrandar QR");
   });
 });


### PR DESCRIPTION
## Qué hace

Agrega un botón toggle al QR del footer del proyector para que el organizador pueda agrandarlo o achicarlo durante el evento sin salir de la vista de juegos.

## Comportamiento

**QR pequeño (estado por defecto)**
El QR en la esquina inferior derecha es ahora un `<button>` en lugar de un `<div>`. Al hover muestra un ring blanco indicando que es clickeable. Click → abre el QR grande.

**QR grande (overlay)**
- Overlay `fixed inset-0` con fondo negro semitransparente (`bg-black/90`)
- QR centrado a `60vh × 60vh` (igual al hero cuando no hay juego activo)
- URL de unión debajo en texto mono
- Botón `✕ Achicar` en la esquina superior derecha
- Click en cualquier parte del overlay también lo cierra

El contenido del juego (encuesta, quiz, nube de palabras, bingo) permanece visible debajo del overlay cuando está abierto — útil para mostrar el QR a late joiners sin perder el contexto del juego.

## Tests

- Actualizado `"QR para unirse"` → `"Agrandar QR"` en el aria-label del elemento.
- Actualizado el test de read-only: el proyector puede tener exactamente 1 botón (el toggle del QR); el contenido de los juegos sigue sin botones.
- 8/8 tests pasan.