### PR TITLE
fix(admin): harden API client error handling and auth subscription

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,16 +23,33 @@ async function request<T>(
     return { success: false, error: "Not authenticated" };
   }
 
-  const res = await fetch(`${API_BASE}${path}`, {
-    method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
+  try {
+    const res = await fetch(`${API_BASE}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
 
-  return res.json();
+    if (!res.ok) {
+      const fallback =
+        res.status === 401 || res.status === 403
+          ? "Sesión expirada o sin permisos. Vuelve a iniciar sesión."
+          : `Error ${res.status}`;
+      // El cuerpo puede no ser JSON (p. ej. una página de error HTML).
+      const data = await res.json().catch(() => null);
+      return {
+        success: false,
+        error: data?.error || data?.message || fallback,
+      };
+    }
+
+    return (await res.json()) as ApiResponse<T>;
+  } catch {
+    return { success: false, error: "No se pudo conectar con el servidor." };
+  }
 }
 
 const realApi = {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,13 +15,17 @@ export async function signOut() {
 
 export function onAuthStateChanged(callback: (user: User | null) => void) {
   let unsubscribe: (() => void) | null = null;
+  let cancelled = false;
   getAuth().then(async (auth) => {
-    const { onAuthStateChanged: firebaseOnAuthStateChanged } = await import(
-      "firebase/auth"
-    );
+    const { onAuthStateChanged: firebaseOnAuthStateChanged } =
+      await import("firebase/auth");
+    // El consumidor pudo desmontarse antes de que resolviera getAuth():
+    // evita suscribirse (y fugar el listener) si ya se llamó al cleanup.
+    if (cancelled) return;
     unsubscribe = firebaseOnAuthStateChanged(auth, callback);
   });
   return () => {
+    cancelled = true;
     if (unsubscribe) unsubscribe();
   };
 }


### PR DESCRIPTION
## What it does

Two reliability fixes in the admin client (`src/lib/`)

### `api.ts` — error handling (A1)
The shared `request()` called `res.json()` directly with no `res.ok` check and no try-catch. A 500 returning an HTML error page, a dropped connection, or an expired session would throw an unhandled rejection instead of a usable `ApiResponse`.

- Wrap `fetch` + JSON parsing in try-catch (network errors → friendly message).
- Check `res.ok`; map **401/403** to a clear "session expired / no permission" message.
- Tolerate non-JSON error bodies (`res.json().catch(() => null)`), falling back to the status code.

### `auth.ts` — auth subscription race (A2)
`onAuthStateChanged` subscribed inside a `.then()` while returning the cleanup synchronously. If the consumer unmounted before `getAuth()` resolved, `unsubscribe` was still `null` at cleanup time and the listener leaked.

- Add a `cancelled` flag: the cleanup sets it, and the resolved promise skips subscribing (or unsubscribes) when already cancelled.

## Why

Prevents unhandled promise rejections and confusing failures in the admin panel, and stops a leaked Firebase auth listener firing callbacks on unmounted components.

## Verification

- `pnpm build` OK.
- Behavior: a non-OK / non-JSON response now resolves to `{ success: false, error }`; unmount-before-resolve no longer leaves a live listener.