### PR TITLE
fix: header buttons (exclamation mark and alignment)

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -13,7 +13,7 @@ type Variant = keyof typeof variantValues;
   target={target}
   href={href}
   rel={target === "_blank" ? "noopener noreferrer" : ""}
-  class=`inline-flex  gap-[10px] items-center font-medium justify-center px-8 py-[10px] border rounded-md ${variantValues[variant as Variant]}`
+  class=`inline-flex gap-[10px] items-center font-medium justify-center whitespace-nowrap px-8 py-[10px] border rounded-md ${variantValues[variant as Variant]}`
   {...props}
 >
   <slot />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -39,7 +39,7 @@ const data = {
     },
   ],
   buttonMember: {
-    text: "!Quiero ser miembro!",
+    text: "¡Quiero ser miembro!",
     url: siteLinks.forms.joinCommunity,
     target: "_blank",
   },


### PR DESCRIPTION
## Problem

The header buttons looked broken:

1. The button read `!Quiero ser miembro!` using `!` as the opening mark instead of the correct Spanish `¡`.
2. The button text (**¡Quiero ser miembro!** and **Contáctanos**) wrapped onto multiple lines, misaligning the header.

## Solution

- `Header.astro`: `!Quiero ser miembro!` → `¡Quiero ser miembro!`.
- `Button.astro`: added `whitespace-nowrap` so the text no longer wraps and the buttons stay aligned.

## Scope

Minimal visual change, no new logic. Affects all usages of the `Button` component.