### PR TITLE
fix: pin protobufjs to 8.6.0 (security)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8786,14 +8786,12 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.3.tgz",
-      "integrity": "sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==",
-      "hasInstallScript": true,
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.0.tgz",
+      "integrity": "sha512-PIOO89BMGMXGz2333TVv/OqPNVWm7w30ll/4FtLbtLBaonzJMYwTbAZSSlobjIy9MoUgIAxSVUpK7aP7EpTtkg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,7 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "protobufjs": ">=7.5.5"
+    "protobufjs": "8.6.0"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.1",


### PR DESCRIPTION
## Summary

`functions/package.json` already had an override for `protobufjs` (`">=7.5.5"`), but that range was too loose: the resolved version, `8.0.3`, satisfies it while still being vulnerable to three separate advisories. This PR tightens the override to an exact pin, `8.6.0`, which is the lowest 8.x release that resolves all three at once.

## Advisories fixed

- [GHSA-f38q-mgvj-vph7](https://github.com/advisories/GHSA-f38q-mgvj-vph7) (CVSS 5.3)
- [GHSA-jggg-4jg4-v7c6](https://github.com/advisories/GHSA-jggg-4jg4-v7c6) (CVSS 5.3)
- [GHSA-wcpc-wj8m-hjx6](https://github.com/advisories/GHSA-wcpc-wj8m-hjx6) (CVSS 7.5)

## Changes

- `functions/package.json`: `overrides.protobufjs` changed from `">=7.5.5"` to `"8.6.0"` (exact pin, not a range, so it can't drift back to a vulnerable version)
- `functions/package-lock.json`: regenerated via `npm install`; `protobufjs` now resolves to `8.6.0`

## Test plan

- [x] `npm install` in `functions/` regenerated the lockfile; confirmed `protobufjs` resolves to `8.6.0`
- [x] `npm test` (vitest) — 82/82 tests passed
- [x] `npm run build` (tsc) — passed with no errors