### PR TITLE
fix: bump form-data to 4.0.6 (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,10 @@
   "packageManager": "pnpm@10.11.0",
   "engines": {
     "node": ">=22.15.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "form-data": "4.0.6"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data: 4.0.6
+
 importers:
 
   .:
@@ -3473,8 +3476,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
@@ -9738,7 +9741,7 @@ snapshots:
       exegesis: 4.3.0
       exegesis-express: 4.0.0
       express: 4.22.2
-      form-data: 4.0.5
+      form-data: 4.0.6
       fs-extra: 10.1.0
       fuzzy: 0.1.3
       gaxios: 6.7.1
@@ -9851,7 +9854,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8


### PR DESCRIPTION
## Summary
- Bumps the transitive `form-data` dependency (pulled in via `firebase-tools`) from 4.0.5 to 4.0.6 using a `pnpm.overrides` entry in `package.json`, since it is not a direct dependency of this project.
- Fixes [GHSA-hmw2-7cc7-3qxx](https://osv.dev/GHSA-hmw2-7cc7-3qxx) (CVSS 8.7).

## Test plan
- [x] `pnpm install` regenerates `pnpm-lock.yaml` with `form-data` resolved to 4.0.6 (`pnpm why form-data` confirms).
- [x] `pnpm test` passes (137/137 tests, 16/16 files).