### PR TITLE
fix(security): add rel=noopener noreferrer to external card links

### DIFF
--- a/src/components/MemberCard.astro
+++ b/src/components/MemberCard.astro
@@ -46,28 +46,48 @@ const { member } = Astro.props;
   <div class="text-secondary mt-4 flex justify-center gap-3">
     {
       member.links.linkedin && (
-        <a href={member.links.linkedin} aria-label="LinkedIn" target="_blank">
+        <a
+          href={member.links.linkedin}
+          aria-label="LinkedIn"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Linkedin size={16} class="hover:text-google-blue" />
         </a>
       )
     }
     {
       member.links.twitter && (
-        <a href={member.links.twitter} aria-label="Twitter" target="_blank">
+        <a
+          href={member.links.twitter}
+          aria-label="Twitter"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Twitter size={16} class="hover:text-google-blue" />
         </a>
       )
     }
     {
       member.links.github && (
-        <a href={member.links.github} aria-label="GitHub" target="_blank">
+        <a
+          href={member.links.github}
+          aria-label="GitHub"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Github size={16} class="hover:text-google-blue" />
         </a>
       )
     }
     {
       member.links.web && (
-        <a href={member.links.web} aria-label="Website" target="_blank">
+        <a
+          href={member.links.web}
+          aria-label="Website"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Globe size={16} class="hover:text-google-blue" />
         </a>
       )

--- a/src/components/OrganizerCard.astro
+++ b/src/components/OrganizerCard.astro
@@ -31,6 +31,7 @@ const { organizer } = Astro.props;
           href={organizer.links.linkedin}
           aria-label="LinkedIn"
           target="_blank"
+          rel="noopener noreferrer"
         >
           <Linkedin size={18} class="hover:text-google-blue" />
         </a>
@@ -38,21 +39,36 @@ const { organizer } = Astro.props;
     }
     {
       organizer.links.twitter && (
-        <a href={organizer.links.twitter} aria-label="Twitter" target="_blank">
+        <a
+          href={organizer.links.twitter}
+          aria-label="Twitter"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Twitter size={18} class="hover:text-google-blue" />
         </a>
       )
     }
     {
       organizer.links.github && (
-        <a href={organizer.links.github} aria-label="GitHub" target="_blank">
+        <a
+          href={organizer.links.github}
+          aria-label="GitHub"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Github size={18} class="hover:text-google-blue" />
         </a>
       )
     }
     {
       organizer.links.web && (
-        <a href={organizer.links.web} aria-label="Website" target="_blank">
+        <a
+          href={organizer.links.web}
+          aria-label="Website"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Globe size={18} class="hover:text-google-blue" />
         </a>
       )

--- a/src/components/VolunteerCard.astro
+++ b/src/components/VolunteerCard.astro
@@ -41,6 +41,7 @@ const { volunteer } = Astro.props;
           href={volunteer.links.linkedin}
           aria-label="LinkedIn"
           target="_blank"
+          rel="noopener noreferrer"
         >
           <Linkedin size={16} class="hover:text-google-blue" />
         </a>
@@ -48,14 +49,24 @@ const { volunteer } = Astro.props;
     }
     {
       volunteer.links.github && (
-        <a href={volunteer.links.github} aria-label="GitHub" target="_blank">
+        <a
+          href={volunteer.links.github}
+          aria-label="GitHub"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Github size={16} class="hover:text-google-blue" />
         </a>
       )
     }
     {
       volunteer.links.twitter && (
-        <a href={volunteer.links.twitter} aria-label="Twitter" target="_blank">
+        <a
+          href={volunteer.links.twitter}
+          aria-label="Twitter"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <Twitter size={16} class="hover:text-google-blue" />
         </a>
       )


### PR DESCRIPTION
## What it does

Adds `rel="noopener noreferrer"` to every `target="_blank"` social link in the three team cards: **MemberCard**, **OrganizerCard** and **VolunteerCard**.

## Why

Links opening a new tab without `rel="noopener"` give the opened page access to `window.opener`, enabling reverse-tabnabbing (the new page can redirect the original tab). 🟡 finding from `gdg-info.md` (P0 #5).

## Notes

- Other components (SpeakerCard, SponsorCard, Footer, SharedButton, FormViewer) already set `rel` — only these three cards were missing it.
- Verified parity: each `target="_blank"` now has a matching `rel="noopener noreferrer"` (4/4, 4/4, 3/3).

## Verification

- `pnpm build` OK.