### PR TITLE
fix: bump @tootallnate/once to 2.0.1 (security)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -2743,9 +2743,9 @@
       "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,8 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "protobufjs": ">=7.5.5"
+    "protobufjs": ">=7.5.5",
+    "@tootallnate/once": "2.0.1"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.1",


### PR DESCRIPTION
## Summary

- Bumps `@tootallnate/once` from 2.0.0 to 2.0.1 in `functions/` via npm `overrides` to fix [GHSA-vpq2-c234-7xj6](https://osv.dev/GHSA-vpq2-c234-7xj6) (CVSS 3.3).
- This is a **transitive** dependency (pulled in via `https-proxy-agent`, used by `googleapis`), not a direct dependency, so it's pinned via the existing `overrides` block in `functions/package.json` alongside the existing `protobufjs` override.
- `functions/package-lock.json` regenerated with `npm install`.

## Test plan

- [x] `npm test` (vitest) — 82/82 tests passing, 9/9 test files
- [x] `npm run build` (tsc) — compiles cleanly, no errors

Marked as draft for review before merge since this touches the Cloud Functions dependency tree.