### PR TITLE
fix: override de websocket-driver (seguridad) y config de ESLint propia para functions

### DIFF
--- a/functions/eslint.config.mjs
+++ b/functions/eslint.config.mjs
@@ -1,0 +1,63 @@
+import tsParser from "@typescript-eslint/parser";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+
+// Config propia de functions/: la raíz ignora "functions/", así que sin este
+// archivo `eslint src/` resolvía la config raíz y se auto-ignoraba entero.
+export default [
+  {
+    ignores: ["lib/", "node_modules/", "coverage/"],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2022,
+      sourceType: "module",
+      parserOptions: {
+        project: null,
+      },
+      globals: {
+        console: "readonly",
+        process: "readonly",
+        Buffer: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        URL: "readonly",
+        fetch: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      eqeqeq: ["error", "always"],
+      "no-console": "warn",
+      "no-control-regex": "error",
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+    },
+  },
+  {
+    files: ["**/*.test.ts", "**/*.spec.ts"],
+    languageOptions: {
+      globals: {
+        describe: "readonly",
+        it: "readonly",
+        expect: "readonly",
+        beforeEach: "readonly",
+        afterEach: "readonly",
+        beforeAll: "readonly",
+        afterAll: "readonly",
+        vi: "readonly",
+      },
+    },
+  },
+];

--- a/functions/src/handlers/minigameJoin.test.ts
+++ b/functions/src/handlers/minigameJoin.test.ts
@@ -81,10 +81,7 @@ interface WiringResult {
   auditAdd: ReturnType<typeof vi.fn>;
 }
 
-function wireFirestore(
-  liveInstances: InstanceFixture[],
-  slug = "devfest-2025"
-): WiringResult {
+function wireFirestore(liveInstances: InstanceFixture[]): WiringResult {
   const setCalls: Array<{ ref: object; data: Record<string, unknown> }> = [];
   const auditAdd = vi.fn(async () => undefined);
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
       "mdast-util-to-hast": "13.2.1",
       "postcss": "8.5.10",
       "undici": "7.28.0",
-      "vite": "8.0.16"
+      "vite": "8.0.16",
+      "websocket-driver": "0.7.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   postcss: 8.5.10
   undici: 7.28.0
   vite: 8.0.16
+  websocket-driver: 0.7.5
 
 importers:
 
@@ -5596,8 +5597,8 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -9000,7 +9001,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -11579,7 +11580,7 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1


### PR DESCRIPTION
Dos arreglos independientes que quedaban pendientes tras #275.

## 1. Seguridad — override de `websocket-driver` a 0.7.5

Entra como transitiva de `firebase` (`@firebase/database` → `faye-websocket`) y estaba en `0.7.4`:

| Sev | Advisory |
|---|---|
| **CRITICAL** | GHSA-mp7j-qc5w-4988 — message corruption via protocol length headers |
| MODERATE | Resource limit bypass via message compression |

Ambas se corrigen en `0.7.5`, un patch dentro de `0.7.x`.

**`pnpm audit`: 4 → 2 vulnerabilidades, ninguna crítica.**

Nota de alcance honesta: `faye-websocket` es la implementación de WebSocket para Node; en el navegador el SDK de Firebase usa WebSocket nativo. Lo verifiqué — 0 apariciones de `faye`/`websocket-driver` en `dist/`, contra 6 archivos que sí mencionan `firebase`. No había exposición real en el sitio estático; el override deja el árbol limpio.

### Lo que se deja fuera a propósito

Las 2 restantes (`uuid` <11.1.1, `@opentelemetry/core` <2.8.0) vienen de `firebase-tools`, que es **devDep**. Parchearlas exige forzar saltos de 1-2 majors (uuid 9.0.1 → ≥11.1.1, otel 1.30.1 → ≥2.8.0) dentro de las tripas de la herramienta que despliega el sitio. El riesgo de romper el deploy supera al beneficio para dependencias que nunca llegan a producción.

## 2. `functions/` no se estaba linteando

La config raíz ignora `"functions/"` (`eslint.config.js:21`) y `functions/` no tenía config propia. Al correr `eslint src/`, ESLint resolvía la config de la raíz y se auto-ignoraba entero: **40 archivos TypeScript pasaban "limpio" sin revisarse.**

Se agrega `functions/eslint.config.mjs` reutilizando los plugins que ya estaban en `devDependencies` — **no se agregan dependencias nuevas**. Incluye `no-console` y `no-control-regex`, que el código ya suprimía con `eslint-disable` esperando que el lint funcionara (esos directivas aparecían como "unused", señal de que nunca corrieron).

Primer lint real sobre los 40 archivos: un único hallazgo. El parámetro `slug` de `wireFirestore()` en `minigameJoin.test.ts`, sin uso en el cuerpo y que ninguno de sus 10 call sites pasa. Se elimina en vez de renombrarlo a `_slug`, porque es código muerto.

## Verificación

- `pnpm build` — 35 páginas
- `pnpm test` — 137/137
- `pnpm lint` (raíz) — limpio
- `npm run build` (functions, `tsc`) — limpio
- `npm test` (functions) — 82/82
- `npm run lint` (functions) — limpio, ahora sobre los 40 archivos reales

## Fuera de alcance

Queda pendiente el **hydration mismatch de React (#418) en `/admin/*`**, preexistente e idéntico en Astro 5 y 7. Vive dentro de `AdminApp` y necesita investigación propia con auth real de Firebase; mezclarlo con una PR de seguridad y tooling no correspondía.