### PR TITLE
fix(handler): serialize Firestore Timestamps as ISO strings in template list

### DIFF
--- a/functions/src/handlers/minigameTemplates.test.ts
+++ b/functions/src/handlers/minigameTemplates.test.ts
@@ -112,10 +112,29 @@ describe("minigameTemplates handler", () => {
   });
 
   describe("list", () => {
-    it("returns docs ordered by updatedAt desc", async () => {
+    it("returns docs ordered by updatedAt desc with ISO timestamps", async () => {
+      const fakeTs = (iso: string) => ({
+        toDate: () => new Date(iso),
+      });
       const docs = [
-        { id: "t1", data: () => ({ ...samplePoll, version: 2 }) },
-        { id: "t2", data: () => ({ ...sampleQuiz, version: 1 }) },
+        {
+          id: "t1",
+          data: () => ({
+            ...samplePoll,
+            version: 2,
+            createdAt: fakeTs("2026-01-01T00:00:00.000Z"),
+            updatedAt: fakeTs("2026-05-01T12:00:00.000Z"),
+          }),
+        },
+        {
+          id: "t2",
+          data: () => ({
+            ...sampleQuiz,
+            version: 1,
+            createdAt: fakeTs("2026-02-01T00:00:00.000Z"),
+            updatedAt: fakeTs("2026-04-01T08:00:00.000Z"),
+          }),
+        },
       ];
       const orderBy = vi.fn(() => ({ get: vi.fn(async () => ({ docs })) }));
       collectionMock.mockReturnValue({ orderBy });
@@ -129,8 +148,20 @@ describe("minigameTemplates handler", () => {
       expect(res.json).toHaveBeenCalledWith({
         success: true,
         data: [
-          { id: "t1", ...samplePoll, version: 2 },
-          { id: "t2", ...sampleQuiz, version: 1 },
+          {
+            id: "t1",
+            ...samplePoll,
+            version: 2,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-05-01T12:00:00.000Z",
+          },
+          {
+            id: "t2",
+            ...sampleQuiz,
+            version: 1,
+            createdAt: "2026-02-01T00:00:00.000Z",
+            updatedAt: "2026-04-01T08:00:00.000Z",
+          },
         ],
       });
     });

--- a/functions/src/handlers/minigameTemplates.ts
+++ b/functions/src/handlers/minigameTemplates.ts
@@ -28,6 +28,12 @@ function auditEntry(
   };
 }
 
+function toIso(
+  ts: admin.firestore.Timestamp | null | undefined
+): string | null {
+  return ts?.toDate?.().toISOString() ?? null;
+}
+
 export async function list(_req: Request, res: Response) {
   try {
     const snap = await admin
@@ -37,7 +43,15 @@ export async function list(_req: Request, res: Response) {
       .get();
     res.json({
       success: true,
-      data: snap.docs.map((d) => ({ id: d.id, ...d.data() })),
+      data: snap.docs.map((d) => {
+        const data = d.data();
+        return {
+          id: d.id,
+          ...data,
+          createdAt: toIso(data.createdAt),
+          updatedAt: toIso(data.updatedAt),
+        };
+      }),
     });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });


### PR DESCRIPTION
## Problema

El campo **Última actualización** siempre mostraba `—` en `/admin/minigame-templates/` para todas las plantillas, sin importar cuándo fueron creadas o editadas.

**Causa raíz:** el Admin SDK de Firestore devuelve los Timestamps como objetos con `.toDate()` pero al serializarlos con `JSON.stringify` en la respuesta Express, el resultado **no** incluye la propiedad `seconds` que el frontend espera:

```ts
// frontend formatUpdatedAt busca:
if ("seconds" in value) { ... }  // nunca se cumple

// porque el Admin SDK serializa como objetos sin toJSON estándar
```

## Fix

Convertir los Timestamps a ISO strings en el handler antes de enviar el JSON:

```ts
function toIso(ts) {
  return ts?.toDate?.().toISOString() ?? null;
}

// en list():
{ ...data, createdAt: toIso(data.createdAt), updatedAt: toIso(data.updatedAt) }
```

El frontend ya maneja strings ISO en `formatUpdatedAt`:
```ts
if (typeof value === "string") {
  const d = new Date(value);
  if (!Number.isNaN(d.getTime())) return d.toLocaleString("es-PE");
}
```

## Tests

- Actualizado el test de `list` para incluir Timestamps mockeados (con `.toDate()`) y verificar que la respuesta contiene strings ISO.
- 10/10 tests del handler pasan.