### PR TITLE
chore: migrate remaining handlers to modular firebase-admin/firestore FieldValue

### DIFF
--- a/functions/src/handlers/auth.ts
+++ b/functions/src/handlers/auth.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { AuthenticatedRequest } from "../middleware/auth";
 
 export async function register(req: Request, res: Response) {
@@ -11,7 +12,7 @@ export async function register(req: Request, res: Response) {
 
     if (userDoc.exists) {
       await userRef.update({
-        lastLoginAt: admin.firestore.FieldValue.serverTimestamp(),
+        lastLoginAt: FieldValue.serverTimestamp(),
       });
       res.json({ success: true, data: userDoc.data() });
       return;
@@ -23,8 +24,8 @@ export async function register(req: Request, res: Response) {
       displayName: user.displayName || "",
       photoURL: user.photoURL || "",
       role: "member",
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      lastLoginAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdAt: FieldValue.serverTimestamp(),
+      lastLoginAt: FieldValue.serverTimestamp(),
     };
 
     await userRef.set(newUser);

--- a/functions/src/handlers/certificates.ts
+++ b/functions/src/handlers/certificates.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { logger } from "firebase-functions";
 import { AuthenticatedRequest } from "../middleware/auth";
@@ -98,7 +98,7 @@ export async function sendCertificates(req: Request, res: Response) {
       targetId: body.eventName,
       targetType: "certificate",
       details: { eventName: body.eventName, sent, failed },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({

--- a/functions/src/handlers/events.ts
+++ b/functions/src/handlers/events.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import {
@@ -142,7 +142,7 @@ export async function createEvent(req: Request, res: Response) {
       targetId: event.id,
       targetType: "event",
       details: { title: event.title },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.status(201).json({ success: true, data: { id: event.id } });
@@ -195,7 +195,7 @@ export async function updateEvent(req: Request, res: Response) {
       targetId: eventId,
       targetType: "event",
       details: { title: event.title },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true, data: { id: eventId } });
@@ -239,7 +239,7 @@ export async function deleteEvent(req: Request, res: Response) {
       targetId: eventId,
       targetType: "event",
       details: {},
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true });

--- a/functions/src/handlers/forms.ts
+++ b/functions/src/handlers/forms.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { GitHubService } from "../services/github";
@@ -72,7 +72,7 @@ export async function addForm(req: Request, res: Response) {
       targetId: entry.id,
       targetType: "form",
       details: { name: entry.name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.status(201).json({ success: true, data: entry });
@@ -112,7 +112,7 @@ export async function updateForm(req: Request, res: Response) {
       targetId: formId,
       targetType: "form",
       details: { name: forms[index].name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true, data: forms[index] });
@@ -149,7 +149,7 @@ export async function deleteForm(req: Request, res: Response) {
       targetId: formId,
       targetType: "form",
       details: {},
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true });

--- a/functions/src/handlers/locations.ts
+++ b/functions/src/handlers/locations.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import {
@@ -41,7 +42,7 @@ export async function create(req: Request, res: Response) {
       address,
       map_url,
       map_embed,
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdAt: FieldValue.serverTimestamp(),
       createdBy: user.uid,
     });
     await writeAuditLog({
@@ -50,7 +51,7 @@ export async function create(req: Request, res: Response) {
       targetId: ref.id,
       targetType: "location",
       details: { name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
     res.status(201).json({ success: true, data: { id: ref.id } });
   } catch (err) {
@@ -83,7 +84,7 @@ export async function update(req: Request, res: Response) {
       targetId: id,
       targetType: "location",
       details: { name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
     res.json({ success: true, data: { id } });
   } catch (err) {
@@ -109,7 +110,7 @@ export async function remove(req: Request, res: Response) {
       targetId: id,
       targetType: "location",
       details: { name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
     res.json({ success: true });
   } catch (err) {

--- a/functions/src/handlers/speakers.ts
+++ b/functions/src/handlers/speakers.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -70,7 +70,7 @@ export async function addSpeaker(req: Request, res: Response) {
       targetId: speaker.id,
       targetType: "speaker",
       details: { name: speaker.name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.status(201).json({ success: true, data: { id: speaker.id } });
@@ -117,7 +117,7 @@ export async function updateSpeaker(req: Request, res: Response) {
       targetId: speakerId,
       targetType: "speaker",
       details: { name: updates.name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true, data: { id: speakerId } });
@@ -162,7 +162,7 @@ export async function deleteSpeaker(req: Request, res: Response) {
       targetId: speakerId,
       targetType: "speaker",
       details: {},
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true });

--- a/functions/src/handlers/sponsors.ts
+++ b/functions/src/handlers/sponsors.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError, validateUrl } from "../middleware/validate";
@@ -68,7 +68,7 @@ export async function addSponsor(req: Request, res: Response) {
       targetId: sponsor.name,
       targetType: "sponsor",
       details: { name: sponsor.name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.status(201).json({ success: true, data: { name: sponsor.name } });
@@ -116,7 +116,7 @@ export async function updateSponsor(req: Request, res: Response) {
       targetId: updates.name,
       targetType: "sponsor",
       details: { name: updates.name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true, data: { name: updates.name } });
@@ -156,7 +156,7 @@ export async function deleteSponsor(req: Request, res: Response) {
       targetId: sponsorId,
       targetType: "sponsor",
       details: {},
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true });

--- a/functions/src/handlers/stats.ts
+++ b/functions/src/handlers/stats.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -46,7 +46,7 @@ export async function updateStats(req: Request, res: Response) {
       targetId: "stats",
       targetType: "stats",
       details: stats,
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true, data: updated });

--- a/functions/src/handlers/team.ts
+++ b/functions/src/handlers/team.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -62,7 +62,7 @@ export async function addTeamMember(req: Request, res: Response) {
       targetId: member.id,
       targetType: "team",
       details: { name: member.name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.status(201).json({ success: true, data: { id: member.id } });
@@ -103,7 +103,7 @@ export async function updateTeamMember(req: Request, res: Response) {
       targetId: memberId,
       targetType: "team",
       details: { name: updates.name },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true, data: { id: memberId } });
@@ -142,7 +142,7 @@ export async function deleteTeamMember(req: Request, res: Response) {
       targetId: memberId,
       targetType: "team",
       details: {},
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true });

--- a/functions/src/handlers/users.ts
+++ b/functions/src/handlers/users.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -59,7 +60,7 @@ export async function updateRole(req: Request, res: Response) {
       targetId: uid,
       targetType: "user",
       details: { newRole: role, previousRole: userDoc.data()?.role },
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({ success: true, data: { uid, role } });


### PR DESCRIPTION
## Summary
Preemptive follow-up to #241. The namespaced `admin.firestore.FieldValue` compat API was confirmed broken under the Firebase Functions Emulator for minigame endpoints. This applies the same modular `firebase-admin/firestore` import to the remaining 10 handlers that shared the identical pattern (25 call sites), to close the door on the same class of bug elsewhere.

**Not confirmed broken in production** — `admin.firestore()` itself worked fine in testing; only the `.FieldValue` namespaced property was affected, and only inside the emulator. This is hygiene/consistency, not a confirmed-bug fix. Flagging explicitly for discussion: is this worth doing now, or should it wait until/unless we see the same failure outside minigames?

## Files
`certificates.ts`, `users.ts`, `auth.ts`, `locations.ts`, `stats.ts`, `forms.ts`, `team.ts`, `events.ts`, `sponsors.ts`, `speakers.ts` — all under `functions/src/handlers/`.

None of these files have existing unit tests covering the `FieldValue` call sites, so there are no test mocks to update.

## Confidence: Low-Medium
Mechanically safe (confirmed via build + full test suite), but touches 10 files across unrelated feature areas (auth, users, events, sponsors, speakers, forms, team, locations, stats, certificates) with no direct bug confirmed in any of them — larger blast radius than #241 for a preemptive fix.

## Test plan
- [x] `cd functions && npm run build` — clean (had to drop 7 now-unused `import * as admin` where `admin.firestore()` wasn't otherwise used)
- [x] `cd functions && npx vitest run` — 82/82 pass (unaffected, no test coverage on these files)
