### PR TITLE
fix: await Firebase Auth persistence before trusting currentUser

### DIFF
--- a/src/lib/__tests__/firebase.test.ts
+++ b/src/lib/__tests__/firebase.test.ts
@@ -53,9 +53,6 @@ describe("firebase.ts auth readiness", () => {
   });
 
   it("signInAnonymouslyIfNeeded does not sign in anonymously when a persisted session resolves after authStateReady (the cross-tab race)", async () => {
-    // Simulates the reported bug: currentUser is only populated once the
-    // SDK finishes rehydrating persisted (IndexedDB) auth state, which
-    // authStateReady() waits for.
     const persistedUser = { uid: "admin-uid" };
     const auth = buildAuth({
       currentUser: null,

--- a/src/lib/__tests__/firebase.test.ts
+++ b/src/lib/__tests__/firebase.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  initializeApp: vi.fn(() => ({ __app: true })),
+  getApps: vi.fn(() => []),
+  getAuth: vi.fn(),
+  signInAnonymously: vi.fn(),
+}));
+
+vi.mock("firebase/app", () => ({
+  initializeApp: mocks.initializeApp,
+  getApps: mocks.getApps,
+}));
+
+vi.mock("firebase/auth", () => ({
+  getAuth: mocks.getAuth,
+  signInAnonymously: mocks.signInAnonymously,
+}));
+
+function buildAuth(options: {
+  currentUser: { uid: string } | null;
+  authStateReady?: () => Promise<void>;
+}) {
+  return {
+    currentUser: options.currentUser,
+    authStateReady: options.authStateReady ?? vi.fn(async () => undefined),
+  };
+}
+
+describe("firebase.ts auth readiness", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.initializeApp.mockClear();
+    mocks.getApps.mockClear().mockReturnValue([]);
+    mocks.getAuth.mockClear();
+    mocks.signInAnonymously.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("getAuth awaits authStateReady before returning", async () => {
+    const authStateReady = vi.fn(async () => undefined);
+    mocks.getAuth.mockReturnValue(
+      buildAuth({ currentUser: null, authStateReady })
+    );
+
+    const { getAuth } = await import("../firebase");
+    await getAuth();
+
+    expect(authStateReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("signInAnonymouslyIfNeeded does not sign in anonymously when a persisted session resolves after authStateReady (the cross-tab race)", async () => {
+    // Simulates the reported bug: currentUser is only populated once the
+    // SDK finishes rehydrating persisted (IndexedDB) auth state, which
+    // authStateReady() waits for.
+    const persistedUser = { uid: "admin-uid" };
+    const auth = buildAuth({
+      currentUser: null,
+      authStateReady: vi.fn(async () => {
+        auth.currentUser = persistedUser;
+      }),
+    });
+    mocks.getAuth.mockReturnValue(auth);
+
+    const { signInAnonymouslyIfNeeded } = await import("../firebase");
+    const user = await signInAnonymouslyIfNeeded();
+
+    expect(mocks.signInAnonymously).not.toHaveBeenCalled();
+    expect(user).toBe(persistedUser);
+  });
+
+  it("signInAnonymouslyIfNeeded still signs in anonymously for a genuinely new participant", async () => {
+    mocks.getAuth.mockReturnValue(buildAuth({ currentUser: null }));
+    mocks.signInAnonymously.mockResolvedValue({
+      user: { uid: "anon-uid" },
+    });
+
+    const { signInAnonymouslyIfNeeded } = await import("../firebase");
+    const user = await signInAnonymouslyIfNeeded();
+
+    expect(mocks.signInAnonymously).toHaveBeenCalledTimes(1);
+    expect(user).toEqual({ uid: "anon-uid" });
+  });
+});

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -9,11 +9,6 @@ const firebaseConfig = {
 
 let _appPromise: Promise<import("firebase/app").FirebaseApp> | null = null;
 
-// Cache the in-flight promise, not just the resolved app: two callers
-// invoking getApp() before the first `await import("firebase/app")`
-// settles would otherwise both see no cached app yet, and could both call
-// initializeApp(), which throws "Firebase App named '[DEFAULT]' already
-// exists" on the second call.
 function getApp() {
   if (!_appPromise) {
     _appPromise = (async () => {
@@ -30,12 +25,6 @@ export async function getAuth() {
   const app = await getApp();
   const { getAuth: firebaseGetAuth } = await import("firebase/auth");
   const auth = firebaseGetAuth(app);
-  // Wait for the SDK to finish restoring any persisted session (IndexedDB)
-  // before callers read `auth.currentUser`. Without this, a fresh tab can
-  // observe `currentUser` as null before rehydration completes and sign in
-  // anonymously (see signInAnonymouslyIfNeeded below), which — because auth
-  // state syncs across same-origin tabs — silently clobbers an existing
-  // signed-in session (e.g. an admin's) in every open tab.
   await auth.authStateReady();
   return auth;
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -7,15 +7,23 @@ const firebaseConfig = {
   appId: "1:647264238138:web:68e7e6fb13454092801303",
 };
 
-let _app: import("firebase/app").FirebaseApp | null = null;
+let _appPromise: Promise<import("firebase/app").FirebaseApp> | null = null;
 
-async function getApp() {
-  if (!_app) {
-    const { initializeApp, getApps } = await import("firebase/app");
-    _app =
-      getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+// Cache the in-flight promise, not just the resolved app: two callers
+// invoking getApp() before the first `await import("firebase/app")`
+// settles would otherwise both see no cached app yet, and could both call
+// initializeApp(), which throws "Firebase App named '[DEFAULT]' already
+// exists" on the second call.
+function getApp() {
+  if (!_appPromise) {
+    _appPromise = (async () => {
+      const { initializeApp, getApps } = await import("firebase/app");
+      return getApps().length === 0
+        ? initializeApp(firebaseConfig)
+        : getApps()[0];
+    })();
   }
-  return _app;
+  return _appPromise;
 }
 
 export async function getAuth() {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -21,14 +21,21 @@ async function getApp() {
 export async function getAuth() {
   const app = await getApp();
   const { getAuth: firebaseGetAuth } = await import("firebase/auth");
-  return firebaseGetAuth(app);
+  const auth = firebaseGetAuth(app);
+  // Wait for the SDK to finish restoring any persisted session (IndexedDB)
+  // before callers read `auth.currentUser`. Without this, a fresh tab can
+  // observe `currentUser` as null before rehydration completes and sign in
+  // anonymously (see signInAnonymouslyIfNeeded below), which — because auth
+  // state syncs across same-origin tabs — silently clobbers an existing
+  // signed-in session (e.g. an admin's) in every open tab.
+  await auth.authStateReady();
+  return auth;
 }
 
 export async function getFirestore() {
   const app = await getApp();
-  const { getFirestore: firebaseGetFirestore } = await import(
-    "firebase/firestore"
-  );
+  const { getFirestore: firebaseGetFirestore } =
+    await import("firebase/firestore");
   return firebaseGetFirestore(app);
 }
 


### PR DESCRIPTION
## Summary
`getAuth()` in `src/lib/firebase.ts` returned the Auth instance without waiting for the SDK to finish restoring a persisted session from IndexedDB. On a fresh tab load, `signInAnonymouslyIfNeeded()` (used by the public event page's participant flow) would read `auth.currentUser` as `null` before that rehydration completed and sign in anonymously — which, because Firebase Auth syncs state across same-origin tabs, **silently overwrote an existing signed-in session (e.g. an admin's Google Sign-In) in every open tab**.

**Reproduced 100% of the time** during the E2E test session: open the admin panel in one tab, open the public event page in another tab of the same browser, and the admin gets logged out everywhere — including their own admin panel tab.

## Fix
Await `auth.authStateReady()` inside `getAuth()` itself (not just in `signInAnonymouslyIfNeeded()`), so every caller gets a settled `currentUser`. This also incidentally fixes the identical bug shape in `getIdToken()`/`getUserRole()` (`src/lib/auth.ts`), which hadn't yet been observed failing but reads `currentUser` the same unsafe way.

`authStateReady(): Promise<void>` is a stable, documented method on the firebase v9+ modular `Auth` object — confirmed present in the installed `firebase@^12.13.0` (`@firebase/auth@1.13.3`).

## Files
- `src/lib/firebase.ts`
- `src/lib/__tests__/firebase.test.ts` (new — no test file existed for this module before)

## Confidence: High
100%-reproducible bug, clear fix with a stable public API, real user-facing failure mode.

## Test plan
- [x] `npx vitest run src/lib/__tests__/firebase.test.ts` — 3/3 pass (asserts `signInAnonymouslyIfNeeded` skips anonymous sign-in when a persisted session resolves after `authStateReady()`, and still signs in anonymously for a genuinely new participant)
- [x] `npx vitest run` (full root suite) — 136/136 pass
- [ ] Manual re-verification of the original repro (admin logged in tab A, open event page in tab B, confirm tab A session survives) — recommended before merge, not yet re-run against a live emulator in this branch
