### PR TITLE
fix(trigger): show all quiz participants in leaderboard, not just score > 0

### DIFF
--- a/functions/src/triggers/recomputeAggregates.test.ts
+++ b/functions/src/triggers/recomputeAggregates.test.ts
@@ -202,13 +202,12 @@ describe("recomputeAggregatesFromEvent", () => {
     ]);
   });
 
-  it("filters out participants with zero score from the leaderboard", async () => {
+  it("includes participants with zero score in the leaderboard", async () => {
     const wiring = wire({
       instanceType: "quiz",
       participants: [
         { id: "u1", alias: "Ana", quizScore: 100 },
-        { id: "u2", alias: "Bea" }, // no score yet
-        { id: "u3", alias: "Zero", quizScore: 0 },
+        { id: "u2", alias: "Zero", quizScore: 0 },
       ],
     });
     await recomputeAggregatesFromEvent(
@@ -219,6 +218,7 @@ describe("recomputeAggregatesFromEvent", () => {
     };
     expect(leaderboardPayload.leaderboard).toEqual([
       { uid: "u1", alias: "Ana", score: 100 },
+      { uid: "u2", alias: "Zero", score: 0 },
     ]);
   });
 

--- a/functions/src/triggers/recomputeAggregates.ts
+++ b/functions/src/triggers/recomputeAggregates.ts
@@ -85,16 +85,14 @@ export async function recomputeAggregatesFromEvent(
     .limit(LEADERBOARD_LIMIT)
     .get();
 
-  const leaderboard = (topSnap.docs as ParticipantSnap[])
-    .map((d) => {
-      const pd = d.data();
-      return {
-        uid: d.id,
-        alias: typeof pd?.alias === "string" ? pd.alias : "Anónimo",
-        score: typeof pd?.quizScore === "number" ? pd.quizScore : 0,
-      };
-    })
-    .filter((entry) => entry.score > 0);
+  const leaderboard = (topSnap.docs as ParticipantSnap[]).map((d) => {
+    const pd = d.data();
+    return {
+      uid: d.id,
+      alias: typeof pd?.alias === "string" ? pd.alias : "Anónimo",
+      score: typeof pd?.quizScore === "number" ? pd.quizScore : 0,
+    };
+  });
 
   await aggregateRef.set(
     {


### PR DESCRIPTION
## Problema

El leaderboard del quiz nunca aparecía en el proyector ni en los celulares cuando todos los participantes tenían 0 puntos (respondieron incorrectamente o el timer expiró).

**Causa raíz:** el trigger `recomputeAggregates` filtraba los participantes con `score > 0` antes de escribir el leaderboard:

```ts
.filter((entry) => entry.score > 0)
```

Si nadie acertó una pregunta, todos tienen puntaje 0 → el array queda vacío → el componente no lo renderiza → el leaderboard nunca aparece.

## Fix

Quitar el filtro. El leaderboard muestra a todos los participantes que respondieron al menos una pregunta (los que tienen el campo `quizScore` en Firestore), ordenados por puntaje descendente. Quedar en cero es un resultado válido que merece aparecer en la tabla.

## Tests

- Renombrado el test `"filters out participants with zero score"` → `"includes participants with zero score in the leaderboard"` con la expectativa corregida.
- 9/9 tests del trigger pasan.