### PR TITLE
fix(functions): await audit logs and log rebuild failures

### DIFF
--- a/functions/src/handlers/certificates.ts
+++ b/functions/src/handlers/certificates.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog } from "../utils/audit";
 import { logger } from "firebase-functions";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -91,18 +92,14 @@ export async function sendCertificates(req: Request, res: Response) {
     const sent = results.filter((r) => r.ok).length;
     const failed = results.length - sent;
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "certificate.send",
-        performedBy: user.uid,
-        targetId: body.eventName,
-        targetType: "certificate",
-        details: { eventName: body.eventName, sent, failed },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      })
-      .catch(() => {});
+    await writeAuditLog({
+      action: "certificate.send",
+      performedBy: user.uid,
+      targetId: body.eventName,
+      targetType: "certificate",
+      details: { eventName: body.eventName, sent, failed },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.json({
       success: true,

--- a/functions/src/handlers/events.ts
+++ b/functions/src/handlers/events.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import {
   safeError,
@@ -132,20 +133,17 @@ export async function createEvent(req: Request, res: Response) {
     );
 
     // Trigger rebuild
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
     // Audit log
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "event.create",
-        performedBy: user.uid,
-        targetId: event.id,
-        targetType: "event",
-        details: { title: event.title },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "event.create",
+      performedBy: user.uid,
+      targetId: event.id,
+      targetType: "event",
+      details: { title: event.title },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.status(201).json({ success: true, data: { id: event.id } });
   } catch (err) {
@@ -189,19 +187,16 @@ export async function updateEvent(req: Request, res: Response) {
       indexSha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "event.update",
-        performedBy: user.uid,
-        targetId: eventId,
-        targetType: "event",
-        details: { title: event.title },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "event.update",
+      performedBy: user.uid,
+      targetId: eventId,
+      targetType: "event",
+      details: { title: event.title },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.json({ success: true, data: { id: eventId } });
   } catch (err) {
@@ -236,9 +231,9 @@ export async function deleteEvent(req: Request, res: Response) {
       indexSha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin.firestore().collection("audit_log").add({
+    await writeAuditLog({
       action: "event.delete",
       performedBy: user.uid,
       targetId: eventId,

--- a/functions/src/handlers/forms.ts
+++ b/functions/src/handlers/forms.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { GitHubService } from "../services/github";
 import { readSheet } from "../services/sheets";
@@ -65,17 +66,14 @@ export async function addForm(req: Request, res: Response) {
       sha
     );
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "form.create",
-        performedBy: user.uid,
-        targetId: entry.id,
-        targetType: "form",
-        details: { name: entry.name },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "form.create",
+      performedBy: user.uid,
+      targetId: entry.id,
+      targetType: "form",
+      details: { name: entry.name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.status(201).json({ success: true, data: entry });
   } catch (err) {
@@ -108,17 +106,14 @@ export async function updateForm(req: Request, res: Response) {
       sha
     );
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "form.update",
-        performedBy: user.uid,
-        targetId: formId,
-        targetType: "form",
-        details: { name: forms[index].name },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "form.update",
+      performedBy: user.uid,
+      targetId: formId,
+      targetType: "form",
+      details: { name: forms[index].name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.json({ success: true, data: forms[index] });
   } catch (err) {
@@ -148,7 +143,7 @@ export async function deleteForm(req: Request, res: Response) {
       sha
     );
 
-    admin.firestore().collection("audit_log").add({
+    await writeAuditLog({
       action: "form.delete",
       performedBy: user.uid,
       targetId: formId,

--- a/functions/src/handlers/locations.ts
+++ b/functions/src/handlers/locations.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import {
   safeError,
@@ -43,7 +44,7 @@ export async function create(req: Request, res: Response) {
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
       createdBy: user.uid,
     });
-    admin.firestore().collection("audit_log").add({
+    await writeAuditLog({
       action: "location.create",
       performedBy: user.uid,
       targetId: ref.id,
@@ -76,7 +77,7 @@ export async function update(req: Request, res: Response) {
       return;
     }
     await ref.update({ name, address, map_url, map_embed });
-    admin.firestore().collection("audit_log").add({
+    await writeAuditLog({
       action: "location.update",
       performedBy: user.uid,
       targetId: id,
@@ -102,7 +103,7 @@ export async function remove(req: Request, res: Response) {
     }
     const name = (doc.data()?.name as string) || id;
     await ref.delete();
-    admin.firestore().collection("audit_log").add({
+    await writeAuditLog({
       action: "location.delete",
       performedBy: user.uid,
       targetId: id,

--- a/functions/src/handlers/minigameInstances.ts
+++ b/functions/src/handlers/minigameInstances.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import type { MinigameTemplate, MinigameTemplateType } from "../schemas";
@@ -124,17 +125,14 @@ export async function attach(req: Request, res: Response) {
 
     const ref = await instancesCol(slug).add(baseInstance);
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add(
-        auditEntry("minigame_instance.attach", user.uid, ref.id, {
-          slug,
-          type: tpl.type,
-          title: tpl.title,
-          templateId,
-        })
-      );
+    await writeAuditLog(
+      auditEntry("minigame_instance.attach", user.uid, ref.id, {
+        slug,
+        type: tpl.type,
+        title: tpl.title,
+        templateId,
+      })
+    );
 
     res
       .status(201)
@@ -172,15 +170,12 @@ export async function setState(req: Request, res: Response) {
 
     await ref.update(update);
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add(
-        auditEntry(`minigame_instance.state.${state}`, user.uid, id, {
-          slug,
-          state,
-        })
-      );
+    await writeAuditLog(
+      auditEntry(`minigame_instance.state.${state}`, user.uid, id, {
+        slug,
+        state,
+      })
+    );
 
     res.json({ success: true, data: { id, state } });
   } catch (err) {
@@ -236,16 +231,13 @@ export async function quizAdvance(req: Request, res: Response) {
       currentQuestionStartedAt: admin.firestore.FieldValue.serverTimestamp(),
     });
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add(
-        auditEntry("minigame_instance.quiz.advance", user.uid, id, {
-          slug,
-          fromIndex,
-          toIndex,
-        })
-      );
+    await writeAuditLog(
+      auditEntry("minigame_instance.quiz.advance", user.uid, id, {
+        slug,
+        fromIndex,
+        toIndex,
+      })
+    );
 
     res.json({ success: true, data: { id, currentQuestionIndex: toIndex } });
   } catch (err) {
@@ -279,15 +271,12 @@ export async function remove(req: Request, res: Response) {
     }
     await ref.delete();
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add(
-        auditEntry("minigame_instance.delete", user.uid, id, {
-          slug,
-          title: data?.title,
-        })
-      );
+    await writeAuditLog(
+      auditEntry("minigame_instance.delete", user.uid, id, {
+        slug,
+        title: data?.title,
+      })
+    );
 
     res.json({ success: true });
   } catch (err) {

--- a/functions/src/handlers/minigameJoin.ts
+++ b/functions/src/handlers/minigameJoin.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import { isCleanAlias } from "../services/profanity";
@@ -125,21 +126,18 @@ export async function join(req: Request, res: Response) {
       })
     );
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "minigame_participant.join",
-        performedBy: user.uid,
-        targetId: slug,
-        targetType: "event",
-        details: {
-          alias: canonicalAlias,
-          instanceCount: summaries.length,
-          newJoins: summaries.filter((s) => s.joined).length,
-        },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "minigame_participant.join",
+      performedBy: user.uid,
+      targetId: slug,
+      targetType: "event",
+      details: {
+        alias: canonicalAlias,
+        instanceCount: summaries.length,
+        newJoins: summaries.filter((s) => s.joined).length,
+      },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.json({
       success: true,

--- a/functions/src/handlers/minigameRoulette.ts
+++ b/functions/src/handlers/minigameRoulette.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 
@@ -34,12 +35,10 @@ export async function spin(req: Request, res: Response) {
       return;
     }
     if (instance?.state !== "live") {
-      res
-        .status(400)
-        .json({
-          success: false,
-          error: "La ruleta debe estar en vivo para girar",
-        });
+      res.status(400).json({
+        success: false,
+        error: "La ruleta debe estar en vivo para girar",
+      });
       return;
     }
 
@@ -80,7 +79,7 @@ export async function spin(req: Request, res: Response) {
       return spinCount;
     });
 
-    db.collection("audit_log").add({
+    await writeAuditLog({
       action: "minigame_instance.roulette.spin",
       performedBy: user.uid,
       targetId: id,

--- a/functions/src/handlers/minigameTemplates.ts
+++ b/functions/src/handlers/minigameTemplates.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import type { MinigameTemplate } from "../schemas";
@@ -73,15 +74,12 @@ export async function create(req: Request, res: Response) {
         updatedAt: now,
         version: 1,
       });
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add(
-        auditEntry("minigame_template.create", user.uid, ref.id, {
-          type: body.type,
-          title: body.title,
-        })
-      );
+    await writeAuditLog(
+      auditEntry("minigame_template.create", user.uid, ref.id, {
+        type: body.type,
+        title: body.title,
+      })
+    );
     res.status(201).json({ success: true, data: { id: ref.id } });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });
@@ -111,16 +109,13 @@ export async function update(req: Request, res: Response) {
       },
       { merge: true }
     );
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add(
-        auditEntry("minigame_template.update", user.uid, id, {
-          type: body.type,
-          title: body.title,
-          version: nextVersion,
-        })
-      );
+    await writeAuditLog(
+      auditEntry("minigame_template.update", user.uid, id, {
+        type: body.type,
+        title: body.title,
+        version: nextVersion,
+      })
+    );
     res.json({ success: true, data: { id, version: nextVersion } });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });
@@ -141,15 +136,12 @@ export async function remove(req: Request, res: Response) {
     }
     const data = snap.data() as Partial<MinigameTemplate> | undefined;
     await ref.delete();
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add(
-        auditEntry("minigame_template.delete", user.uid, id, {
-          type: data?.type ?? "poll",
-          title: data?.title ?? id,
-        })
-      );
+    await writeAuditLog(
+      auditEntry("minigame_template.delete", user.uid, id, {
+        type: data?.type ?? "poll",
+        title: data?.title ?? id,
+      })
+    );
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });

--- a/functions/src/handlers/minigameWords.ts
+++ b/functions/src/handlers/minigameWords.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 
@@ -87,17 +88,14 @@ export async function setWordHidden(req: Request, res: Response) {
       hiddenAt: hidden ? admin.firestore.FieldValue.serverTimestamp() : null,
       hiddenBy: hidden ? user.uid : null,
     });
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add(
-        auditEntry(
-          hidden ? "minigame_word.hide" : "minigame_word.unhide",
-          user.uid,
-          wordId,
-          { slug, instanceId: id, wordId, hidden }
-        )
-      );
+    await writeAuditLog(
+      auditEntry(
+        hidden ? "minigame_word.hide" : "minigame_word.unhide",
+        user.uid,
+        wordId,
+        { slug, instanceId: id, wordId, hidden }
+      )
+    );
     res.json({ success: true, data: { id: wordId, hidden } });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });

--- a/functions/src/handlers/speakers.ts
+++ b/functions/src/handlers/speakers.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import { GitHubService } from "../services/github";
@@ -61,19 +62,16 @@ export async function addSpeaker(req: Request, res: Response) {
       sha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "speaker.create",
-        performedBy: user.uid,
-        targetId: speaker.id,
-        targetType: "speaker",
-        details: { name: speaker.name },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "speaker.create",
+      performedBy: user.uid,
+      targetId: speaker.id,
+      targetType: "speaker",
+      details: { name: speaker.name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.status(201).json({ success: true, data: { id: speaker.id } });
   } catch (err) {
@@ -111,19 +109,16 @@ export async function updateSpeaker(req: Request, res: Response) {
       indexSha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "speaker.update",
-        performedBy: user.uid,
-        targetId: speakerId,
-        targetType: "speaker",
-        details: { name: updates.name },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "speaker.update",
+      performedBy: user.uid,
+      targetId: speakerId,
+      targetType: "speaker",
+      details: { name: updates.name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.json({ success: true, data: { id: speakerId } });
   } catch (err) {
@@ -159,9 +154,9 @@ export async function deleteSpeaker(req: Request, res: Response) {
       indexSha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin.firestore().collection("audit_log").add({
+    await writeAuditLog({
       action: "speaker.delete",
       performedBy: user.uid,
       targetId: speakerId,

--- a/functions/src/handlers/sponsors.ts
+++ b/functions/src/handlers/sponsors.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError, validateUrl } from "../middleware/validate";
 import { GitHubService } from "../services/github";
@@ -59,19 +60,16 @@ export async function addSponsor(req: Request, res: Response) {
       sha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "sponsor.create",
-        performedBy: user.uid,
-        targetId: sponsor.name,
-        targetType: "sponsor",
-        details: { name: sponsor.name },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "sponsor.create",
+      performedBy: user.uid,
+      targetId: sponsor.name,
+      targetType: "sponsor",
+      details: { name: sponsor.name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.status(201).json({ success: true, data: { name: sponsor.name } });
   } catch (err) {
@@ -110,19 +108,16 @@ export async function updateSponsor(req: Request, res: Response) {
       sha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "sponsor.update",
-        performedBy: user.uid,
-        targetId: updates.name,
-        targetType: "sponsor",
-        details: { name: updates.name },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "sponsor.update",
+      performedBy: user.uid,
+      targetId: updates.name,
+      targetType: "sponsor",
+      details: { name: updates.name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.json({ success: true, data: { name: updates.name } });
   } catch (err) {
@@ -153,9 +148,9 @@ export async function deleteSponsor(req: Request, res: Response) {
       sha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin.firestore().collection("audit_log").add({
+    await writeAuditLog({
       action: "sponsor.delete",
       performedBy: user.uid,
       targetId: sponsorId,

--- a/functions/src/handlers/stats.ts
+++ b/functions/src/handlers/stats.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import { GitHubService } from "../services/github";
@@ -37,9 +38,9 @@ export async function updateStats(req: Request, res: Response) {
       sha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin.firestore().collection("audit_log").add({
+    await writeAuditLog({
       action: "stats.update",
       performedBy: user.uid,
       targetId: "stats",

--- a/functions/src/handlers/team.ts
+++ b/functions/src/handlers/team.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import { GitHubService } from "../services/github";
@@ -53,19 +54,16 @@ export async function addTeamMember(req: Request, res: Response) {
       sha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "team.create",
-        performedBy: user.uid,
-        targetId: member.id,
-        targetType: "team",
-        details: { name: member.name },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "team.create",
+      performedBy: user.uid,
+      targetId: member.id,
+      targetType: "team",
+      details: { name: member.name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.status(201).json({ success: true, data: { id: member.id } });
   } catch (err) {
@@ -97,19 +95,16 @@ export async function updateTeamMember(req: Request, res: Response) {
       sha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "team.update",
-        performedBy: user.uid,
-        targetId: memberId,
-        targetType: "team",
-        details: { name: updates.name },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await writeAuditLog({
+      action: "team.update",
+      performedBy: user.uid,
+      targetId: memberId,
+      targetType: "team",
+      details: { name: updates.name },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.json({ success: true, data: { id: memberId } });
   } catch (err) {
@@ -139,9 +134,9 @@ export async function deleteTeamMember(req: Request, res: Response) {
       sha
     );
 
-    github.triggerRebuild().catch(() => {});
+    triggerRebuildAndLog(github);
 
-    admin.firestore().collection("audit_log").add({
+    await writeAuditLog({
       action: "team.delete",
       performedBy: user.uid,
       targetId: memberId,

--- a/functions/src/handlers/users.ts
+++ b/functions/src/handlers/users.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import { Role } from "../types/users";
@@ -52,17 +53,14 @@ export async function updateRole(req: Request, res: Response) {
 
     await userRef.update({ role });
 
-    await admin
-      .firestore()
-      .collection("audit_log")
-      .add({
-        action: "user.role.change",
-        performedBy: performer.uid,
-        targetId: uid,
-        targetType: "user",
-        details: { newRole: role, previousRole: userDoc.data()?.role },
-        timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      });
+    await await writeAuditLog({
+      action: "user.role.change",
+      performedBy: performer.uid,
+      targetId: uid,
+      targetType: "user",
+      details: { newRole: role, previousRole: userDoc.data()?.role },
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    });
 
     res.json({ success: true, data: { uid, role } });
   } catch (err) {

--- a/functions/src/utils/audit.ts
+++ b/functions/src/utils/audit.ts
@@ -1,0 +1,32 @@
+import * as admin from "firebase-admin";
+import { logger } from "firebase-functions";
+
+/**
+ * Writes an audit log entry, awaiting the write so failures surface instead of
+ * being silently dropped. The entry is stored verbatim (callers set their own
+ * `timestamp`, e.g. a serverTimestamp or a transaction-local value).
+ */
+export async function writeAuditLog(
+  entry: Record<string, unknown>
+): Promise<void> {
+  try {
+    await admin.firestore().collection("audit_log").add(entry);
+  } catch (err) {
+    logger.error("Failed to write audit log", {
+      action: entry.action,
+      err,
+    });
+  }
+}
+
+/**
+ * Triggers a site rebuild without blocking the response, logging a warning if
+ * the dispatch fails instead of swallowing the error.
+ */
+export function triggerRebuildAndLog(github: {
+  triggerRebuild: () => Promise<void>;
+}): void {
+  github.triggerRebuild().catch((err) => {
+    logger.warn("Site rebuild trigger failed", err);
+  });
+}


### PR DESCRIPTION
### Audit logs were fire-and-forget (B1)
Every write handler logged to `audit_log` with `admin.firestore().collection("audit_log").add({...})` and **no `await`** — if the write failed (quota, permissions, network), the audit trail was silently lost. `certificates.ts` even had an explicit `.catch(() => {})` while still responding `success: true`.

### Rebuild errors were swallowed (B3)
`github.triggerRebuild().catch(() => {})` hid dispatch failures, so the site could silently stop updating with no trace.

## Changes

- **New** `functions/src/utils/audit.ts`:
  - `writeAuditLog(entry)` — awaits the Firestore write and `logger.error`s on failure. Stores the entry verbatim (callers keep their own `timestamp`, e.g. `serverTimestamp()` or a transaction-local value).
  - `triggerRebuildAndLog(github)` — fire-and-forget rebuild that `logger.warn`s instead of swallowing.
- Replaced **31** audit writes and **13** rebuild triggers across the handlers (events, team, speakers, sponsors, stats, forms, locations, users, certificates, minigame*).

## Notes

- The audit write is now awaited before responding, so the trail is durable; on failure it logs but does not break the request (the helper swallows-and-logs).
- `rebuild.ts` keeps its own `await github.triggerRebuild()` (it intentionally surfaces the error to the caller).

## Verification

- `npx tsc --noEmit` passes (functions package).
- `grep` confirms 0 remaining `collection("audit_log").add` and 0 remaining `triggerRebuild().catch(() => {})`.