### PR TITLE
feat(seo): add JSON-LD structured data to team, sponsors and about pages

### DIFF
--- a/src/pages/equipo/index.astro
+++ b/src/pages/equipo/index.astro
@@ -8,6 +8,7 @@ import { Users } from "@lucide/astro";
 import { getCollection } from "astro:content";
 import { fetchStats, fetchLinks } from "@/loaders/transform-site-config";
 import StatsBar from "@/components/StatsBar.astro";
+import { buildTeamSchema } from "@/utils/schema";
 
 const membersCollection = await getCollection("members");
 const members = membersCollection.map((entry) => entry.data);
@@ -21,6 +22,7 @@ const metadata = {
     "Conoce al equipo de organizadores del Google Developer Group Ica. 7 organizadores activos con más de 10 años de experiencia construyendo comunidad tech en Ica, Perú.",
   image: "https://gdgica.com/gdg-logo.png",
   url: "https://gdgica.com/equipo/",
+  schema: buildTeamSchema(members, links.social),
 };
 ---
 

--- a/src/pages/nosotros/index.astro
+++ b/src/pages/nosotros/index.astro
@@ -8,6 +8,7 @@ import { MapPin, Users, Calendar, User } from "@lucide/astro";
 // data
 import { getCollection } from "astro:content";
 import { fetchStats, fetchLinks } from "@/loaders/transform-site-config";
+import { buildAboutSchema } from "@/utils/schema";
 
 const organizersCollection = await getCollection("organizers");
 const organizers = organizersCollection.map((entry) => entry.data);
@@ -25,6 +26,7 @@ const metadata = {
     "Conoce la historia, misión y equipo del Google Developer Group Ica. Más de 10 años conectando desarrolladores en Ica, Perú.",
   image: "https://gdgica.com/gdg-logo.png",
   url: "https://gdgica.com/nosotros/",
+  schema: buildAboutSchema(links.social),
 };
 ---
 

--- a/src/pages/patrocinadores/index.astro
+++ b/src/pages/patrocinadores/index.astro
@@ -9,6 +9,7 @@ import HeroPage from "@/components/HeroPage.astro";
 import { getCollection } from "astro:content";
 import { fetchStats, fetchLinks } from "@/loaders/transform-site-config";
 import StatsBar from "@/components/StatsBar.astro";
+import { buildSponsorsSchema } from "@/utils/schema";
 
 const sponsorsCollection = await getCollection("sponsors");
 const sponsors = sponsorsCollection.map((entry) => entry.data);
@@ -21,6 +22,7 @@ const metadata = {
     "Descubre las empresas que apoyan al GDG ICA y cómo tu organización puede patrocinar eventos tech en Ica, Perú. Conecta con más de 5000 desarrolladores de la región.",
   image: "https://gdgica.com/gdg-logo.png",
   url: "https://gdgica.com/patrocinadores/",
+  schema: buildSponsorsSchema(sponsors),
 };
 ---
 

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,0 +1,118 @@
+// Builders de datos estructurados (JSON-LD / schema.org) reutilizables.
+// El Layout (src/layouts/Layout.astro) inyecta cualquier objeto pasado como
+// prop `schema` dentro de un <script type="application/ld+json">.
+
+const SITE = "https://gdgica.com";
+
+/** Convierte una ruta absoluta del sitio (p. ej. "/team/foo.png") en URL absoluta. */
+function absUrl(path: string | undefined): string | undefined {
+  if (!path) return undefined;
+  if (path.startsWith("http")) return path;
+  return `${SITE}${path.startsWith("/") ? "" : "/"}${path}`;
+}
+
+interface SocialLinks {
+  linkedin?: string;
+  facebook?: string;
+  instagram?: string;
+}
+
+/** Lista de URLs de redes sociales (para `sameAs`), filtrando vacíos. */
+function sameAs(social?: SocialLinks): string[] {
+  if (!social) return [];
+  return [social.linkedin, social.facebook, social.instagram].filter(
+    (u): u is string => Boolean(u)
+  );
+}
+
+/** Organization base de GDG Ica. */
+export function buildOrganizationSchema(social?: SocialLinks) {
+  const schema: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Google Developer Group Ica",
+    alternateName: "GDG Ica",
+    url: SITE,
+    logo: `${SITE}/gdg-logo.png`,
+    foundingDate: "2015",
+    location: {
+      "@type": "Place",
+      address: {
+        "@type": "PostalAddress",
+        addressLocality: "Ica",
+        addressCountry: "PE",
+      },
+    },
+  };
+  const links = sameAs(social);
+  if (links.length) schema.sameAs = links;
+  return schema;
+}
+
+interface TeamMember {
+  name: string;
+  role: string;
+  avatar?: string;
+  links?: { linkedin?: string; github?: string; web?: string };
+}
+
+/** Organization de GDG Ica con su equipo como `member` (Person). */
+export function buildTeamSchema(members: TeamMember[], social?: SocialLinks) {
+  const org = buildOrganizationSchema(social);
+  org.member = members.map((m) => {
+    const person: Record<string, unknown> = {
+      "@type": "Person",
+      name: m.name,
+      jobTitle: m.role,
+    };
+    const image = absUrl(m.avatar);
+    if (image) person.image = image;
+    const profile = m.links?.linkedin || m.links?.web || m.links?.github;
+    if (profile) person.sameAs = [profile];
+    return person;
+  });
+  return org;
+}
+
+interface Sponsor {
+  name: string;
+  logo?: string;
+  website?: string;
+  description?: string;
+}
+
+/** ItemList de patrocinadores como Organization. */
+export function buildSponsorsSchema(sponsors: Sponsor[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "Patrocinadores de GDG Ica",
+    itemListElement: sponsors.map((s, i) => {
+      const org: Record<string, unknown> = {
+        "@type": "Organization",
+        name: s.name,
+      };
+      if (s.website) org.url = s.website;
+      const logo = absUrl(s.logo);
+      if (logo) org.logo = logo;
+      if (s.description) org.description = s.description;
+      return {
+        "@type": "ListItem",
+        position: i + 1,
+        item: org,
+      };
+    }),
+  };
+}
+
+/** Organization enriquecida para la página "Nosotros". */
+export function buildAboutSchema(social?: SocialLinks) {
+  const org = buildOrganizationSchema(social);
+  org.description =
+    "Comunidad de desarrolladores en Ica, Perú, enfocada en las tecnologías de Google. Desde 2015 organizamos eventos, talleres y meetups para aprender y construir comunidad.";
+  org.areaServed = {
+    "@type": "Place",
+    name: "Ica, Perú",
+  };
+  return org;
+}


### PR DESCRIPTION
## What it does

Extends structured data (JSON-LD / schema.org) beyond event pages, which were the only ones emitting it.

- **New** `src/utils/schema.ts` with reusable builders:
  - `buildOrganizationSchema(social)` — base GDG Ica `Organization` (with `sameAs` to social profiles).
  - `buildTeamSchema(members, social)` — the Organization with the team as `member` (`Person` with `jobTitle` and image).
  - `buildSponsorsSchema(sponsors)` — `ItemList` of sponsors as `Organization`.
  - `buildAboutSchema(social)` — enriched Organization for the "About" page.
- The `/equipo`, `/patrocinadores` and `/nosotros` pages now pass `schema` in their `metadata`; the `Layout` already injects it as `<script type="application/ld+json">`.

## Why

Improves SEO and search-engine presentation (rich results) for the institutional pages. Quick win from `gdg-info.md` §7.

## Notes

- Purely additive: zero client JS, no visible render changes.
- Absolute URLs use the canonical domain `https://gdgica.com`.

## Verification

- `pnpm build` OK; the `<head>` of all 3 pages emits the expected JSON-LD.
- Validate with [Google Rich Results Test](https://search.google.com/test/rich-results).