### PR TITLE
fix: bump nodemailer to 9.0.1 (security)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -14,7 +14,7 @@
         "firebase-admin": "^13.10.0",
         "firebase-functions": "^7.2.5",
         "googleapis": "^173.0.0",
-        "nodemailer": "^9.0.0",
+        "nodemailer": "^9.0.1",
         "pdf-lib": "^1.17.1",
         "zod": "^4.4.3"
       },
@@ -8273,9 +8273,9 @@
       "peer": true
     },
     "node_modules/nodemailer": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.0.tgz",
-      "integrity": "sha512-tbPTid7d/p9jAA8CRZ3iomvrMaST0o6NYuY7v6JQZHpPRZ61mLFSPKYd7342NtOFuej9/+L48SOIxwfu2uDvtw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,7 +20,7 @@
     "firebase-admin": "^13.10.0",
     "firebase-functions": "^7.2.5",
     "googleapis": "^173.0.0",
-    "nodemailer": "^9.0.0",
+    "nodemailer": "^9.0.1",
     "pdf-lib": "^1.17.1",
     "zod": "^4.4.3"
   },
@@ -31,8 +31,8 @@
     "@firebase/rules-unit-testing": "^5.0.1",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
-    "@types/nodemailer": "^8.0.1",
     "@types/node": "^25.6.0",
+    "@types/nodemailer": "^8.0.1",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.35.1",
     "eslint": "^10.5.0",


### PR DESCRIPTION
## Summary
- Bumps `nodemailer` from 9.0.0 to 9.0.1 in `functions/` to fix [GHSA-p6gq-j5cr-w38f](https://osv.dev/GHSA-p6gq-j5cr-w38f) (CVSS 7.1)
- `nodemailer` is a **direct dependency** in `functions/package.json` (used for email sending in Cloud Functions)
- The existing `^9.0.0` range already satisfies `9.0.1`; this updates the declared range and lockfile-resolved version accordingly. No code changes required.

## Test plan
- [x] `npm test` (vitest) — 82 passed (9 test files)
- [x] `npm run build` (tsc) — passed with no errors