### PR TITLE
feat(events): add search and category/status filters to events listing

### DIFF
--- a/src/components/react/EventFilters.tsx
+++ b/src/components/react/EventFilters.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from "react";
+
+// Filtra las tarjetas de evento renderizadas en el servidor mostrando/ocultando
+// los wrappers [data-event-card] según búsqueda + categoría + estado.
+// No re-renderiza las tarjetas: solo togglea la clase `hidden`.
+
+const CATEGORIES: { value: string; label: string }[] = [
+  { value: "devfest", label: "DevFest" },
+  { value: "io", label: "Google I/O" },
+  { value: "studyjam", label: "Study Jam" },
+  { value: "wtm", label: "Women Techmakers" },
+  { value: "meetup", label: "Meetup" },
+];
+
+const STATUSES: { value: string; label: string }[] = [
+  { value: "upcoming", label: "Próximo" },
+  { value: "in-progress", label: "En progreso" },
+  { value: "completed", label: "Finalizado" },
+];
+
+function toggle(list: string[], value: string): string[] {
+  return list.includes(value)
+    ? list.filter((v) => v !== value)
+    : [...list, value];
+}
+
+export function EventFilters() {
+  const [search, setSearch] = useState("");
+  const [activeCategories, setActiveCategories] = useState<string[]>([]);
+  const [activeStatuses, setActiveStatuses] = useState<string[]>([]);
+
+  useEffect(() => {
+    const q = search.trim().toLowerCase();
+    const cards = document.querySelectorAll<HTMLElement>("[data-event-card]");
+    let visible = 0;
+
+    cards.forEach((card) => {
+      const name = card.dataset.name ?? "";
+      const tags = card.dataset.tags ?? "";
+      const category = card.dataset.category ?? "";
+      const status = card.dataset.status ?? "";
+
+      const matchesSearch = !q || name.includes(q) || tags.includes(q);
+      const matchesCategory =
+        activeCategories.length === 0 || activeCategories.includes(category);
+      const matchesStatus =
+        activeStatuses.length === 0 || activeStatuses.includes(status);
+
+      const show = matchesSearch && matchesCategory && matchesStatus;
+      card.classList.toggle("hidden", !show);
+      if (show) visible += 1;
+    });
+
+    const empty = document.getElementById("events-empty");
+    if (empty) empty.classList.toggle("hidden", visible !== 0);
+  }, [search, activeCategories, activeStatuses]);
+
+  const hasFilters =
+    search !== "" || activeCategories.length > 0 || activeStatuses.length > 0;
+
+  const chipClass = (active: boolean) =>
+    `cursor-pointer rounded-full border px-4 py-1.5 text-sm font-medium transition-colors ${
+      active
+        ? "bg-google-blue border-google-blue text-white"
+        : "border-gray-custom text-primary bg-white hover:bg-gray-100"
+    }`;
+
+  return (
+    <div className="mx-auto mt-8 max-w-3xl">
+      <label className="sr-only" htmlFor="event-search">
+        Buscar eventos
+      </label>
+      <input
+        id="event-search"
+        type="search"
+        value={search}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        placeholder="Buscar por nombre o tema…"
+        className="border-gray-custom focus:border-google-blue w-full rounded-md border px-4 py-3 outline-none"
+      />
+
+      <div className="mt-4 flex flex-wrap justify-center gap-2">
+        {CATEGORIES.map((c) => (
+          <button
+            key={c.value}
+            type="button"
+            aria-pressed={activeCategories.includes(c.value)}
+            onClick={() => setActiveCategories((prev) => toggle(prev, c.value))}
+            className={chipClass(activeCategories.includes(c.value))}
+          >
+            {c.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 flex flex-wrap justify-center gap-2">
+        {STATUSES.map((s) => (
+          <button
+            key={s.value}
+            type="button"
+            aria-pressed={activeStatuses.includes(s.value)}
+            onClick={() => setActiveStatuses((prev) => toggle(prev, s.value))}
+            className={chipClass(activeStatuses.includes(s.value))}
+          >
+            {s.label}
+          </button>
+        ))}
+      </div>
+
+      {hasFilters && (
+        <div className="mt-3 text-center">
+          <button
+            type="button"
+            onClick={() => {
+              setSearch("");
+              setActiveCategories([]);
+              setActiveStatuses([]);
+            }}
+            className="text-secondary hover:text-primary text-sm underline"
+          >
+            Limpiar filtros
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/eventos/index.astro
+++ b/src/pages/eventos/index.astro
@@ -9,6 +9,7 @@ import { getCollection } from "astro:content";
 import { parseSpanishDate } from "@/utils/parseSpanishDate";
 import { fetchStats, fetchLinks } from "@/loaders/transform-site-config";
 import StatsBar from "@/components/StatsBar.astro";
+import { EventFilters } from "@/components/react/EventFilters";
 
 const allEventsRaw = await getCollection("events");
 
@@ -113,15 +114,31 @@ const metadata = {
       <p class="text-secondary text-center text-xl">
         Explora nuestro catálogo completo de eventos pasados y próximos
       </p>
+      <EventFilters client:visible />
       <div
         class="grid-col-1 sm:grid-col-2 md:grid-col-2 mt-12 grid gap-8 lg:grid-cols-3"
       >
         {
           allEvents.map((event) => (
-            <EventCard slug={event.id} {...event.data} />
+            <div
+              class="h-full"
+              data-event-card
+              data-name={event.data.name.toLowerCase()}
+              data-category={event.data.category.type}
+              data-status={event.data.status.type}
+              data-tags={event.data.tags.join(",").toLowerCase()}
+            >
+              <EventCard slug={event.id} {...event.data} />
+            </div>
           ))
         }
       </div>
+      <p
+        id="events-empty"
+        class="text-secondary mt-12 hidden text-center text-xl"
+      >
+        No hay eventos que coincidan con tu búsqueda.
+      </p>
     </div>
   </section>
   <CallToActionSection>


### PR DESCRIPTION
## What it does

Adds search and filters to `/eventos`: a text input plus **category** chips (DevFest, Google I/O, Study Jam, Women Techmakers, Meetup) and **status** chips (Upcoming, In progress, Finished).

- `src/pages/eventos/index.astro` — each card is wrapped in a container with `data-name/category/status/tags`; the island and an empty state are mounted.
- **New** `src/components/react/EventFilters.tsx` — island (`client:visible`) that shows/hides the `[data-event-card]` wrappers via the DOM. It does **not** re-implement `EventCard`: cards are still server-rendered.

## Why

As the catalog grows, finding an event by topic/type/status greatly improves navigation. Quick win from `gdg-info.md` §7 (filter buttons were half-done/commented out on other pages).

## Notes

- **Graceful degradation without JS:** if the island doesn't hydrate, all events are shown (nothing breaks).
- Island bundle: ~2.4 kB (gzip 1.1 kB).
- Accessible chips (`<button aria-pressed>`), input with an sr-only `<label>`.

## Verification

- `pnpm build` OK; `data-*` attributes present in the HTML.
- Tested with Playwright (chromium) against the preview: filtering "Meetup" → 2 visible; clearing → 6; search with no matches → 0 + empty state.