### PR TITLE
fix: bump devalue to 5.8.1 (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,10 @@
   "packageManager": "pnpm@10.11.0",
   "engines": {
     "node": ">=22.15.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "devalue": "5.8.1"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  devalue: 5.8.1
+
 importers:
 
   .:
@@ -3043,9 +3046,6 @@ packages:
   deterministic-object-hash@2.0.2:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
-
-  devalue@5.8.0:
-    resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
 
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
@@ -8543,7 +8543,7 @@ snapshots:
       cssesc: 3.0.0
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
-      devalue: 5.8.0
+      devalue: 5.8.1
       diff: 8.0.4
       dlv: 1.1.3
       dset: 3.1.4
@@ -9170,8 +9170,6 @@ snapshots:
   deterministic-object-hash@2.0.2:
     dependencies:
       base-64: 1.0.0
-
-  devalue@5.8.0: {}
 
   devalue@5.8.1: {}
 


### PR DESCRIPTION
## Summary
- Bumps the transitive `devalue` dependency from 5.8.0 to 5.8.1 via a pnpm override
- `devalue` is pulled in indirectly through `astro` (and `@astrojs/react`) — it is not a direct dependency in `package.json`
- Fixes [GHSA-77vg-94rm-hx3p](https://osv.dev/GHSA-77vg-94rm-hx3p) (CVSS 7.5)

## Change
- Added `pnpm.overrides.devalue: "5.8.1"` to root `package.json`
- Regenerated `pnpm-lock.yaml` — `devalue` now resolves to `5.8.1` everywhere (`pnpm why devalue` confirms no remaining references to 5.8.0)

## Test plan
- [x] `pnpm test` passes: 137 tests / 16 files, no failures

Draft PR opened for review before merge.