### PR TITLE
feat(events): add "add to calendar" button (.ics + Google Calendar)

### DIFF
--- a/src/pages/eventos/[slug].astro
+++ b/src/pages/eventos/[slug].astro
@@ -13,6 +13,8 @@ import {
   Ticket,
   Share2,
   Calendar,
+  CalendarPlus,
+  Download,
   Clock,
   Building,
   Users,
@@ -26,7 +28,7 @@ import {
 } from "@lucide/astro";
 import SharedButton from "@/components/react/SharedButton";
 import { MiniGamesRoot } from "@/components/react/event/MiniGamesRoot";
-import { parseSpanishDate } from "@/utils/parseSpanishDate";
+import { getEventDates, googleCalendarUrl } from "@/utils/eventDates";
 
 export async function getStaticPaths() {
   const events = await getCollection("events");
@@ -38,26 +40,7 @@ export async function getStaticPaths() {
 const { event } = Astro.props;
 
 function buildEventSchema(data: typeof event.data, slug: string) {
-  const parsedDate = parseSpanishDate(data.date);
-  const year = parsedDate.getFullYear();
-  const month = String(parsedDate.getMonth() + 1).padStart(2, "0");
-  const day = String(parsedDate.getDate()).padStart(2, "0");
-  const dateBase = `${year}-${month}-${day}`;
-
-  const parseTime = (t: string): string => {
-    const match = t.trim().match(/(\d+):(\d+)\s*(AM|PM)/i);
-    if (!match) return "00:00:00";
-    let hours = parseInt(match[1]);
-    const minutes = match[2];
-    const ampm = match[3].toUpperCase();
-    if (ampm === "PM" && hours < 12) hours += 12;
-    if (ampm === "AM" && hours === 12) hours = 0;
-    return `${String(hours).padStart(2, "0")}:${minutes}:00`;
-  };
-
-  const timeParts = data.time.split(" - ");
-  const startDate = `${dateBase}T${parseTime(timeParts[0])}-05:00`;
-  const endDate = `${dateBase}T${parseTime(timeParts[1] ?? timeParts[0])}-05:00`;
+  const { startISO: startDate, endISO: endDate } = getEventDates(data);
 
   const location = data.isVirtual
     ? {
@@ -128,6 +111,9 @@ const metadata = {
   url: `https://gdgica.com/eventos/${event.id}`,
   schema: buildEventSchema(event.data, event.id),
 };
+
+const gcalUrl = googleCalendarUrl(event.data, event.id);
+const icsUrl = `/eventos/${event.id}.ics`;
 
 const schedule = event.data.schedule;
 const isArraySchedule = Array.isArray(schedule);
@@ -211,6 +197,32 @@ const whatsappQrSvg = whatsappGroupLink
             eventHashtags={JSON.stringify(event.data.tags)}
             eventOrganization="Google Developer Group Ica"
           />
+          <details class="group relative">
+            <summary
+              class="border-gray-custom text-primary inline-flex cursor-pointer list-none items-center justify-center gap-[10px] rounded-md border bg-white px-8 py-[10px] font-medium whitespace-nowrap [&::-webkit-details-marker]:hidden"
+            >
+              <CalendarPlus size={16} /> Añadir a calendario
+            </summary>
+            <div
+              class="absolute z-10 mt-2 flex w-60 flex-col overflow-hidden rounded-md border border-gray-200 bg-white shadow-lg"
+            >
+              <a
+                href={gcalUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-primary flex items-center gap-2 px-4 py-3 hover:bg-gray-100"
+              >
+                <Calendar size={16} /> Google Calendar
+              </a>
+              <a
+                href={icsUrl}
+                download
+                class="text-primary flex items-center gap-2 px-4 py-3 hover:bg-gray-100"
+              >
+                <Download size={16} /> Descargar .ics
+              </a>
+            </div>
+          </details>
         </div>
       </div>
     </div>

--- a/src/pages/eventos/[slug].ics.ts
+++ b/src/pages/eventos/[slug].ics.ts
@@ -1,0 +1,23 @@
+import { getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+import type { APIContext } from "astro";
+import { buildEventIcs } from "@/utils/eventDates";
+
+export async function getStaticPaths() {
+  const events = await getCollection("events");
+  return events.map((event) => ({
+    params: { slug: event.id },
+    props: { event },
+  }));
+}
+
+export async function GET({ props }: APIContext) {
+  const { event } = props as { event: CollectionEntry<"events"> };
+  const body = buildEventIcs(event.data, event.id);
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/calendar; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${event.id}.ics"`,
+    },
+  });
+}

--- a/src/utils/eventDates.ts
+++ b/src/utils/eventDates.ts
@@ -1,0 +1,125 @@
+// Utilidades de fecha/hora de eventos, compartidas por el JSON-LD del evento,
+// el endpoint .ics y el enlace de Google Calendar.
+//
+// Los eventos guardan `date` como texto en español ("15 de junio de 2026") y
+// `time` como rango ("09:00 AM - 05:00 PM"). Ica/Perú es UTC-5 fijo (sin DST).
+
+import { parseSpanishDate } from "./parseSpanishDate";
+
+const LIMA_OFFSET = "-05:00";
+
+export interface EventDateLike {
+  date: string;
+  time: string;
+}
+
+export interface EventIcsLike extends EventDateLike {
+  name: string;
+  shortDescription: string;
+  isVirtual: boolean;
+  location: { name: string; direction: string };
+}
+
+/** "09:00 AM" → "09:00:00" (24h). Devuelve "00:00:00" si no matchea. */
+function parseTime(t: string): string {
+  const match = t.trim().match(/(\d+):(\d+)\s*(AM|PM)/i);
+  if (!match) return "00:00:00";
+  let hours = parseInt(match[1]);
+  const minutes = match[2];
+  const ampm = match[3].toUpperCase();
+  if (ampm === "PM" && hours < 12) hours += 12;
+  if (ampm === "AM" && hours === 12) hours = 0;
+  return `${String(hours).padStart(2, "0")}:${minutes}:00`;
+}
+
+/** Instante UTC en formato compacto iCalendar/Google: "YYYYMMDDTHHMMSSZ". */
+function toUtcCompact(isoWithOffset: string): string {
+  const d = new Date(isoWithOffset);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}` +
+    `T${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}Z`
+  );
+}
+
+/**
+ * Calcula las fechas de inicio/fin del evento.
+ * - `startISO`/`endISO`: ISO 8601 con offset de Lima (para schema.org).
+ * - `startUTC`/`endUTC`: formato compacto UTC (para .ics y Google Calendar).
+ */
+export function getEventDates(data: EventDateLike) {
+  const parsedDate = parseSpanishDate(data.date);
+  const year = parsedDate.getFullYear();
+  const month = String(parsedDate.getMonth() + 1).padStart(2, "0");
+  const day = String(parsedDate.getDate()).padStart(2, "0");
+  const dateBase = `${year}-${month}-${day}`;
+
+  const timeParts = data.time.split(" - ");
+  const startISO = `${dateBase}T${parseTime(timeParts[0])}${LIMA_OFFSET}`;
+  const endISO = `${dateBase}T${parseTime(timeParts[1] ?? timeParts[0])}${LIMA_OFFSET}`;
+
+  return {
+    startISO,
+    endISO,
+    startUTC: toUtcCompact(startISO),
+    endUTC: toUtcCompact(endISO),
+  };
+}
+
+/** URL de "Añadir a Google Calendar" para un evento. */
+export function googleCalendarUrl(data: EventIcsLike, slug: string): string {
+  const { startUTC, endUTC } = getEventDates(data);
+  const eventUrl = `https://gdgica.com/eventos/${slug}`;
+  const details = `${data.shortDescription}\n\n${eventUrl}`;
+  const location = data.isVirtual
+    ? "Evento Virtual"
+    : [data.location.name, data.location.direction].filter(Boolean).join(", ");
+
+  const params = new URLSearchParams({
+    action: "TEMPLATE",
+    text: data.name,
+    dates: `${startUTC}/${endUTC}`,
+    details,
+    location,
+  });
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+/** Escapa un valor de texto según RFC 5545 (iCalendar). */
+function escapeIcs(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\r?\n/g, "\\n");
+}
+
+/** Genera el contenido de un archivo .ics (VCALENDAR con un VEVENT). */
+export function buildEventIcs(data: EventIcsLike, slug: string): string {
+  const { startUTC, endUTC } = getEventDates(data);
+  const eventUrl = `https://gdgica.com/eventos/${slug}`;
+  const location = data.isVirtual
+    ? "Evento Virtual"
+    : [data.location.name, data.location.direction].filter(Boolean).join(", ");
+
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//GDG Ica//Eventos//ES",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${slug}@gdgica.com`,
+    `DTSTAMP:${startUTC}`,
+    `DTSTART:${startUTC}`,
+    `DTEND:${endUTC}`,
+    `SUMMARY:${escapeIcs(data.name)}`,
+    `DESCRIPTION:${escapeIcs(`${data.shortDescription}\n\n${eventUrl}`)}`,
+    `LOCATION:${escapeIcs(location)}`,
+    `URL:${eventUrl}`,
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ];
+  // iCalendar requiere CRLF como separador de líneas.
+  return lines.join("\r\n");
+}


### PR DESCRIPTION
## What it does

Adds an **"Add to calendar"** menu on every event page with two options: open in **Google Calendar** and download an **`.ics`** file.

- **New** `src/utils/eventDates.ts` — centralizes the date logic that was *inlined* in `buildEventSchema`:
  - `getEventDates(data)` → ISO with Lima offset (for schema.org) and compact UTC format (for .ics / Google).
  - `googleCalendarUrl(data, slug)` and `buildEventIcs(data, slug)` (with RFC 5545 escaping).
- `src/pages/eventos/[slug].astro` — `buildEventSchema` now reuses `getEventDates` (no duplicated parsing); new `<details>` dropdown in the hero (zero JS).
- **New** `src/pages/eventos/[slug].ics.ts` — static endpoint that pre-generates one `.ics` per event.

## Why

Makes it easy for attendees to save the event to their calendar. Quick win from `gdg-info.md` §7. It also removes the date-logic duplication (the ISO reconstruction previously lived only inside the JSON-LD).

## Notes

- Ica/Peru is fixed UTC-5 (no DST): times are emitted in UTC (`...Z`), consistent with the JSON-LD (`-05:00`).
- The dropdown uses native `<details>/<summary>`: accessible and JavaScript-free.

## Verification

- `pnpm build` generates one `.ics` per event under `dist/eventos/<slug>.ics`.
- JSON-LD `startDate`/`endDate` unchanged from before the refactor.
- Open the `.ics` in Google/Apple Calendar and check date, time and location; test the Google Calendar link.