### PR TITLE
fix: use modular firebase-admin/firestore FieldValue in minigame handlers

### DIFF
--- a/functions/src/handlers/minigameInstances.test.ts
+++ b/functions/src/handlers/minigameInstances.test.ts
@@ -15,6 +15,12 @@ vi.mock("firebase-admin", () => ({
   }),
 }));
 
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => "__SERVER_TS__",
+  },
+}));
+
 import * as handler from "./minigameInstances";
 import type { AuthenticatedRequest } from "../middleware/auth";
 

--- a/functions/src/handlers/minigameInstances.ts
+++ b/functions/src/handlers/minigameInstances.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -31,7 +32,7 @@ function auditEntry(
     targetId,
     targetType: "minigame_instance",
     details,
-    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    timestamp: FieldValue.serverTimestamp(),
   };
 }
 
@@ -80,8 +81,7 @@ export async function attach(req: Request, res: Response) {
       return;
     }
     const tpl = tplSnap.data() as
-      | (MinigameTemplate & { version?: number })
-      | undefined;
+      (MinigameTemplate & { version?: number }) | undefined;
     if (!tpl) {
       res.status(404).json({ success: false, error: "Template not found" });
       return;
@@ -93,12 +93,12 @@ export async function attach(req: Request, res: Response) {
     await eventRef.set(
       {
         slug,
-        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        createdAt: FieldValue.serverTimestamp(),
       },
       { merge: true }
     );
 
-    const now = admin.firestore.FieldValue.serverTimestamp();
+    const now = FieldValue.serverTimestamp();
     const config = pickConfig(tpl);
     const baseInstance: Record<string, unknown> = {
       eventSlug: slug,
@@ -163,9 +163,9 @@ export async function setState(req: Request, res: Response) {
 
     const update: Record<string, unknown> = { state };
     if (state === "live") {
-      update.activatedAt = admin.firestore.FieldValue.serverTimestamp();
+      update.activatedAt = FieldValue.serverTimestamp();
     } else if (state === "closed") {
-      update.closedAt = admin.firestore.FieldValue.serverTimestamp();
+      update.closedAt = FieldValue.serverTimestamp();
     }
 
     await ref.update(update);
@@ -228,7 +228,7 @@ export async function quizAdvance(req: Request, res: Response) {
 
     await ref.update({
       currentQuestionIndex: toIndex,
-      currentQuestionStartedAt: admin.firestore.FieldValue.serverTimestamp(),
+      currentQuestionStartedAt: FieldValue.serverTimestamp(),
     });
 
     await writeAuditLog(

--- a/functions/src/handlers/minigameJoin.test.ts
+++ b/functions/src/handlers/minigameJoin.test.ts
@@ -22,6 +22,12 @@ vi.mock("firebase-admin", () => ({
   ),
 }));
 
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => "__SERVER_TS__",
+  },
+}));
+
 import * as handler from "./minigameJoin";
 import type { AuthenticatedRequest } from "../middleware/auth";
 

--- a/functions/src/handlers/minigameJoin.ts
+++ b/functions/src/handlers/minigameJoin.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -80,8 +81,7 @@ export async function join(req: Request, res: Response) {
           const existing = await tx.get(participantRef);
           if (existing.exists) {
             const data = existing.data() as
-              | { alias?: string; bingoCard?: string[] }
-              | undefined;
+              { alias?: string; bingoCard?: string[] } | undefined;
             // Lock alias to whatever was stored first.
             if (data?.alias) {
               canonicalAlias = data.alias;
@@ -96,7 +96,7 @@ export async function join(req: Request, res: Response) {
           const participantDoc: Record<string, unknown> = {
             uid: user.uid,
             alias: requestedAlias,
-            joinedAt: admin.firestore.FieldValue.serverTimestamp(),
+            joinedAt: FieldValue.serverTimestamp(),
           };
 
           if (instanceData.type === "bingo") {
@@ -136,7 +136,7 @@ export async function join(req: Request, res: Response) {
         instanceCount: summaries.length,
         newJoins: summaries.filter((s) => s.joined).length,
       },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({

--- a/functions/src/handlers/minigameRoulette.ts
+++ b/functions/src/handlers/minigameRoulette.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -26,8 +27,7 @@ export async function spin(req: Request, res: Response) {
       return;
     }
     const instance = instanceSnap.data() as
-      | { type?: string; state?: string; spinCount?: number }
-      | undefined;
+      { type?: string; state?: string; spinCount?: number } | undefined;
     if (instance?.type !== "roulette") {
       res
         .status(400)
@@ -59,7 +59,7 @@ export async function spin(req: Request, res: Response) {
     const winner = eligible[Math.floor(Math.random() * eligible.length)];
     const winnerData = winner.data() as { alias?: string };
     const alias = winnerData.alias ?? "Anónimo";
-    const now = admin.firestore.FieldValue.serverTimestamp();
+    const now = FieldValue.serverTimestamp();
 
     const spinNumber = await db.runTransaction(async (tx) => {
       const freshSnap = await tx.get(instanceRef);

--- a/functions/src/handlers/minigameTemplates.test.ts
+++ b/functions/src/handlers/minigameTemplates.test.ts
@@ -15,6 +15,13 @@ vi.mock("firebase-admin", () => ({
   }),
 }));
 
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => fieldValueServerTimestamp,
+  },
+  Timestamp: class {},
+}));
+
 // Imported after the mock is set up.
 import * as handler from "./minigameTemplates";
 import type { AuthenticatedRequest } from "../middleware/auth";

--- a/functions/src/handlers/minigameTemplates.ts
+++ b/functions/src/handlers/minigameTemplates.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -25,13 +26,11 @@ function auditEntry(
     targetId,
     targetType: "minigame_template",
     details,
-    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    timestamp: FieldValue.serverTimestamp(),
   };
 }
 
-function toIso(
-  ts: admin.firestore.Timestamp | null | undefined
-): string | null {
+function toIso(ts: Timestamp | null | undefined): string | null {
   return ts?.toDate?.().toISOString() ?? null;
 }
 
@@ -63,7 +62,7 @@ export async function create(req: Request, res: Response) {
   try {
     const user = (req as AuthenticatedRequest).user;
     const body = req.body as MinigameTemplate;
-    const now = admin.firestore.FieldValue.serverTimestamp();
+    const now = FieldValue.serverTimestamp();
     const ref = await admin
       .firestore()
       .collection(COLLECTION)
@@ -104,7 +103,7 @@ export async function update(req: Request, res: Response) {
     await ref.set(
       {
         ...body,
-        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
         version: nextVersion,
       },
       { merge: true }

--- a/functions/src/handlers/minigameWords.test.ts
+++ b/functions/src/handlers/minigameWords.test.ts
@@ -15,6 +15,12 @@ vi.mock("firebase-admin", () => ({
   }),
 }));
 
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: () => "__SERVER_TS__",
+  },
+}));
+
 import * as handler from "./minigameWords";
 import type { AuthenticatedRequest } from "../middleware/auth";
 

--- a/functions/src/handlers/minigameWords.ts
+++ b/functions/src/handlers/minigameWords.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -23,7 +24,7 @@ function auditEntry(
     targetId,
     targetType: "minigame_word",
     details,
-    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    timestamp: FieldValue.serverTimestamp(),
   };
 }
 
@@ -85,7 +86,7 @@ export async function setWordHidden(req: Request, res: Response) {
     }
     await ref.update({
       hidden,
-      hiddenAt: hidden ? admin.firestore.FieldValue.serverTimestamp() : null,
+      hiddenAt: hidden ? FieldValue.serverTimestamp() : null,
       hiddenBy: hidden ? user.uid : null,
     });
     await writeAuditLog(

--- a/functions/src/triggers/recomputeAggregates.test.ts
+++ b/functions/src/triggers/recomputeAggregates.test.ts
@@ -18,6 +18,13 @@ vi.mock("firebase-admin", () => ({
   }),
 }));
 
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    increment: mocks.incrementMock,
+    serverTimestamp: mocks.serverTsMock,
+  },
+}));
+
 // Stub `firebase-functions/v2/firestore` so importing the module does not
 // require Functions runtime config. We don't invoke the wrapped export
 // directly; tests target the exported inner handler.

--- a/functions/src/triggers/recomputeAggregates.ts
+++ b/functions/src/triggers/recomputeAggregates.ts
@@ -1,5 +1,6 @@
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
 import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 
 // Fires whenever a response doc is written under a minigame instance and
 // keeps the single `aggregates/current` doc in sync. Spectators (the
@@ -66,10 +67,10 @@ export async function recomputeAggregatesFromEvent(
   await aggregateRef.set(
     {
       optionCounts: {
-        [optionKey]: admin.firestore.FieldValue.increment(1),
+        [optionKey]: FieldValue.increment(1),
       },
-      totalResponses: admin.firestore.FieldValue.increment(1),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      totalResponses: FieldValue.increment(1),
+      updatedAt: FieldValue.serverTimestamp(),
     },
     { merge: true }
   );
@@ -97,7 +98,7 @@ export async function recomputeAggregatesFromEvent(
   await aggregateRef.set(
     {
       leaderboard,
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
     },
     { merge: true }
   );


### PR DESCRIPTION
## Summary
- `admin.firestore.FieldValue.serverTimestamp()`/`.increment()` (the namespaced compat API, via `import * as admin from "firebase-admin"`) returned `undefined` for `.FieldValue` specifically when running under `firebase emulators:start --only functions` — even though `admin.firestore()` itself worked fine. This broke **every** minigame write endpoint (create template, attach instance, join, mark bingo, vote poll, spin roulette) with a 500 in the emulator.
- Reproduced across two clean emulator restarts, confirmed via manual Playwright E2E testing of all 5 minigames (Bingo, WordCloud, Quiz, Encuesta, Ruleta).
- Fix: switch to the modular `firebase-admin/firestore` `FieldValue`/`Timestamp` imports in the 6 affected files, instead of the namespaced `admin.firestore.FieldValue` pattern.

## Files
- `functions/src/handlers/minigameTemplates.ts` (+ `.test.ts`)
- `functions/src/handlers/minigameInstances.ts` (+ `.test.ts`)
- `functions/src/handlers/minigameJoin.ts` (+ `.test.ts`)
- `functions/src/handlers/minigameWords.ts` (+ `.test.ts`)
- `functions/src/handlers/minigameRoulette.ts` (no existing test file)
- `functions/src/triggers/recomputeAggregates.ts` (+ `.test.ts`)

## Confidence: High
Confirmed, reproduced, fixed, verified live via emulator + Playwright. Tests updated to match (vitest mocks now also stub `firebase-admin/firestore`).

## Test plan
- [x] `cd functions && npm run build` — clean
- [x] `cd functions && npx vitest run` — 82/82 pass
- [x] Manually re-verified against `firebase emulators:start --only functions,firestore,auth` (create template → attach → join → mark bingo → vote poll → spin roulette, no 500s)

