### PR TITLE
fix(event): re-join silently when a new live instance appears after join

### DIFF
--- a/src/components/react/event/MiniGamesRoot.tsx
+++ b/src/components/react/event/MiniGamesRoot.tsx
@@ -72,6 +72,14 @@ export function MiniGamesRoot({ slug }: Props) {
     };
   }, []);
 
+  // Instance IDs the participant has a Firestore participant doc for.
+  // /join only creates docs for currently-live instances, so if the quiz
+  // goes live after the participant already joined we need to re-join to
+  // get a doc created — otherwise Firestore rules deny the answer write.
+  const [registeredIds, setRegisteredIds] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
+
   const submitJoin = useCallback(
     async (
       pendingAlias: string
@@ -82,12 +90,25 @@ export function MiniGamesRoot({ slug }: Props) {
         writeStoredAlias(slug, stored);
         setAlias(stored);
         setStep("joined");
+        setRegisteredIds(
+          new Set(res.data.instances.map((i: { id: string }) => i.id))
+        );
         return { success: true };
       }
       return { success: false, error: res.error };
     },
     [slug]
   );
+
+  // When already joined and a new live instance appears that we have no
+  // participant doc for, silently re-join. /join is idempotent — existing
+  // docs are left untouched; only the new instance gets a doc created.
+  useEffect(() => {
+    if (step !== "joined" || !alias) return;
+    const unregistered = liveInstances.filter((i) => !registeredIds.has(i.id));
+    if (unregistered.length === 0) return;
+    submitJoin(alias);
+  }, [liveInstances, step, alias, registeredIds, submitJoin]);
 
   // Drive the state machine off (live instances, alias, dismissed).
   useEffect(() => {

--- a/src/components/react/event/__tests__/MiniGamesRoot.test.tsx
+++ b/src/components/react/event/__tests__/MiniGamesRoot.test.tsx
@@ -137,6 +137,57 @@ describe("MiniGamesRoot", () => {
     expect(mocks.joinEventMinigames).not.toHaveBeenCalled();
   });
 
+  it("silently re-joins when a new live instance appears after already joined", async () => {
+    // Participant joins while only the poll is live.
+    window.localStorage.setItem("gdg_minigame_alias_x", "Ana");
+    const { rerender } = render(<MiniGamesRoot slug="x" />);
+
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [POLL],
+      error: null,
+    });
+    rerender(<MiniGamesRoot slug="x" />);
+
+    await waitFor(() =>
+      expect(mocks.joinEventMinigames).toHaveBeenCalledTimes(1)
+    );
+
+    // Quiz goes live after the participant already joined — new instance.
+    const QUIZ: LiveInstance = {
+      id: "i-quiz",
+      type: "quiz",
+      mode: "realtime",
+      state: "live",
+      title: "Live quiz",
+      order: 1,
+    };
+    mocks.joinEventMinigames.mockResolvedValueOnce({
+      success: true,
+      data: {
+        alias: "Ana",
+        instances: [
+          { id: "i-poll", type: "poll", joined: false },
+          { id: "i-quiz", type: "quiz", joined: true },
+        ],
+      },
+    });
+    mocks.useLiveMinigames.mockReturnValue({
+      loading: false,
+      liveInstances: [POLL, QUIZ],
+      error: null,
+    });
+    rerender(<MiniGamesRoot slug="x" />);
+
+    // Should re-join automatically to get a participant doc for the quiz.
+    await waitFor(() =>
+      expect(mocks.joinEventMinigames).toHaveBeenCalledTimes(2)
+    );
+    expect(mocks.joinEventMinigames).toHaveBeenLastCalledWith("x", {
+      alias: "Ana",
+    });
+  });
+
   it("forces the modal open when ?play=1 is in the URL even with stored alias", async () => {
     window.localStorage.setItem("gdg_minigame_alias_x", "Ana");
     window.history.replaceState({}, "", "/eventos/x?play=1");


### PR DESCRIPTION
## Problema

`Missing or insufficient permissions` al intentar responder el quiz si el participante se unió al evento antes de que el quiz fuera activado.

**Causa raíz:** El endpoint `/join` crea documentos en `participants/{uid}` únicamente para las instancias que están en estado `live` en el momento de la llamada. Si el quiz estaba `scheduled` cuando el participante se unió, su doc no existe en esa instancia.

La regla de Firestore para escribir una respuesta exige:
```
exists(events/{slug}/minigames/{id}/participants/{uid})
```

Cuando el admin activa el quiz más tarde, el overlay aparece en el celular del participante (la query de Firestore funciona por `onSnapshot`), pero al intentar responder, la regla rechaza la escritura porque el doc de participante no existe para esa instancia.

## Fix

Se agrega un `registeredIds` que rastrea qué instancias tienen doc de participante. Cuando `liveInstances` cambia y aparece una instancia nueva no registrada, se llama `/join` de forma silenciosa. El endpoint es **idempotente** — los docs existentes no se tocan; solo se crean los que faltan.

```
Participante unido (poll live) → quiz se activa → effect detecta id nuevo
→ /join silencioso → doc creado para el quiz → respuestas permitidas ✓
```

## Tests

- Nuevo test: `"silently re-joins when a new live instance appears after already joined"` verifica que `/join` se llama una segunda vez cuando aparece una instancia no registrada.
- 7/7 tests pasan.