### PR TITLE
fix: bump js-yaml to 4.2.0 (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,10 @@
   "packageManager": "pnpm@10.11.0",
   "engines": {
     "node": ">=22.15.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml": "4.2.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml: 4.2.0
+
 importers:
 
   .:
@@ -3948,12 +3951,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -6286,7 +6285,7 @@ snapshots:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
       call-me-maybe: 1.0.2
-      js-yaml: 4.3.0
+      js-yaml: 4.2.0
 
   '@apphosting/common@0.0.8': {}
 
@@ -6320,7 +6319,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.2.0
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.2.0
@@ -6337,7 +6336,7 @@ snapshots:
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
       import-meta-resolve: 4.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
@@ -8556,7 +8555,7 @@ snapshots:
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
       import-meta-resolve: 4.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       magic-string: 0.30.21
       magicast: 0.5.2
       mrmime: 2.0.1
@@ -9745,7 +9744,7 @@ snapshots:
       glob: 10.5.0
       google-auth-library: 9.15.1
       ignore: 7.0.5
-      js-yaml: 4.3.0
+      js-yaml: 4.2.0
       jsonwebtoken: 9.0.3
       libsodium-wrappers: 0.7.16
       lodash: 4.18.1
@@ -10400,11 +10399,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.3.0:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

- Fixes [GHSA-h67p-54hq-rp68](https://osv.dev/GHSA-h67p-54hq-rp68) (CVSS 5.3) by pinning `js-yaml` to `4.2.0` via a `pnpm.overrides` entry in root `package.json`.
- `js-yaml` is only a transitive dependency (pulled in via `astro`, `@astrojs/react` → `@astrojs/internal-helpers`, `firebase-tools`, etc.), so it is not listed directly in this project's own `dependencies`/`devDependencies`. Previously it resolved to a mix of `4.1.1` and `4.3.0` across the dependency tree.
- `pnpm-lock.yaml` was regenerated with `pnpm install` after the override was added; `pnpm why js-yaml` now shows every occurrence resolved to `4.2.0`.

## Test plan

- [x] `pnpm test` — 137/137 tests passing (16 test files)