### PR TITLE
fix(certificates): pool SMTP connection and log real send errors

### DIFF
--- a/functions/src/handlers/certificates.ts
+++ b/functions/src/handlers/certificates.ts
@@ -49,11 +49,15 @@ async function sendOne(
     });
     return { email: recipient.email, name: recipient.name, ok: true };
   } catch (err) {
+    // The structured log gets the real message so failures are
+    // diagnosable directly from Cloud Logging; the response still
+    // surfaces only safeError's generic string to the caller.
+    const detail = err instanceof Error ? err.message : String(err);
     logger.error("certificate.failed", {
       recipientName: recipient.name,
       recipientEmail: recipient.email,
       eventName: body.eventName,
-      error: safeError(err),
+      error: detail,
     });
     return {
       email: recipient.email,

--- a/functions/src/services/email.ts
+++ b/functions/src/services/email.ts
@@ -8,8 +8,17 @@ let transporter: nodemailer.Transporter | null = null;
 
 function getTransporter(): nodemailer.Transporter {
   if (transporter) return transporter;
+  // Pool a single authenticated connection across messages. Without
+  // pooling, every sendMail opens TCP+TLS+AUTH from scratch; with the
+  // batch handler running multiple workers in parallel that triggers
+  // Gmail's "454-4.7.0 Too many login attempts" guard and the rest of
+  // the batch fails. One pooled connection authenticates once and
+  // streams every certificate through it.
   transporter = nodemailer.createTransport({
     service: "gmail",
+    pool: true,
+    maxConnections: 1,
+    maxMessages: 100,
     auth: {
       user: GMAIL_USER.value(),
       pass: GMAIL_APP_PASSWORD.value(),


### PR DESCRIPTION
## Summary

- Batch certificate sends were failing partway through with Gmail's `454-4.7.0 Too many login attempts, please try again later`. The Nodemailer transporter was created without pooling, so every `sendMail` opened a fresh TCP+TLS+AUTH session; with the handler running multiple workers in parallel that produced a burst of simultaneous logins that Gmail rate-limits.
- Enable Nodemailer's connection pool with a single reused connection (`maxConnections: 1`, `maxMessages: 100`). All certificates in a batch now authenticate once and stream through the same session, eliminating the auth burst while PDF generation still runs concurrently across workers.
- Include the real error message in the structured `certificate.failed` log entry. The previous version logged `safeError`'s generic placeholder, which forced operators to pivot to stderr to recover the actual SMTP/PDF cause. The HTTP response still returns `safeError` so internal details are not leaked to the client.

## Test plan

- [x] `cd functions && npm run build` — TypeScript compiles cleanly.
- [x] `cd functions && npm test` — 82/82 backend tests pass.
- [ ] After deploy, run a batch send and confirm no `454-4.7.0` failures and that any future per-recipient failure shows its real reason directly in the structured `certificate.failed` log entry (no need to grep stderr).