### PR TITLE
feat: add roulette mini-game type

### DIFF
--- a/functions/src/handlers/minigameInstances.ts
+++ b/functions/src/handlers/minigameInstances.ts
@@ -116,6 +116,11 @@ export async function attach(req: Request, res: Response) {
       baseInstance.currentQuestionIndex = -1;
       baseInstance.currentQuestionStartedAt = null;
     }
+    if (tpl.type === "roulette") {
+      baseInstance.spinCount = 0;
+      baseInstance.lastSpinWinnerId = null;
+      baseInstance.lastSpinAt = null;
+    }
 
     const ref = await instancesCol(slug).add(baseInstance);
 
@@ -302,5 +307,7 @@ function pickConfig(tpl: MinigameTemplate): Record<string, unknown> {
       return { ...tpl.wordcloud };
     case "bingo":
       return { ...tpl.bingo };
+    case "roulette":
+      return { ...tpl.roulette };
   }
 }

--- a/functions/src/handlers/minigameRoulette.ts
+++ b/functions/src/handlers/minigameRoulette.ts
@@ -1,0 +1,99 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { safeError } from "../middleware/validate";
+
+// POST /api/events/:slug/minigames/:id/roulette/spin
+//
+// Picks a random participant who hasn't won yet, records their win on the
+// participant doc and updates the instance doc so all real-time listeners
+// (projector, participant views) can react to the new spin immediately.
+// Uses a transaction to keep spinCount and rouletteWonAt consistent.
+export async function spin(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const id = req.params.id as string;
+    const user = (req as AuthenticatedRequest).user;
+    const db = admin.firestore();
+
+    const instanceRef = db.doc(`events/${slug}/minigames/${id}`);
+    const instanceSnap = await instanceRef.get();
+    if (!instanceSnap.exists) {
+      res
+        .status(404)
+        .json({ success: false, error: "Instancia no encontrada" });
+      return;
+    }
+    const instance = instanceSnap.data() as
+      | { type?: string; state?: string; spinCount?: number }
+      | undefined;
+    if (instance?.type !== "roulette") {
+      res
+        .status(400)
+        .json({ success: false, error: "No es una instancia de ruleta" });
+      return;
+    }
+    if (instance?.state !== "live") {
+      res
+        .status(400)
+        .json({
+          success: false,
+          error: "La ruleta debe estar en vivo para girar",
+        });
+      return;
+    }
+
+    // Load all participants who haven't won yet.
+    const participantsCol = instanceRef.collection("participants");
+    const eligibleSnap = await participantsCol
+      .where("rouletteWonAt", "==", null)
+      .get();
+
+    if (eligibleSnap.empty) {
+      res
+        .status(400)
+        .json({ success: false, error: "No hay participantes elegibles" });
+      return;
+    }
+
+    const eligible = eligibleSnap.docs;
+    const winner = eligible[Math.floor(Math.random() * eligible.length)];
+    const winnerData = winner.data() as { alias?: string };
+    const alias = winnerData.alias ?? "Anónimo";
+    const now = admin.firestore.FieldValue.serverTimestamp();
+
+    const spinNumber = await db.runTransaction(async (tx) => {
+      const freshSnap = await tx.get(instanceRef);
+      const spinCount =
+        ((freshSnap.data() as { spinCount?: number })?.spinCount ?? 0) + 1;
+
+      tx.update(instanceRef, {
+        spinCount,
+        lastSpinWinnerId: winner.id,
+        lastSpinAt: now,
+      });
+      tx.update(participantsCol.doc(winner.id), {
+        rouletteWonAt: now,
+        rouletteSpinNumber: spinCount,
+      });
+
+      return spinCount;
+    });
+
+    db.collection("audit_log").add({
+      action: "minigame_instance.roulette.spin",
+      performedBy: user.uid,
+      targetId: id,
+      targetType: "minigame_instance",
+      details: { slug, winnerId: winner.id, alias, spinNumber },
+      timestamp: now,
+    });
+
+    res.json({
+      success: true,
+      data: { winnerId: winner.id, alias, spinNumber },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -33,6 +33,7 @@ import * as minigameTemplates from "./handlers/minigameTemplates";
 import * as minigameInstances from "./handlers/minigameInstances";
 import * as minigameJoin from "./handlers/minigameJoin";
 import * as minigameWords from "./handlers/minigameWords";
+import * as minigameRoulette from "./handlers/minigameRoulette";
 
 admin.initializeApp();
 
@@ -359,6 +360,16 @@ app.post(
   joinLimiter,
   validateBody(minigameJoinSchema),
   minigameJoin.join
+);
+
+// Roulette spin (admin-only)
+app.post(
+  "/api/events/:slug/minigames/:id/roulette/spin",
+  requireRole("admin"),
+  slugP,
+  vid,
+  writeLimiter,
+  minigameRoulette.spin
 );
 
 // Word cloud moderation + bingo winners (admin-only)

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -220,6 +220,17 @@ export const minigameTemplateSchema = z.discriminatedUnion("type", [
         .strict(),
     })
     .strict(),
+  z
+    .object({
+      type: z.literal("roulette"),
+      ...baseTemplate,
+      roulette: z
+        .object({
+          prize: shortText(120).optional(),
+        })
+        .strict(),
+    })
+    .strict(),
 ]);
 
 export type MinigameTemplate = z.infer<typeof minigameTemplateSchema>;

--- a/src/components/react/admin/event-minigames/EventMinigameManager.tsx
+++ b/src/components/react/admin/event-minigames/EventMinigameManager.tsx
@@ -4,6 +4,7 @@ import { Toast } from "../ui/Toast";
 import { AttachTemplateModal } from "./AttachTemplateModal";
 import { BingoWinnersPanel } from "./BingoWinnersPanel";
 import { InstanceCard } from "./InstanceCard";
+import { RoulettePanel } from "./RoulettePanel";
 import { WordModerationPanel } from "./WordModerationPanel";
 import type { InstanceState, MinigameInstance } from "./types";
 
@@ -101,6 +102,24 @@ export function EventMinigameManager({ initialSlug }: Props) {
     } else {
       setToast({
         message: res.error || "Error al avanzar pregunta",
+        type: "error",
+      });
+    }
+    setBusyId(null);
+  }
+
+  async function handleSpin(id: string) {
+    if (!slug) return;
+    setBusyId(id);
+    const res = await api.spinRoulette(slug, id);
+    if (res.success && res.data) {
+      setToast({
+        message: `🎉 Ganó: ${res.data.alias} (giro #${res.data.spinNumber})`,
+        type: "success",
+      });
+    } else {
+      setToast({
+        message: res.error || "Error al girar la ruleta",
         type: "error",
       });
     }
@@ -205,9 +224,14 @@ export function EventMinigameManager({ initialSlug }: Props) {
               onAdvanceQuiz={() => handleAdvanceQuiz(inst.id)}
               onDelete={() => handleDelete(inst.id)}
               onOpenModeration={
-                inst.type === "wordcloud" || inst.type === "bingo"
+                inst.type === "wordcloud" ||
+                inst.type === "bingo" ||
+                inst.type === "roulette"
                   ? () => setModerationFor(inst)
                   : undefined
+              }
+              onSpin={
+                inst.type === "roulette" ? () => handleSpin(inst.id) : undefined
               }
             />
           ))}
@@ -224,6 +248,14 @@ export function EventMinigameManager({ initialSlug }: Props) {
       )}
       {moderationFor && moderationFor.type === "bingo" && (
         <BingoWinnersPanel
+          slug={slug!}
+          instanceId={moderationFor.id}
+          title={moderationFor.title}
+          onClose={() => setModerationFor(null)}
+        />
+      )}
+      {moderationFor && moderationFor.type === "roulette" && (
+        <RoulettePanel
           slug={slug!}
           instanceId={moderationFor.id}
           title={moderationFor.title}

--- a/src/components/react/admin/event-minigames/InstanceCard.tsx
+++ b/src/components/react/admin/event-minigames/InstanceCard.tsx
@@ -14,9 +14,11 @@ interface Props {
   onAdvanceQuiz: () => Promise<void> | void;
   onDelete: () => Promise<void> | void;
   busy: boolean;
-  // PR5: opens the moderation/winners side panel for global games.
+  // Opens the moderation/winners side panel for global games.
   // Optional so admin tests of the card itself don't need to wire it.
   onOpenModeration?: () => void;
+  // Roulette-specific: spin the wheel.
+  onSpin?: () => Promise<void> | void;
 }
 
 function questionCount(instance: MinigameInstance): number {
@@ -32,11 +34,12 @@ export function InstanceCard({
   onDelete,
   busy,
   onOpenModeration,
+  onSpin,
 }: Props) {
   const moderationLabel =
     instance.type === "wordcloud"
       ? "Ver moderación"
-      : instance.type === "bingo"
+      : instance.type === "bingo" || instance.type === "roulette"
         ? "Ver ganadores"
         : null;
   const moderationVisible =
@@ -149,6 +152,16 @@ export function InstanceCard({
                 className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
               >
                 ⏭ Avanzar pregunta
+              </button>
+            )}
+            {instance.type === "roulette" && onSpin && (
+              <button
+                type="button"
+                onClick={() => onSpin()}
+                disabled={busy}
+                className="rounded-lg bg-rose-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+              >
+                🎰 Girar ruleta
               </button>
             )}
           </>

--- a/src/components/react/admin/event-minigames/RoulettePanel.tsx
+++ b/src/components/react/admin/event-minigames/RoulettePanel.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import { api } from "@/lib/api";
+import { useRouletteParticipants } from "@/components/react/event/useRouletteParticipants";
+
+interface Props {
+  slug: string;
+  instanceId: string;
+  title: string;
+  onClose: () => void;
+}
+
+export function RoulettePanel({ slug, instanceId, title, onClose }: Props) {
+  const { eligible, winners, loading, error } = useRouletteParticipants(
+    slug,
+    instanceId
+  );
+  const [spinning, setSpinning] = useState(false);
+  const [spinError, setSpinError] = useState<string | null>(null);
+  const [lastWinner, setLastWinner] = useState<{
+    alias: string;
+    spinNumber: number;
+  } | null>(null);
+
+  async function handleSpin() {
+    setSpinning(true);
+    setSpinError(null);
+    setLastWinner(null);
+    const res = await api.spinRoulette(slug, instanceId);
+    if (res.success && res.data) {
+      setLastWinner({ alias: res.data.alias, spinNumber: res.data.spinNumber });
+    } else {
+      setSpinError(res.error ?? "Error al girar la ruleta");
+    }
+    setSpinning(false);
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <button
+        type="button"
+        aria-label="Cerrar fondo"
+        className="fixed inset-0 cursor-default bg-black/60"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Ruleta: ${title}`}
+        className="relative z-10 max-h-[90vh] w-full max-w-lg overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-gray-800"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+          <div>
+            <p className="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+              Ruleta
+            </p>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+              {title}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-1 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+            aria-label="Cerrar"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="max-h-[75vh] space-y-5 overflow-y-auto p-6">
+          {/* Stats bar */}
+          <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm dark:border-gray-700 dark:bg-gray-900/40">
+            <span className="text-gray-600 dark:text-gray-400">
+              <span className="font-semibold text-gray-900 dark:text-white">
+                {loading ? "…" : eligible.length}
+              </span>{" "}
+              elegibles
+            </span>
+            <span className="text-gray-400">·</span>
+            <span className="text-gray-600 dark:text-gray-400">
+              <span className="font-semibold text-gray-900 dark:text-white">
+                {loading ? "…" : winners.length}
+              </span>{" "}
+              ganadores
+            </span>
+          </div>
+
+          {/* Spin button */}
+          <button
+            type="button"
+            onClick={handleSpin}
+            disabled={spinning || loading || eligible.length === 0}
+            className="w-full rounded-xl bg-rose-600 py-3 text-base font-semibold text-white hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {spinning ? "Girando…" : "🎰 Girar ruleta"}
+          </button>
+
+          {/* Last winner banner */}
+          {lastWinner && (
+            <div className="rounded-xl border border-green-300 bg-green-50 px-5 py-4 text-center dark:border-green-700 dark:bg-green-900/20">
+              <p className="text-2xl" aria-hidden>
+                🎉
+              </p>
+              <p className="mt-1 font-bold text-green-800 dark:text-green-300">
+                ¡{lastWinner.alias} ganó el giro #{lastWinner.spinNumber}!
+              </p>
+            </div>
+          )}
+
+          {spinError && (
+            <p className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+              {spinError}
+            </p>
+          )}
+
+          {error && (
+            <p className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+              {error}
+            </p>
+          )}
+
+          {/* Winners leaderboard */}
+          {winners.length > 0 && (
+            <div>
+              <p className="mb-2 text-xs font-semibold tracking-wider text-gray-500 uppercase dark:text-gray-400">
+                Ganadores
+              </p>
+              <ol className="space-y-2">
+                {winners.map((w, i) => (
+                  <li
+                    key={w.uid}
+                    className="flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-3 dark:border-gray-700"
+                  >
+                    <span className="text-lg" aria-hidden>
+                      {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : "🎉"}
+                    </span>
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      {w.alias}
+                    </p>
+                    <span className="ml-auto text-xs text-gray-400 dark:text-gray-500">
+                      Giro #{w.rouletteSpinNumber}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          {/* Eligible participants list */}
+          {eligible.length > 0 && (
+            <details className="group">
+              <summary className="cursor-pointer text-xs font-semibold tracking-wider text-gray-500 uppercase hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300">
+                Elegibles ({eligible.length})
+              </summary>
+              <ul className="mt-2 space-y-1">
+                {eligible.map((p) => (
+                  <li
+                    key={p.uid}
+                    className="text-sm text-gray-700 dark:text-gray-300"
+                  >
+                    {p.alias}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          {!loading && eligible.length === 0 && winners.length === 0 && (
+            <p className="py-4 text-center text-sm text-gray-500 dark:text-gray-400">
+              Aún no hay participantes en la ruleta.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/minigame-templates/MinigameTemplateForm.tsx
+++ b/src/components/react/admin/minigame-templates/MinigameTemplateForm.tsx
@@ -11,6 +11,7 @@ import { PollFields } from "./forms/PollFields";
 import { QuizFields } from "./forms/QuizFields";
 import { WordCloudFields } from "./forms/WordCloudFields";
 import { BingoFields } from "./forms/BingoFields";
+import { RouletteFields } from "./forms/RouletteFields";
 
 interface Props {
   initial: Template;
@@ -64,6 +65,9 @@ function validate(template: Template): FormErrors {
       if (template.bingo.terms.length < 16) {
         errors.config = "El bingo necesita al menos 16 términos";
       }
+      break;
+    case "roulette":
+      // No required fields — prize is optional.
       break;
   }
   return errors;
@@ -195,6 +199,12 @@ export function MinigameTemplateForm({
             <BingoFields
               value={template.bingo}
               onChange={(next) => setTemplate({ ...template, bingo: next })}
+            />
+          )}
+          {template.type === "roulette" && (
+            <RouletteFields
+              value={template.roulette}
+              onChange={(next) => setTemplate({ ...template, roulette: next })}
             />
           )}
           {submitted && errors.config && (

--- a/src/components/react/admin/minigame-templates/forms/RouletteFields.tsx
+++ b/src/components/react/admin/minigame-templates/forms/RouletteFields.tsx
@@ -1,0 +1,48 @@
+import { inputClass, type RouletteConfig } from "../types";
+
+interface Props {
+  value: RouletteConfig;
+  onChange: (next: RouletteConfig) => void;
+}
+
+export function RouletteFields({ value, onChange }: Props) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+          Premio (opcional)
+        </label>
+        <input
+          type="text"
+          value={value.prize ?? ""}
+          onChange={(e) => onChange({ ...value, prize: e.target.value })}
+          placeholder="Ej. Camiseta GDG ICA, Stickers, ..."
+          maxLength={120}
+          className={inputClass}
+        />
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Se muestra a los participantes mientras esperan el giro.
+        </p>
+      </div>
+      <div className="rounded-lg border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800 dark:border-rose-800 dark:bg-rose-900/20 dark:text-rose-300">
+        <p className="font-medium">¿Cómo funciona la ruleta?</p>
+        <ul className="mt-2 list-disc space-y-1 pl-4">
+          <li>
+            Los asistentes se unen escaneando el QR del proyector y registrando
+            su nombre.
+          </li>
+          <li>
+            El admin gira la ruleta desde el panel de mini-juegos del evento.
+          </li>
+          <li>
+            Se elige un ganador al azar entre los participantes que aún no han
+            ganado.
+          </li>
+          <li>
+            Puedes girar la ruleta varias veces para elegir múltiples ganadores.
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/admin/minigame-templates/types.ts
+++ b/src/components/react/admin/minigame-templates/types.ts
@@ -1,4 +1,4 @@
-export type MinigameType = "poll" | "quiz" | "wordcloud" | "bingo";
+export type MinigameType = "poll" | "quiz" | "wordcloud" | "bingo" | "roulette";
 
 export interface OptionItem {
   id: string;
@@ -35,6 +35,10 @@ export interface BingoConfig {
   freeCenter: boolean;
 }
 
+export interface RouletteConfig {
+  prize?: string;
+}
+
 interface BaseTemplate {
   id?: string;
   title: string;
@@ -47,13 +51,15 @@ export type Template =
   | (BaseTemplate & { type: "poll"; poll: PollConfig })
   | (BaseTemplate & { type: "quiz"; quiz: QuizConfig })
   | (BaseTemplate & { type: "wordcloud"; wordcloud: WordCloudConfig })
-  | (BaseTemplate & { type: "bingo"; bingo: BingoConfig });
+  | (BaseTemplate & { type: "bingo"; bingo: BingoConfig })
+  | (BaseTemplate & { type: "roulette"; roulette: RouletteConfig });
 
 export const TYPE_LABELS: Record<MinigameType, string> = {
   poll: "Encuesta",
   quiz: "Quiz",
   wordcloud: "Nube de palabras",
   bingo: "Bingo",
+  roulette: "Ruleta",
 };
 
 export const TYPE_COLORS: Record<MinigameType, string> = {
@@ -62,6 +68,7 @@ export const TYPE_COLORS: Record<MinigameType, string> = {
   wordcloud:
     "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
   bingo: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+  roulette: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300",
 };
 
 function makeId(): string {
@@ -135,6 +142,13 @@ export function emptyForType(type: MinigameType): Template {
           cardSize: 4,
           freeCenter: false,
         },
+      };
+    case "roulette":
+      return {
+        type: "roulette",
+        title: "",
+        description: "",
+        roulette: { prize: "" },
       };
   }
 }

--- a/src/components/react/event/MiniGamesRoot.tsx
+++ b/src/components/react/event/MiniGamesRoot.tsx
@@ -6,6 +6,7 @@ import { BingoCardView } from "./BingoCardView";
 import { JoinModal } from "./JoinModal";
 import { PollOverlay } from "./PollOverlay";
 import { QuizOverlay } from "./QuizOverlay";
+import { RouletteView } from "./RouletteView";
 import { useLiveMinigames } from "./useLiveMinigames";
 import { WordCloudView } from "./WordCloudView";
 import { LOCAL_STORAGE_ALIAS_KEY, type LiveInstance } from "./types";
@@ -210,6 +211,15 @@ export function MiniGamesRoot({ slug }: Props) {
                     instanceId={inst.id}
                     uid={uid}
                     title={inst.title}
+                  />
+                )}
+                {inst.type === "roulette" && (
+                  <RouletteView
+                    slug={slug}
+                    instanceId={inst.id}
+                    uid={uid}
+                    title={inst.title}
+                    instance={inst}
                   />
                 )}
               </div>

--- a/src/components/react/event/ProjectorView.tsx
+++ b/src/components/react/event/ProjectorView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   PollConfig,
   QuizConfig,
@@ -7,6 +7,7 @@ import type {
 import { useAggregates } from "./useAggregates";
 import { useBingoWinners } from "./useBingoWinners";
 import { useLiveMinigames } from "./useLiveMinigames";
+import { useRouletteParticipants } from "./useRouletteParticipants";
 import { useWordCloud } from "./useWordCloud";
 import type { LiveInstance } from "./types";
 
@@ -70,6 +71,9 @@ export function ProjectorView({ slug, eventName, joinUrl, qrSvg }: Props) {
                 )}
                 {inst.type === "bingo" && (
                   <ProjectorBingo slug={slug} instance={inst} />
+                )}
+                {inst.type === "roulette" && (
+                  <ProjectorRoulette slug={slug} instance={inst} />
                 )}
               </article>
             ))}
@@ -413,13 +417,162 @@ function ProjectorBingo({
   );
 }
 
+// ---- Roulette -------------------------------------------------------------
+
+const SPIN_DURATION_MS = 4000;
+
+function ProjectorRoulette({
+  slug,
+  instance,
+}: {
+  slug: string;
+  instance: LiveInstance;
+}) {
+  const { eligible, winners, loading } = useRouletteParticipants(
+    slug,
+    instance.id
+  );
+  const prize = instance.config?.prize as string | undefined;
+
+  // Detect new spins by watching lastSpinAt from the live instance.
+  const lastSpinAtRef = useRef<number | null>(null);
+  const [spinning, setSpinning] = useState(false);
+  const [displayedWinner, setDisplayedWinner] = useState<string | null>(null);
+  // Index cycling through eligible names during animation
+  const [spinIndex, setSpinIndex] = useState(0);
+
+  const lastSpinAt = instance.lastSpinAt;
+  const lastSpinWinnerId = instance.lastSpinWinnerId;
+
+  useEffect(() => {
+    const newSeconds = lastSpinAt?.seconds ?? null;
+    if (newSeconds === null) return;
+    if (newSeconds === lastSpinAtRef.current) return;
+    lastSpinAtRef.current = newSeconds;
+
+    // A new spin just happened — start the slot-machine animation.
+    setSpinning(true);
+    setDisplayedWinner(null);
+
+    const stop = window.setTimeout(() => {
+      setSpinning(false);
+      // Reveal winner after animation completes.
+      const winnerEntry =
+        winners.find((w) => w.uid === lastSpinWinnerId) ??
+        // Winner might still be in `eligible` list if state hasn't settled; fall back.
+        null;
+      setDisplayedWinner(
+        winnerEntry?.alias ??
+          (lastSpinWinnerId
+            ? (eligible.find((p) => p.uid === lastSpinWinnerId)?.alias ??
+              "¡Ganador!")
+            : "¡Ganador!")
+      );
+    }, SPIN_DURATION_MS);
+
+    // Cycle through random names while spinning
+    let frame = 0;
+    const allNames = [...eligible, ...winners].map((p) => p.alias);
+    const cycle = window.setInterval(
+      () => {
+        if (allNames.length > 0) {
+          setSpinIndex((prev) => (prev + 1) % allNames.length);
+        }
+        frame++;
+      },
+      Math.max(50, 80 - frame * 2)
+    ); // accelerate then slow — simple approximation
+
+    return () => {
+      window.clearTimeout(stop);
+      window.clearInterval(cycle);
+    };
+  }, [lastSpinAt?.seconds]); // intentionally only fires on new spin timestamps
+
+  const allNames = useMemo(
+    () => [...eligible, ...winners].map((p) => p.alias),
+    [eligible, winners]
+  );
+
+  const spinLabel =
+    allNames.length > 0 ? allNames[spinIndex % allNames.length] : "…";
+
+  return (
+    <div>
+      <Badge color="rose">Ruleta</Badge>
+      <h2 className="mt-3 text-3xl font-bold">{instance.title}</h2>
+      {prize && <p className="mt-1 text-lg text-white/80">Premio: {prize}</p>}
+
+      {/* Slot machine / winner reveal */}
+      <div className="mt-6 flex min-h-[120px] items-center justify-center rounded-2xl border border-white/10 bg-black/40 p-6 text-center">
+        {loading ? (
+          <p className="text-white/60">Cargando participantes...</p>
+        ) : spinning ? (
+          <p
+            className="text-4xl font-extrabold tracking-tight text-rose-300 transition-none"
+            aria-live="off"
+          >
+            {spinLabel}
+          </p>
+        ) : displayedWinner ? (
+          <div>
+            <p className="text-2xl" aria-hidden>
+              🎉
+            </p>
+            <p className="mt-1 text-4xl font-extrabold text-green-300">
+              {displayedWinner}
+            </p>
+            <p className="mt-2 text-sm text-white/60">
+              Giro #{instance.spinCount}
+            </p>
+          </div>
+        ) : eligible.length === 0 && winners.length === 0 ? (
+          <p className="text-white/60">
+            Esperando que los participantes se unan...
+          </p>
+        ) : (
+          <p className="text-white/60">
+            {eligible.length} participante{eligible.length !== 1 && "s"}{" "}
+            elegibles
+            {winners.length > 0 && ` · ${winners.length} ya ganaron`}
+          </p>
+        )}
+      </div>
+
+      {/* Winners leaderboard */}
+      {winners.length > 0 && (
+        <div className="mt-6 rounded-xl border border-white/10 bg-black/40 p-4">
+          <p className="text-xs tracking-widest text-white/50 uppercase">
+            Ganadores
+          </p>
+          <ol className="mt-2 space-y-1 text-base">
+            {winners.map((w, i) => (
+              <li key={w.uid} className="flex items-center justify-between">
+                <span>
+                  <span aria-hidden className="mr-2">
+                    {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : "🎉"}
+                  </span>
+                  {w.alias}
+                </span>
+                <span className="text-sm text-white/60">
+                  #{w.rouletteSpinNumber}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ---- Shared --------------------------------------------------------------
 
 function Badge({
   color,
   children,
 }: {
-  color: "blue" | "purple" | "amber" | "green";
+  color: "blue" | "purple" | "amber" | "green" | "rose";
   children: React.ReactNode;
 }) {
   const palette: Record<typeof color, string> = {
@@ -427,6 +580,7 @@ function Badge({
     purple: "bg-purple-500/20 text-purple-200",
     amber: "bg-amber-500/20 text-amber-200",
     green: "bg-green-500/20 text-green-200",
+    rose: "bg-rose-500/20 text-rose-200",
   };
   return (
     <span

--- a/src/components/react/event/RouletteView.tsx
+++ b/src/components/react/event/RouletteView.tsx
@@ -1,0 +1,107 @@
+import { useRouletteParticipants } from "./useRouletteParticipants";
+import type { LiveInstance } from "./types";
+
+interface Props {
+  slug: string;
+  instanceId: string;
+  uid: string;
+  title: string;
+  instance: LiveInstance;
+}
+
+export function RouletteView({
+  slug,
+  instanceId,
+  uid,
+  title,
+  instance,
+}: Props) {
+  const { eligible, winners, loading } = useRouletteParticipants(
+    slug,
+    instanceId
+  );
+
+  const myWin = winners.find((w) => w.uid === uid);
+  const prize = instance.config?.prize as string | undefined;
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center gap-2">
+        <span className="inline-block rounded-full bg-rose-500/20 px-3 py-1 text-xs font-semibold tracking-widest text-rose-700 uppercase dark:text-rose-300">
+          Ruleta
+        </span>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          {title}
+        </h3>
+      </div>
+
+      {prize && (
+        <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
+          Premio: <span className="font-medium">{prize}</span>
+        </p>
+      )}
+
+      {myWin ? (
+        <div className="rounded-xl border border-green-300 bg-green-50 p-6 text-center dark:border-green-700 dark:bg-green-900/20">
+          <p className="text-4xl" aria-hidden>
+            🎉
+          </p>
+          <p className="mt-2 text-xl font-bold text-green-800 dark:text-green-300">
+            ¡Ganaste!
+          </p>
+          <p className="mt-1 text-sm text-green-700 dark:text-green-400">
+            Preséntate con el organizador para reclamar tu premio.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-gray-200 bg-gray-50 p-6 text-center dark:border-gray-700 dark:bg-gray-800/50">
+          <p className="text-3xl" aria-hidden>
+            🎯
+          </p>
+          <p className="mt-2 font-semibold text-gray-800 dark:text-gray-200">
+            Estás en la ruleta
+          </p>
+          {loading ? (
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Cargando participantes...
+            </p>
+          ) : (
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              {eligible.length} participante{eligible.length !== 1 && "s"}{" "}
+              elegibles · {winners.length} ganador{winners.length !== 1 && "es"}
+            </p>
+          )}
+          <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+            Espera a que el organizador gire la ruleta
+          </p>
+        </div>
+      )}
+
+      {winners.length > 0 && (
+        <div className="mt-4">
+          <p className="mb-2 text-xs font-semibold tracking-wider text-gray-500 uppercase dark:text-gray-400">
+            Ganadores anteriores
+          </p>
+          <ol className="space-y-1">
+            {winners.map((w, i) => (
+              <li
+                key={w.uid}
+                className={`flex items-center gap-2 text-sm ${
+                  w.uid === uid
+                    ? "font-bold text-green-700 dark:text-green-400"
+                    : "text-gray-700 dark:text-gray-300"
+                }`}
+              >
+                <span aria-hidden>
+                  {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : "🎉"}
+                </span>
+                {w.alias}
+                {w.uid === uid && " (tú)"}
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/react/event/types.ts
+++ b/src/components/react/event/types.ts
@@ -19,6 +19,10 @@ export interface LiveInstance {
   // into the relevant subtree; PR4 only needs `type` for badges.
   config?: Record<string, unknown>;
   currentQuestionIndex?: number;
+  // Roulette-specific runtime fields (written by Cloud Function on spin)
+  spinCount?: number;
+  lastSpinWinnerId?: string | null;
+  lastSpinAt?: { seconds: number; nanoseconds?: number } | null;
 }
 
 export const LOCAL_STORAGE_ALIAS_KEY = (slug: string) =>

--- a/src/components/react/event/useRouletteParticipants.ts
+++ b/src/components/react/event/useRouletteParticipants.ts
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import { getFirestore } from "@/lib/firebase";
+
+export interface RouletteParticipant {
+  uid: string;
+  alias: string;
+  joinedAt: { seconds: number; nanoseconds?: number } | null;
+  rouletteWonAt: { seconds: number; nanoseconds?: number } | null;
+  rouletteSpinNumber: number | null;
+}
+
+interface State {
+  all: RouletteParticipant[];
+  eligible: RouletteParticipant[];
+  winners: RouletteParticipant[];
+  loading: boolean;
+  error: string | null;
+}
+
+// Subscribes to all participants in a roulette instance. Derives eligible
+// (not yet won) and winners (won, ordered by spin number) client-side so
+// both the projector and participant view stay in sync with one listener.
+export function useRouletteParticipants(
+  slug: string | null,
+  instanceId: string | null
+): State {
+  const [state, setState] = useState<State>({
+    all: [],
+    eligible: [],
+    winners: [],
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!slug || !instanceId) {
+      setState({
+        all: [],
+        eligible: [],
+        winners: [],
+        loading: false,
+        error: null,
+      });
+      return;
+    }
+    let unsub: (() => void) | null = null;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const db = await getFirestore();
+        const { collection, onSnapshot } = await import("firebase/firestore");
+        if (cancelled) return;
+
+        unsub = onSnapshot(
+          collection(db, `events/${slug}/minigames/${instanceId}/participants`),
+          (snap) => {
+            const all = snap.docs.map((d) => ({
+              uid: d.id,
+              ...(d.data() as Omit<RouletteParticipant, "uid">),
+            })) as RouletteParticipant[];
+
+            const eligible = all.filter(
+              (p) => p.rouletteWonAt === null || p.rouletteWonAt === undefined
+            );
+            const winners = all
+              .filter(
+                (p) => p.rouletteWonAt !== null && p.rouletteWonAt !== undefined
+              )
+              .sort(
+                (a, b) =>
+                  (a.rouletteSpinNumber ?? 0) - (b.rouletteSpinNumber ?? 0)
+              );
+
+            setState({ all, eligible, winners, loading: false, error: null });
+          },
+          (err) => {
+            setState({
+              all: [],
+              eligible: [],
+              winners: [],
+              loading: false,
+              error: err.message,
+            });
+          }
+        );
+      } catch (err) {
+        setState({
+          all: [],
+          eligible: [],
+          winners: [],
+          loading: false,
+          error: err instanceof Error ? err.message : "Listener error",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (unsub) unsub();
+    };
+  }, [slug, instanceId]);
+
+  return state;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -155,6 +155,13 @@ const realApi = {
       `/events/${encodeURIComponent(slug)}/minigames/${id}/winners`
     ),
 
+  // Roulette spin (admin-only)
+  spinRoulette: (slug: string, id: string) =>
+    request<{ winnerId: string; alias: string; spinNumber: number }>(
+      "POST",
+      `/events/${encodeURIComponent(slug)}/minigames/${id}/roulette/spin`
+    ),
+
   // Rebuild
   triggerRebuild: () => request("POST", "/rebuild"),
 };


### PR DESCRIPTION
## Summary

- Adds a new **Ruleta** mini-game type where participants join via QR + alias and the admin spins a wheel to select random winners.
- Winners are excluded from subsequent spins (eliminating them from the wheel), enabling multiple prize draws from the same pool.
- Real-time projector animation: when a spin fires, the projector cycles through participant names slot-machine style for ~4 seconds then reveals the winner.
- Leaderboard tracks winners in spin order on both the projector and the admin panel.

### Files changed

**Backend (`functions/`):**
- `handlers/minigameRoulette.ts` — new `spin` endpoint (Firestore transaction: picks random eligible participant, sets `rouletteWonAt` + `rouletteSpinNumber`, updates instance `lastSpinAt`)
- `handlers/minigameInstances.ts` — `modeForType` + `pickConfig` + `attach` extended for `roulette`
- `schemas/index.ts` — roulette Zod branch (`{ prize?: string }`)
- `index.ts` — `POST /api/events/:slug/minigames/:id/roulette/spin` route registered

**Frontend:**
- `event/types.ts` — `LiveInstance` gets `spinCount?`, `lastSpinWinnerId?`, `lastSpinAt?`
- `event/useRouletteParticipants.ts` — real-time hook: subscribes to all participants, derives `eligible` / `winners` client-side
- `event/RouletteView.tsx` — participant view: "Estás en la ruleta" / "¡Ganaste!" + previous winners list
- `event/ProjectorView.tsx` — `ProjectorRoulette` component with slot-machine animation
- `event/MiniGamesRoot.tsx` — renders `RouletteView` for global roulette instances
- `admin/minigame-templates/types.ts` — `RouletteConfig`, `Template` union, `TYPE_LABELS/COLORS/emptyForType`
- `admin/minigame-templates/forms/RouletteFields.tsx` — minimal form (optional prize field)
- `admin/minigame-templates/MinigameTemplateForm.tsx` — roulette case wired
- `admin/event-minigames/InstanceCard.tsx` — "🎰 Girar ruleta" button for live roulette instances
- `admin/event-minigames/RoulettePanel.tsx` — full panel: spin button, winner banner, leaderboard, eligible list
- `admin/event-minigames/EventMinigameManager.tsx` — `handleSpin` + `RoulettePanel` mounted
- `src/lib/api.ts` — `spinRoulette()` method

## Test plan

- [ ] All 96 frontend tests pass (`npx vitest run src`)
- [ ] All 82 Cloud Function tests pass (`pnpm test` in `functions/`)
- [ ] Create a "Ruleta" template from `/admin` → attach to a test event → activate
- [ ] Join with 3 different aliases via QR
- [ ] Open projector — verify all 3 names appear as eligible
- [ ] Admin clicks "🎰 Girar ruleta" in InstanceCard or RoulettePanel → projector animates → reveals winner
- [ ] Winner disappears from eligible pool; repeat spin for remaining participants
- [ ] 4th spin returns "No hay participantes elegibles"
- [ ] Participant who won sees "¡Ganaste!" on their screen