### PR TITLE
chore(dev): add Firebase Emulator Suite opt-in for local testing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,18 +8,9 @@ import sitemap from "@astrojs/sitemap";
 import react from "@astrojs/react";
 
 // https://astro.build/config
-// Unlike import.meta.env (used by src/lib/firebase.ts and src/lib/api.ts),
-// Astro does not load .env files into process.env before evaluating this
-// config file — only real shell-exported vars land here by default. Load
-// .env explicitly so PUBLIC_USE_FIREBASE_EMULATOR set in a .env file is
-// picked up the same way it is by the client SDK, instead of silently
-// leaving the /api proxy below off while the client still connects to the
-// emulator.
 try {
   process.loadEnvFile();
-} catch {
-  // No .env file present — fine, PUBLIC_USE_FIREBASE_EMULATOR is opt-in.
-}
+} catch {}
 const useFirebaseEmulator = process.env.PUBLIC_USE_FIREBASE_EMULATOR === "true";
 
 export default defineConfig({

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,18 @@ import sitemap from "@astrojs/sitemap";
 import react from "@astrojs/react";
 
 // https://astro.build/config
+// Unlike import.meta.env (used by src/lib/firebase.ts and src/lib/api.ts),
+// Astro does not load .env files into process.env before evaluating this
+// config file — only real shell-exported vars land here by default. Load
+// .env explicitly so PUBLIC_USE_FIREBASE_EMULATOR set in a .env file is
+// picked up the same way it is by the client SDK, instead of silently
+// leaving the /api proxy below off while the client still connects to the
+// emulator.
+try {
+  process.loadEnvFile();
+} catch {
+  // No .env file present — fine, PUBLIC_USE_FIREBASE_EMULATOR is opt-in.
+}
 const useFirebaseEmulator = process.env.PUBLIC_USE_FIREBASE_EMULATOR === "true";
 
 export default defineConfig({

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,11 +8,23 @@ import sitemap from "@astrojs/sitemap";
 import react from "@astrojs/react";
 
 // https://astro.build/config
+const useFirebaseEmulator = process.env.PUBLIC_USE_FIREBASE_EMULATOR === "true";
+
 export default defineConfig({
   site: "https://gdgica.com",
 
   vite: {
     plugins: [tailwindcss()],
+    server: useFirebaseEmulator
+      ? {
+          proxy: {
+            "/api": {
+              target: "http://127.0.0.1:5001/appgdgica/us-central1/api",
+              changeOrigin: true,
+            },
+          },
+        }
+      : undefined,
   },
 
   integrations: [

--- a/firebase.json
+++ b/firebase.json
@@ -24,6 +24,9 @@
     "firestore": {
       "port": 8080
     },
+    "functions": {
+      "port": 5001
+    },
     "ui": {
       "enabled": true
     },

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,2 +1,3 @@
 lib/
 node_modules/
+.secret.local

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,10 +1,13 @@
 import { getIdToken } from "./auth";
 import { mockApi } from "./mock-api";
 
+const USE_EMULATOR = import.meta.env.PUBLIC_USE_FIREBASE_EMULATOR === "true";
 const API_BASE = "/api";
 
 export const isDevPreview =
-  typeof window !== "undefined" && window.location.hostname === "localhost";
+  !USE_EMULATOR &&
+  typeof window !== "undefined" &&
+  window.location.hostname === "localhost";
 
 interface ApiResponse<T> {
   success: boolean;

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -18,18 +18,37 @@ async function getApp() {
   return _app;
 }
 
+// PUBLIC_USE_FIREBASE_EMULATOR opts local dev into the Firebase Emulator
+// Suite instead of the production project, so manual/E2E testing never
+// touches real user data.
+const USE_EMULATOR = import.meta.env.PUBLIC_USE_FIREBASE_EMULATOR === "true";
+let _authEmulatorConnected = false;
+let _firestoreEmulatorConnected = false;
+
 export async function getAuth() {
   const app = await getApp();
-  const { getAuth: firebaseGetAuth } = await import("firebase/auth");
-  return firebaseGetAuth(app);
+  const { getAuth: firebaseGetAuth, connectAuthEmulator } =
+    await import("firebase/auth");
+  const auth = firebaseGetAuth(app);
+  if (USE_EMULATOR && !_authEmulatorConnected) {
+    connectAuthEmulator(auth, "http://127.0.0.1:9099", {
+      disableWarnings: true,
+    });
+    _authEmulatorConnected = true;
+  }
+  return auth;
 }
 
 export async function getFirestore() {
   const app = await getApp();
-  const { getFirestore: firebaseGetFirestore } = await import(
-    "firebase/firestore"
-  );
-  return firebaseGetFirestore(app);
+  const { getFirestore: firebaseGetFirestore, connectFirestoreEmulator } =
+    await import("firebase/firestore");
+  const db = firebaseGetFirestore(app);
+  if (USE_EMULATOR && !_firestoreEmulatorConnected) {
+    connectFirestoreEmulator(db, "127.0.0.1", 8080);
+    _firestoreEmulatorConnected = true;
+  }
+  return db;
 }
 
 // Used by the public event island in PR4. No-ops when there is already

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -18,9 +18,6 @@ async function getApp() {
   return _app;
 }
 
-// PUBLIC_USE_FIREBASE_EMULATOR opts local dev into the Firebase Emulator
-// Suite instead of the production project, so manual/E2E testing never
-// touches real user data.
 const USE_EMULATOR = import.meta.env.PUBLIC_USE_FIREBASE_EMULATOR === "true";
 let _authEmulatorConnected = false;
 let _firestoreEmulatorConnected = false;


### PR DESCRIPTION
## Summary
- Adds a `PUBLIC_USE_FIREBASE_EMULATOR` flag (off by default) that, when set, points the client SDK (Auth + Firestore) and the `/api` Vite proxy at a locally running Firebase Emulator Suite instead of the production project.
- This is the dev infrastructure used to find and verify the FieldValue bug in #241 — lets admin/minigame flows be exercised end-to-end locally without touching real user data.

## Files
- `astro.config.mjs` — Vite proxy `/api` → emulated Cloud Functions endpoint, gated on the env flag
- `firebase.json` — exposes the functions emulator on port 5001
- `src/lib/firebase.ts` — `connectAuthEmulator`/`connectFirestoreEmulator` when the flag is set
- `src/lib/api.ts` — bypasses the `mockApi` dev-preview shortcut when the flag is set, so calls hit the real (emulated) Cloud Functions
- `functions/.gitignore` — ignores the local-only `.secret.local` file used to satisfy `defineSecret()` during emulator runs

## Test plan
- [x] `PUBLIC_USE_FIREBASE_EMULATOR=true npx astro dev` + `firebase emulators:start --only auth,firestore,functions` — site loads and hits the emulator
- [x] `npx astro build` with the flag unset — unaffected, builds clean
