### PR TITLE
fix: bump @grpc/grpc-js to 1.14.4 (security)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1105,21 +1105,6 @@
         "@firebase/util": "1.x"
       }
     },
-    "node_modules/@firebase/firestore/node_modules/@grpc/grpc-js": {
-      "version": "1.9.15",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
-      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
-      }
-    },
     "node_modules/@firebase/functions": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.3.tgz",
@@ -1582,11 +1567,11 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -1599,8 +1584,8 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
       "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -2337,8 +2322,8 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,8 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "protobufjs": ">=7.5.5"
+    "protobufjs": ">=7.5.5",
+    "@grpc/grpc-js": "1.14.4"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.1",


### PR DESCRIPTION
## Summary

- Bumps the transitive dependency `@grpc/grpc-js` (used by `googleapis`/`firebase-admin` and, in dev, by `firebase-functions-test`) to `1.14.4` in `functions/` via an npm `overrides` entry.
- Previously resolved at two different versions in the lockfile: `1.14.3` (prod chain) and `1.9.15` (dev chain). The override unifies both to `1.14.4`.
- The existing `protobufjs` override is untouched.

## Advisories fixed

- [GHSA-5375-pq7m-f5r2](https://osv.dev/GHSA-5375-pq7m-f5r2) (CVSS 7.5)
- [GHSA-99f4-grh7-6pcq](https://osv.dev/GHSA-99f4-grh7-6pcq) (CVSS 7.5)

Both are resolved by `@grpc/grpc-js@1.14.4`.

## Test plan

- [x] `npm test` in `functions/` — 82 tests passed (9 files)
- [x] `npm run build` in `functions/` (tsc) — passes with no errors
- [x] Verified in `functions/package-lock.json` that both previously-resolved copies now point to `1.14.4`

Draft PR — opening for review since this touches Cloud Functions dependencies (indirect via `googleapis`/`firebase-admin`), not the direct package version.