### PR TITLE
chore: add scheduled OSV-Scanner workflow

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,23 @@
+name: OSV Scanner
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # weekly, Monday — same cadence as Dependabot
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan-scheduled:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      scan-args: |-
+        -r
+        --skip-git
+        ./
+      fail-on-vuln: false


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/osv-scanner.yml`: weekly scheduled scan (same cadence as Dependabot) + manual `workflow_dispatch`, using Google's official `osv-scanner-action` reusable workflow.
- Uploads findings to Security > Code Scanning. Does not run on `pull_request`, matching this repo's convention of no PR-gating CI.
- `fail-on-vuln: false` so the scheduled run doesn't show a persistent red X while known findings are still being triaged/fixed — results stay visible in the Security tab either way.

## Test plan
- [x] Validated YAML syntax
- [x] Confirmed action SHA (`9a498708…`) resolves to the `v2.3.8` tag of `google/osv-scanner-action`
- [ ] Reviewer confirms desired schedule/cadence and `fail-on-vuln` default