### PR TITLE
fix: bump form-data to 2.5.6 (security)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -5831,16 +5831,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -6446,9 +6446,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,8 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "protobufjs": ">=7.5.5"
+    "protobufjs": ">=7.5.5",
+    "form-data": "2.5.6"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.1",


### PR DESCRIPTION
## Summary

- Bumps the transitive `form-data` dependency in `functions/` from 2.5.5 to 2.5.6 via an npm `overrides` entry, fixing [GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx) / [osv.dev](https://osv.dev/GHSA-hmw2-7cc7-3qxx) (CVSS 8.7).
- `form-data` is not a direct dependency here; it comes in transitively (parent range `^2.5.5`), so the fix uses the existing `overrides` block in `functions/package.json` (alongside the pre-existing `protobufjs` override) rather than a `package.json` dependency change.
- Deliberately stays on the **2.x line** (2.5.6) to match the parent's `^2.5.5` requirement — distinct from the root project's separate `form-data` 4.x line/fix.

## Test plan

- [x] `npm install` in `functions/` regenerated `package-lock.json`; confirmed `form-data` resolves to `2.5.6` (single resolution in the tree).
- [x] `npm test` (vitest) — 9 test files, 82 tests, all passing.
- [x] `npm run build` (tsc) — clean build, no errors.