### PR TITLE
fix: translate sponsorship benefit titles to Spanish

### DIFF
--- a/src/pages/patrocinadores/index.astro
+++ b/src/pages/patrocinadores/index.astro
@@ -133,7 +133,9 @@ const metadata = {
           class="flex flex-col items-center justify-center gap-3 rounded-lg border border-gray-200 p-6 text-center"
         >
           <Target stroke-width={1.5} class="h-8 w-8" color="#DC2626" />
-          <h3 class="text-primary text-2xl font-semibold">Brand Awareness</h3>
+          <h3 class="text-primary text-2xl font-semibold">
+            Visibilidad de marca
+          </h3>
           <p class="text-secondary text-sm">
             Aumenta la visibilidad de tu marca en la comunidad tech más activa
             de la región.
@@ -144,7 +146,7 @@ const metadata = {
         >
           <Zap stroke-width={1.5} class="h-8 w-8" color="#F59E0B" />
           <h3 class="text-primary text-2xl font-semibold">
-            Thought Leadership
+            Liderazgo de opinión
           </h3>
           <p class="text-secondary text-sm">
             Posiciona tu empresa como líder tecnológico compartiendo
@@ -155,7 +157,9 @@ const metadata = {
           class="flex flex-col items-center justify-center gap-3 rounded-lg border border-gray-200 p-6 text-center"
         >
           <Heart stroke-width={1.5} class="h-8 w-8" color="#16A34A" />
-          <h3 class="text-primary text-2xl font-semibold">Community Impact</h3>
+          <h3 class="text-primary text-2xl font-semibold">
+            Impacto en la comunidad
+          </h3>
           <p class="text-secondary text-sm">
             Contribuye al crecimiento del ecosistema tecnológico y genera
             impacto social positivo.


### PR DESCRIPTION
## What changes

Translates the three English titles in the "¿Por Qué Patrocinar GDG?" section on `/patrocinadores` into Spanish:

- **Brand Awareness** → **Visibilidad de marca**
- **Thought Leadership** → **Liderazgo de opinión**
- **Community Impact** → **Impacto en la comunidad**

## Why

The site is Spanish-language content, but these benefit cards displayed their headings in English, breaking the page's language consistency.

## How to test

1. `npm run dev`
2. Go to `/patrocinadores`
3. Verify the four benefit cards have Spanish titles (Acceso a talento, Visibilidad de marca, Liderazgo de opinión, Impacto en la comunidad).