### PR TITLE
feat(checkin): on-site check-in panel for GDG ICA events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ public/carousel/
 # Windows Zone.Identifier files
 *:Zone.Identifier
 *.Identifier
+
+# Playwright MCP artifacts (snapshots, console logs, test fixtures).
+# Never commit: E2E runs put real attendee CSVs here.
+.playwright-mcp/

--- a/firestore.rules
+++ b/firestore.rules
@@ -131,7 +131,28 @@ service cloud.firestore {
                           || request.resource.data.checkedInBy == request.auth.uid)
                       && (!('note' in request.resource.data)
                           || request.resource.data.note == null
-                          || request.resource.data.note.size() <= 200);
+                          || request.resource.data.note.size() <= 200)
+                      // The remaining allowlisted keys need bounds too. The
+                      // client is untrusted even when the caller holds the
+                      // organizer role, and without these a volunteer could
+                      // write a multi-megabyte checkedInByName or fabricate
+                      // the DNI-verification state these fields are reserved
+                      // for.
+                      && (!('checkedInByName' in request.resource.data)
+                          || request.resource.data.checkedInByName == null
+                          || (request.resource.data.checkedInByName is string
+                              && request.resource.data.checkedInByName.size() <= 120))
+                      && (!('dniVerified' in request.resource.data)
+                          || request.resource.data.dniVerified is bool)
+                      && (!('dniMatchedName' in request.resource.data)
+                          || request.resource.data.dniMatchedName == null
+                          || (request.resource.data.dniMatchedName is string
+                              && request.resource.data.dniMatchedName.size() <= 200))
+                      && (!('dniMatchScore' in request.resource.data)
+                          || request.resource.data.dniMatchScore == null
+                          || (request.resource.data.dniMatchScore is number
+                              && request.resource.data.dniMatchScore >= 0
+                              && request.resource.data.dniMatchScore <= 1));
       }
 
       // Import metadata (last import id, roster count, last Bevy sync).

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,18 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    // Reads the caller's role from users/{uid}. Costs one billed document
+    // read per rule evaluation, so on a roster subscribe it is ~1 extra
+    // read per attendee doc. Fine at event scale; if the roster ever
+    // reaches thousands, move role into a custom auth claim
+    // (request.auth.token.role), which is free.
+    function callerRole() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role;
+    }
+    function isOrganizer() {
+      return request.auth != null && callerRole() in ['organizer', 'admin'];
+    }
+
     match /users/{userId} {
       allow read: if request.auth != null && request.auth.uid == userId;
       allow create: if request.auth != null
@@ -86,6 +98,47 @@ service cloud.firestore {
           allow read: if true;
           allow write: if false;
         }
+      }
+
+      // Attendee roster imported from the Bevy registrations CSV, used by
+      // the on-site check-in panel. Contains names and emails, so unlike
+      // the parent event doc it is NOT publicly readable. Note that the
+      // `allow read: if true` above does not cascade here — rules only
+      // inherit through recursive wildcards — but we state the restriction
+      // explicitly so a later refactor cannot widen it by accident.
+      match /roster/{attendeeId} {
+        allow read: if isOrganizer();
+
+        // Import and removal run through Cloud Functions with the Admin
+        // SDK, which bypasses these rules.
+        allow create, delete: if false;
+
+        // Volunteers toggle check-in straight from the client rather than
+        // via an HTTPS call, because only a direct Firestore write can be
+        // queued in the local cache and replayed when venue wifi drops.
+        // hasOnly() pins them to the check-in fields, so a volunteer
+        // cannot rewrite an attendee's email, name or bevyCheckinAt.
+        allow update: if isOrganizer()
+                      && request.resource.data.diff(resource.data).affectedKeys()
+                         .hasOnly(['checkedIn', 'checkedInAt', 'checkedInBy',
+                                   'checkedInByName', 'note',
+                                   'dniVerified', 'dniVerifiedAt',
+                                   'dniMatchScore', 'dniMatchedName'])
+                      && request.resource.data.checkedIn is bool
+                      // Marking someone present must be attributable; only
+                      // un-checking may leave checkedInBy unset.
+                      && (request.resource.data.checkedIn == false
+                          || request.resource.data.checkedInBy == request.auth.uid)
+                      && (!('note' in request.resource.data)
+                          || request.resource.data.note == null
+                          || request.resource.data.note.size() <= 200);
+      }
+
+      // Import metadata (last import id, roster count, last Bevy sync).
+      // Written only by Cloud Functions.
+      match /checkinMeta/{docId} {
+        allow read: if isOrganizer();
+        allow write: if false;
       }
     }
 

--- a/functions/src/handlers/checkin.ts
+++ b/functions/src/handlers/checkin.ts
@@ -1,0 +1,145 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
+import { writeAuditLog } from "../utils/audit";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { safeError } from "../middleware/validate";
+import { buildSearchTokens, parseBevyDate } from "../services/nameMatch";
+
+// Firestore caps a WriteBatch at 500 operations; 400 leaves headroom.
+const BATCH_SIZE = 400;
+
+/** Bevy ticket numbers look like GOOGA263171317, but sanitize anyway —
+ *  this value becomes a document ID and Firestore rejects "/" and "..". */
+function attendeeId(ticketNumber: string): string {
+  return `t_${ticketNumber.replace(/[^A-Za-z0-9_-]/g, "")}`;
+}
+
+interface RosterRow {
+  ticketNumber: string;
+  orderNumber: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  company: string;
+  title: string;
+  ticketTitle: string;
+  bevyCheckinAt: string;
+}
+
+/**
+ * POST /api/events/:slug/checkin/import
+ *
+ * Imports the parsed Bevy registrations CSV into
+ * events/{slug}/roster/{attendeeId}.
+ *
+ * Idempotent by construction: the merge payload contains only roster
+ * fields, never checkedIn*, so re-importing an updated export (people
+ * register right up to the doors opening) cannot clobber check-ins that
+ * already happened. Check-in defaults are written only for documents
+ * that do not exist yet.
+ */
+export async function importRoster(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const user = (req as AuthenticatedRequest).user;
+    const rows = (req.body.rows ?? []) as RosterRow[];
+
+    if (rows.length === 0) {
+      res.status(400).json({ success: false, error: "No hay filas que importar" });
+      return;
+    }
+
+    const db = admin.firestore();
+    const rosterRef = db.collection(`events/${slug}/roster`);
+
+    // Which attendees already exist decides whether this import may write
+    // check-in defaults. select() with no fields fetches IDs only.
+    const existingSnap = await rosterRef.select().get();
+    const existing = new Set(existingSnap.docs.map((d) => d.id));
+
+    const importId = `imp_${Date.now()}`;
+    let created = 0;
+    let updated = 0;
+
+    for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+      const batch = db.batch();
+      for (const row of rows.slice(i, i + BATCH_SIZE)) {
+        const id = attendeeId(row.ticketNumber);
+        const isNew = !existing.has(id);
+
+        const rosterFields: Record<string, unknown> = {
+          ticketNumber: row.ticketNumber,
+          orderNumber: row.orderNumber,
+          firstName: row.firstName,
+          lastName: row.lastName,
+          email: row.email,
+          company: row.company,
+          title: row.title,
+          ticketTitle: row.ticketTitle,
+          searchTokens: buildSearchTokens(row),
+          // Refreshed every import on purpose: this is how the panel
+          // learns who was already checked in on Bevy itself.
+          bevyCheckinAt: parseBevyDate(row.bevyCheckinAt),
+          lastImportId: importId,
+          importedAt: FieldValue.serverTimestamp(),
+        };
+
+        if (isNew) {
+          // Only ever set on creation. The rules require checkedIn to be
+          // a bool, so a doc without it would be unwritable.
+          Object.assign(rosterFields, {
+            checkedIn: false,
+            checkedInAt: null,
+            checkedInBy: null,
+            checkedInByName: null,
+            note: null,
+            dniVerified: false,
+            dniVerifiedAt: null,
+            dniMatchScore: null,
+            dniMatchedName: null,
+          });
+          created++;
+        } else {
+          updated++;
+        }
+
+        batch.set(rosterRef.doc(id), rosterFields, { merge: true });
+      }
+      await batch.commit();
+    }
+
+    // Attendees present in a previous import but absent here (refunds,
+    // cancellations) are deliberately NOT deleted — they may already be
+    // checked in. They keep an older lastImportId, which the panel uses
+    // to flag them without losing their state.
+    const stale = existingSnap.size - updated;
+
+    await db.doc(`events/${slug}/checkinMeta/current`).set(
+      {
+        lastImportId: importId,
+        lastImportAt: FieldValue.serverTimestamp(),
+        lastImportBy: user.uid,
+        lastImportByName: user.displayName || user.email || user.uid,
+        rosterCount: rows.length,
+      },
+      { merge: true }
+    );
+
+    await writeAuditLog({
+      action: "checkin.import",
+      performedBy: user.uid,
+      targetId: slug,
+      targetType: "checkin_roster",
+      details: { importId, total: rows.length, created, updated, stale },
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    res.json({
+      success: true,
+      data: { importId, total: rows.length, created, updated, stale },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}

--- a/functions/src/handlers/checkin.ts
+++ b/functions/src/handlers/checkin.ts
@@ -36,8 +36,10 @@ interface RosterRow {
  * Idempotent by construction: the merge payload contains only roster
  * fields, never checkedIn*, so re-importing an updated export (people
  * register right up to the doors opening) cannot clobber check-ins that
- * already happened. Check-in defaults are written only for documents
- * that do not exist yet.
+ * already happened. No check-in fields are written at all, not even
+ * defaults — absence reads as "not checked in" on both the client and in
+ * the rules, which keeps the guarantee structural instead of conditional
+ * on a prior existence read that two concurrent imports could race.
  */
 export async function importRoster(req: Request, res: Response) {
   try {
@@ -50,23 +52,44 @@ export async function importRoster(req: Request, res: Response) {
       return;
     }
 
-    // The browser parser already drops duplicate tickets, but this
-    // endpoint is reachable directly by any organizer. Two rows sharing a
-    // ticket number would write the same document twice and skew the
-    // created/updated counts, which would in turn make `stale` negative.
+    // Dedup on the DOCUMENT ID, not the raw ticket number. attendeeId() is
+    // lossy — it strips everything outside [A-Za-z0-9_-] — so "GOOGA 123"
+    // and "GOOGA123" are distinct strings that address the same document.
+    // Keying the set on the raw value let both through, and the second
+    // write silently replaced the first: one registrant vanished from the
+    // roster and could not be checked in at the door.
     const rows: RosterRow[] = [];
     const seen = new Set<string>();
+    let unusableTickets = 0;
     for (const row of rawRows) {
-      if (seen.has(row.ticketNumber)) continue;
-      seen.add(row.ticketNumber);
+      const id = attendeeId(row.ticketNumber);
+      // A ticket of pure punctuation sanitizes to the bare prefix, which
+      // would collapse every such row onto one shared document.
+      if (id === "t_") {
+        unusableTickets++;
+        continue;
+      }
+      if (seen.has(id)) continue;
+      seen.add(id);
       rows.push(row);
+    }
+
+    if (rows.length === 0) {
+      res.status(400).json({
+        success: false,
+        error: "Ninguna fila tiene un número de ticket utilizable",
+      });
+      return;
     }
 
     const db = admin.firestore();
     const rosterRef = db.collection(`events/${slug}/roster`);
 
-    // Which attendees already exist decides whether this import may write
-    // check-in defaults. select() with no fields fetches IDs only.
+    // Counts only — never correctness. An earlier version decided whether
+    // to write check-in defaults from this snapshot, which raced: a
+    // concurrent import reading before the other committed would see a doc
+    // as new and merge checkedIn:false over a check-in that had already
+    // happened. Nothing below depends on it now.
     const existingSnap = await rosterRef.select().get();
     const existing = new Set(existingSnap.docs.map((d) => d.id));
 
@@ -97,24 +120,15 @@ export async function importRoster(req: Request, res: Response) {
           importedAt: FieldValue.serverTimestamp(),
         };
 
-        if (isNew) {
-          // Only ever set on creation. The rules require checkedIn to be
-          // a bool, so a doc without it would be unwritable.
-          Object.assign(rosterFields, {
-            checkedIn: false,
-            checkedInAt: null,
-            checkedInBy: null,
-            checkedInByName: null,
-            note: null,
-            dniVerified: false,
-            dniVerifiedAt: null,
-            dniMatchScore: null,
-            dniMatchedName: null,
-          });
-          created++;
-        } else {
-          updated++;
-        }
+        // Counters only. The import deliberately writes NO check-in fields
+        // at all — not even defaults on a seemingly-new document. Absence
+        // is the default: useRoster reads `data.checkedIn === true`, and
+        // the rules constrain request.resource.data (the post-write state,
+        // which the client always populates), not what is already stored.
+        // That makes "an import can never disturb a check-in" a structural
+        // property rather than something conditional on a prior read.
+        if (isNew) created++;
+        else updated++;
 
         batch.set(rosterRef.doc(id), rosterFields, { merge: true });
       }
@@ -125,7 +139,11 @@ export async function importRoster(req: Request, res: Response) {
     // cancellations) are deliberately NOT deleted — they may already be
     // checked in. They keep an older lastImportId, which the panel uses
     // to flag them without losing their state.
-    const stale = existingSnap.size - updated;
+    // Clamped: `updated` counts rows matched against a snapshot taken
+    // before the batches ran, so a concurrent import can push it past the
+    // snapshot size. Cosmetic either way, but a negative count reads as a
+    // bug to whoever sees it in the audit log.
+    const stale = Math.max(0, existingSnap.size - updated);
 
     await db.doc(`events/${slug}/checkinMeta/current`).set(
       {
@@ -143,13 +161,27 @@ export async function importRoster(req: Request, res: Response) {
       performedBy: user.uid,
       targetId: slug,
       targetType: "checkin_roster",
-      details: { importId, total: rows.length, created, updated, stale },
+      details: {
+        importId,
+        total: rows.length,
+        created,
+        updated,
+        stale,
+        unusableTickets,
+      },
       timestamp: FieldValue.serverTimestamp(),
     });
 
     res.json({
       success: true,
-      data: { importId, total: rows.length, created, updated, stale },
+      data: {
+        importId,
+        total: rows.length,
+        created,
+        updated,
+        stale,
+        unusableTickets,
+      },
     });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });

--- a/functions/src/handlers/checkin.ts
+++ b/functions/src/handlers/checkin.ts
@@ -43,11 +43,23 @@ export async function importRoster(req: Request, res: Response) {
   try {
     const slug = req.params.slug as string;
     const user = (req as AuthenticatedRequest).user;
-    const rows = (req.body.rows ?? []) as RosterRow[];
+    const rawRows = (req.body.rows ?? []) as RosterRow[];
 
-    if (rows.length === 0) {
+    if (rawRows.length === 0) {
       res.status(400).json({ success: false, error: "No hay filas que importar" });
       return;
+    }
+
+    // The browser parser already drops duplicate tickets, but this
+    // endpoint is reachable directly by any organizer. Two rows sharing a
+    // ticket number would write the same document twice and skew the
+    // created/updated counts, which would in turn make `stale` negative.
+    const rows: RosterRow[] = [];
+    const seen = new Set<string>();
+    for (const row of rawRows) {
+      if (seen.has(row.ticketNumber)) continue;
+      seen.add(row.ticketNumber);
+      rows.push(row);
     }
 
     const db = admin.firestore();

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -19,6 +19,7 @@ import {
   minigameJoinSchema,
   minigameWordHiddenSchema,
   certificateSendSchema,
+  checkinImportSchema,
 } from "./schemas";
 import { register } from "./handlers/auth";
 import * as events from "./handlers/events";
@@ -36,6 +37,7 @@ import * as minigameJoin from "./handlers/minigameJoin";
 import * as minigameWords from "./handlers/minigameWords";
 import * as minigameRoulette from "./handlers/minigameRoulette";
 import * as certificates from "./handlers/certificates";
+import * as checkin from "./handlers/checkin";
 
 admin.initializeApp();
 
@@ -408,6 +410,18 @@ app.post(
   writeLimiter,
   validateBody(certificateSendSchema),
   certificates.sendCertificates
+);
+
+// On-site check-in. The roster import is the only write that goes
+// through the API — volunteers toggle check-in straight against
+// Firestore so the write can be queued when venue wifi drops.
+app.post(
+  "/api/events/:slug/checkin/import",
+  requireRole("organizer"),
+  slugP,
+  writeLimiter,
+  validateBody(checkinImportSchema),
+  checkin.importRoster
 );
 
 // Rebuild

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,5 @@
 import * as admin from "firebase-admin";
+import { logger } from "firebase-functions";
 import { onRequest } from "firebase-functions/v2/https";
 import express from "express";
 import cors from "cors";
@@ -48,6 +49,21 @@ const ALLOWED_ORIGINS = [
   "http://localhost:4321",
 ];
 
+// Only true inside the Functions emulator; the variable is set by the
+// emulator itself and never exists in a deployed function.
+const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === "true";
+
+// Astro picks the next free port when 4321 is taken (a second dev server,
+// a leftover process), and every API call then fails CORS with no hint as
+// to why. Accept any localhost port — but ONLY under the emulator, so the
+// deployed allowlist stays exactly the four origins above.
+const LOCALHOST_RE = /^http:\/\/(localhost|127\.0\.0\.1):\d+$/;
+
+function isAllowedOrigin(origin: string): boolean {
+  if (ALLOWED_ORIGINS.includes(origin)) return true;
+  return IS_EMULATOR && LOCALHOST_RE.test(origin);
+}
+
 const app = express();
 // Firebase Hosting + Cloud Functions sits behind exactly one Google
 // Frontend hop, so trust a single proxy. Setting `true` would let
@@ -56,14 +72,34 @@ app.set("trust proxy", 1);
 app.use(
   cors({
     origin: (origin, callback) => {
-      if (!origin || ALLOWED_ORIGINS.includes(origin)) {
+      if (!origin || isAllowedOrigin(origin)) {
         callback(null, true);
-      } else {
-        callback(new Error("Not allowed by CORS"));
+        return;
       }
+      // Never pass an Error here: cors() forwards it to the default
+      // express handler, which answers 500. The caller then sees a bare
+      // "Error 500" with nothing pointing at the origin — the actual
+      // cause. Reject the CORS headers instead and let the explicit 403
+      // middleware below answer with something diagnosable.
+      logger.warn("Blocked CORS origin", { origin });
+      callback(null, false);
     },
   })
 );
+
+// Requests from a disallowed origin reach here without CORS headers. Answer
+// them explicitly so the failure is legible in the network tab and in logs.
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (origin && !isAllowedOrigin(origin)) {
+    res.status(403).json({
+      success: false,
+      error: `Origen no permitido: ${origin}`,
+    });
+    return;
+  }
+  next();
+});
 app.use(express.json({ limit: "1mb" }));
 
 // Outer perimeter limit: large window, generous cap. Protects against
@@ -74,6 +110,12 @@ app.use(
     max: 300,
     standardHeaders: true,
     legacyHeaders: false,
+    // The two limiters below already guard against a missing req.ip; this
+    // one did not, and threw ERR_ERL_UNDEFINED_IP_ADDRESS on every request
+    // under the emulator. Falling back to a shared bucket keeps the
+    // perimeter limit working instead of erroring out.
+    keyGenerator: (req) =>
+      req.ip ? `ip:${ipKeyGenerator(req.ip)}` : "ip:unknown",
     message: { success: false, error: "Too many requests, try again later" },
   })
 );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,4 @@
 import * as admin from "firebase-admin";
-import { logger } from "firebase-functions";
 import { onRequest } from "firebase-functions/v2/https";
 import express from "express";
 import cors from "cors";
@@ -49,21 +48,6 @@ const ALLOWED_ORIGINS = [
   "http://localhost:4321",
 ];
 
-// Only true inside the Functions emulator; the variable is set by the
-// emulator itself and never exists in a deployed function.
-const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === "true";
-
-// Astro picks the next free port when 4321 is taken (a second dev server,
-// a leftover process), and every API call then fails CORS with no hint as
-// to why. Accept any localhost port — but ONLY under the emulator, so the
-// deployed allowlist stays exactly the four origins above.
-const LOCALHOST_RE = /^http:\/\/(localhost|127\.0\.0\.1):\d+$/;
-
-function isAllowedOrigin(origin: string): boolean {
-  if (ALLOWED_ORIGINS.includes(origin)) return true;
-  return IS_EMULATOR && LOCALHOST_RE.test(origin);
-}
-
 const app = express();
 // Firebase Hosting + Cloud Functions sits behind exactly one Google
 // Frontend hop, so trust a single proxy. Setting `true` would let
@@ -72,34 +56,14 @@ app.set("trust proxy", 1);
 app.use(
   cors({
     origin: (origin, callback) => {
-      if (!origin || isAllowedOrigin(origin)) {
+      if (!origin || ALLOWED_ORIGINS.includes(origin)) {
         callback(null, true);
-        return;
+      } else {
+        callback(new Error("Not allowed by CORS"));
       }
-      // Never pass an Error here: cors() forwards it to the default
-      // express handler, which answers 500. The caller then sees a bare
-      // "Error 500" with nothing pointing at the origin — the actual
-      // cause. Reject the CORS headers instead and let the explicit 403
-      // middleware below answer with something diagnosable.
-      logger.warn("Blocked CORS origin", { origin });
-      callback(null, false);
     },
   })
 );
-
-// Requests from a disallowed origin reach here without CORS headers. Answer
-// them explicitly so the failure is legible in the network tab and in logs.
-app.use((req, res, next) => {
-  const origin = req.headers.origin;
-  if (origin && !isAllowedOrigin(origin)) {
-    res.status(403).json({
-      success: false,
-      error: `Origen no permitido: ${origin}`,
-    });
-    return;
-  }
-  next();
-});
 app.use(express.json({ limit: "1mb" }));
 
 // Outer perimeter limit: large window, generous cap. Protects against
@@ -110,12 +74,6 @@ app.use(
     max: 300,
     standardHeaders: true,
     legacyHeaders: false,
-    // The two limiters below already guard against a missing req.ip; this
-    // one did not, and threw ERR_ERL_UNDEFINED_IP_ADDRESS on every request
-    // under the emulator. Falling back to a shared bucket keeps the
-    // perimeter limit working instead of erroring out.
-    keyGenerator: (req) =>
-      req.ip ? `ip:${ipKeyGenerator(req.ip)}` : "ip:unknown",
     message: { success: false, error: "Too many requests, try again later" },
   })
 );

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -296,3 +296,31 @@ export const certificateSendSchema = z
   .strict();
 
 export type CertificateSendBody = z.infer<typeof certificateSendSchema>;
+
+// Check-in roster import. The client parses the Bevy registrations CSV
+// and posts the rows; the handler writes them to Firestore. The 2000-row
+// cap sits well above any GDG ICA event while keeping the payload inside
+// the 1mb express body limit.
+const rosterRowSchema = z
+  .object({
+    // Bevy's per-registration primary key; becomes the document ID.
+    ticketNumber: z.string().trim().min(1).max(100),
+    orderNumber: shortText(100),
+    firstName: shortText(200),
+    lastName: shortText(200),
+    email: z.string().trim().email().max(254),
+    company: shortText(300),
+    title: shortText(300),
+    ticketTitle: shortText(200),
+    // Raw "Checkin Date (UTC)" cell; empty when not checked in on Bevy.
+    bevyCheckinAt: shortText(100),
+  })
+  .strict();
+
+export const checkinImportSchema = z
+  .object({
+    rows: z.array(rosterRowSchema).min(1).max(2000),
+  })
+  .strict();
+
+export type CheckinImportBody = z.infer<typeof checkinImportSchema>;

--- a/functions/src/services/nameMatch.test.ts
+++ b/functions/src/services/nameMatch.test.ts
@@ -2,31 +2,31 @@ import { describe, expect, it } from "vitest";
 import {
   buildSearchTokens,
   nameTokens,
-  normalizeName,
+  normalizeSearchText,
   parseBevyDate,
 } from "./nameMatch";
 
-describe("normalizeName", () => {
+describe("normalizeSearchText", () => {
   it("strips diacritics so accented and unaccented spellings unify", () => {
     // The whole point for Peru: a volunteer typing into the search box
     // will not reach for ñ or í, and Bevy names are self-typed.
-    expect(normalizeName("Ñañez Solís")).toBe("nanez solis");
-    expect(normalizeName("María Huamaní")).toBe("maria huamani");
-    expect(normalizeName("Adrián Yusef")).toBe("adrian yusef");
+    expect(normalizeSearchText("Ñañez Solís")).toBe("nanez solis");
+    expect(normalizeSearchText("María Huamaní")).toBe("maria huamani");
+    expect(normalizeSearchText("Adrián Yusef")).toBe("adrian yusef");
   });
 
   it("lowercases and collapses whitespace", () => {
-    expect(normalizeName("  ALEX   ALBERTO  ")).toBe("alex alberto");
+    expect(normalizeSearchText("  ALEX   ALBERTO  ")).toBe("alex alberto");
   });
 
   it("replaces punctuation with a separator rather than joining words", () => {
-    expect(normalizeName("Quintanilla-Garcia")).toBe("quintanilla garcia");
-    expect(normalizeName("O'Brien")).toBe("o brien");
+    expect(normalizeSearchText("Quintanilla-Garcia")).toBe("quintanilla garcia");
+    expect(normalizeSearchText("O'Brien")).toBe("o brien");
   });
 
   it("returns an empty string for empty input", () => {
-    expect(normalizeName("")).toBe("");
-    expect(normalizeName("   ")).toBe("");
+    expect(normalizeSearchText("")).toBe("");
+    expect(normalizeSearchText("   ")).toBe("");
   });
 });
 
@@ -119,5 +119,39 @@ describe("parseBevyDate", () => {
     // on Bevy" and make the sync skip this person entirely.
     expect(parseBevyDate("not a date")).toBeNull();
     expect(parseBevyDate("--")).toBeNull();
+  });
+
+  // Regression: this used to hand the string to `new Date()`, whose legacy
+  // parser skips tokens it does not recognize. Each of these produced a
+  // VALID Date, which reads as "already checked in on Bevy" and makes the
+  // sync skip someone who never was.
+  it.each([
+    "2026",
+    "Jul 2026",
+    "pending Jul 06, 2026",
+    "Jul 06, 2026",
+    "06/07/2026 - 03:10 PM",
+    "2026-07-06T15:10:00Z",
+  ])("rejects %j instead of guessing", (input) => {
+    expect(parseBevyDate(input)).toBeNull();
+  });
+
+  it("rejects a trailing offset rather than silently overriding it", () => {
+    // Appending " UTC" used to win over the real offset, shifting the
+    // timestamp by five hours with no error.
+    expect(parseBevyDate("Jul 06, 2026 - 03:10 PM -05:00")).toBeNull();
+  });
+
+  it("rejects impossible calendar dates instead of rolling them over", () => {
+    expect(parseBevyDate("Feb 31, 2026 - 10:00 AM")).toBeNull();
+  });
+
+  it("handles the 12-hour boundaries correctly", () => {
+    expect(parseBevyDate("Jul 06, 2026 - 12:00 AM")?.toISOString()).toBe(
+      "2026-07-06T00:00:00.000Z"
+    );
+    expect(parseBevyDate("Jul 06, 2026 - 12:30 PM")?.toISOString()).toBe(
+      "2026-07-06T12:30:00.000Z"
+    );
   });
 });

--- a/functions/src/services/nameMatch.test.ts
+++ b/functions/src/services/nameMatch.test.ts
@@ -121,6 +121,33 @@ describe("parseBevyDate", () => {
     expect(parseBevyDate("--")).toBeNull();
   });
 
+  // THE format the CSV export actually writes — verified against the
+  // "Paid date (UTC)" column of a real DevFest Ica 2026 export. The
+  // dashboard's "Jul 06, 2026 - 03:10 PM" is what the web UI *renders*; an
+  // earlier version of this parser only accepted that, so every genuinely
+  // checked-in registrant would have parsed to null and the Bevy sync would
+  // have silently believed nobody was checked in.
+  it("parses the real CSV export format", () => {
+    expect(parseBevyDate("2026-07-06 20:10:16+00:00")?.toISOString()).toBe(
+      "2026-07-06T20:10:16.000Z"
+    );
+  });
+
+  it("honours a non-UTC offset instead of assuming UTC", () => {
+    expect(parseBevyDate("2026-07-06 15:10:00-05:00")?.toISOString()).toBe(
+      "2026-07-06T20:10:00.000Z"
+    );
+  });
+
+  it.each([
+    ["2026-07-06T15:10:00Z", "2026-07-06T15:10:00.000Z"],
+    ["2026-07-06 15:10:00", "2026-07-06T15:10:00.000Z"], // no offset = UTC
+    ["2026-07-06 15:10", "2026-07-06T15:10:00.000Z"], // seconds optional
+    ["2026-07-06 15:10:00.123+00:00", "2026-07-06T15:10:00.123Z"],
+  ])("parses ISO variant %j", (input, expected) => {
+    expect(parseBevyDate(input)?.toISOString()).toBe(expected);
+  });
+
   // Regression: this used to hand the string to `new Date()`, whose legacy
   // parser skips tokens it does not recognize. Each of these produced a
   // VALID Date, which reads as "already checked in on Bevy" and makes the
@@ -131,15 +158,8 @@ describe("parseBevyDate", () => {
     "pending Jul 06, 2026",
     "Jul 06, 2026",
     "06/07/2026 - 03:10 PM",
-    "2026-07-06T15:10:00Z",
   ])("rejects %j instead of guessing", (input) => {
     expect(parseBevyDate(input)).toBeNull();
-  });
-
-  it("rejects a trailing offset rather than silently overriding it", () => {
-    // Appending " UTC" used to win over the real offset, shifting the
-    // timestamp by five hours with no error.
-    expect(parseBevyDate("Jul 06, 2026 - 03:10 PM -05:00")).toBeNull();
   });
 
   it("rejects impossible calendar dates instead of rolling them over", () => {

--- a/functions/src/services/nameMatch.test.ts
+++ b/functions/src/services/nameMatch.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSearchTokens,
+  nameTokens,
+  normalizeName,
+  parseBevyDate,
+} from "./nameMatch";
+
+describe("normalizeName", () => {
+  it("strips diacritics so accented and unaccented spellings unify", () => {
+    // The whole point for Peru: a volunteer typing into the search box
+    // will not reach for ñ or í, and Bevy names are self-typed.
+    expect(normalizeName("Ñañez Solís")).toBe("nanez solis");
+    expect(normalizeName("María Huamaní")).toBe("maria huamani");
+    expect(normalizeName("Adrián Yusef")).toBe("adrian yusef");
+  });
+
+  it("lowercases and collapses whitespace", () => {
+    expect(normalizeName("  ALEX   ALBERTO  ")).toBe("alex alberto");
+  });
+
+  it("replaces punctuation with a separator rather than joining words", () => {
+    expect(normalizeName("Quintanilla-Garcia")).toBe("quintanilla garcia");
+    expect(normalizeName("O'Brien")).toBe("o brien");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(normalizeName("")).toBe("");
+    expect(normalizeName("   ")).toBe("");
+  });
+});
+
+describe("nameTokens", () => {
+  it("splits a full name into normalized tokens", () => {
+    expect(nameTokens("Alex Alberto Quintanilla Garcia")).toEqual([
+      "alex",
+      "alberto",
+      "quintanilla",
+      "garcia",
+    ]);
+  });
+
+  it("drops connective particles that appear inconsistently", () => {
+    expect(nameTokens("Juan de la Cruz Rojas")).toEqual([
+      "juan",
+      "cruz",
+      "rojas",
+    ]);
+  });
+
+  it("drops single-character initials", () => {
+    expect(nameTokens("Ana M Lopez")).toEqual(["ana", "lopez"]);
+  });
+
+  it("dedupes repeated tokens", () => {
+    expect(nameTokens("Lopez Lopez")).toEqual(["lopez"]);
+  });
+
+  it("is order-independent as a set — the basis for DNI matching", () => {
+    const reniec = nameTokens("Quintanilla Garcia Alex Alberto");
+    const bevy = nameTokens("Alex Alberto Quintanilla Garcia");
+    expect(new Set(reniec)).toEqual(new Set(bevy));
+  });
+});
+
+describe("buildSearchTokens", () => {
+  const attendee = {
+    firstName: "Alex Alberto",
+    lastName: "Quintanilla Garcia",
+    email: "WCandry@Gmail.com",
+    ticketNumber: "GOOGA263171317",
+  };
+
+  it("lets a volunteer find someone by name, email or ticket", () => {
+    const tokens = buildSearchTokens(attendee);
+    expect(tokens).toContain("quintanilla");
+    expect(tokens).toContain("alex");
+    expect(tokens).toContain("wcandry@gmail.com");
+    expect(tokens).toContain("wcandry"); // email local part alone
+    expect(tokens).toContain("googa263171317");
+  });
+
+  it("lowercases the email so search is case-insensitive", () => {
+    expect(buildSearchTokens(attendee)).not.toContain("WCandry@Gmail.com");
+  });
+
+  it("tolerates missing optional fields", () => {
+    const tokens = buildSearchTokens({
+      firstName: "Ana",
+      lastName: "",
+      email: "",
+      ticketNumber: "",
+    });
+    expect(tokens).toEqual(["ana"]);
+  });
+});
+
+describe("parseBevyDate", () => {
+  it("parses the exact format Bevy exports", () => {
+    const d = parseBevyDate("Jul 06, 2026 - 03:10 PM");
+    expect(d).toBeInstanceOf(Date);
+    expect(d?.toISOString()).toBe("2026-07-06T15:10:00.000Z");
+  });
+
+  it("interprets the time as UTC, per the column header", () => {
+    // Would drift by the server's offset if the UTC suffix were dropped.
+    expect(parseBevyDate("Jan 01, 2026 - 12:00 AM")?.toISOString()).toBe(
+      "2026-01-01T00:00:00.000Z"
+    );
+  });
+
+  it("returns null for an empty cell — the common case", () => {
+    expect(parseBevyDate("")).toBeNull();
+    expect(parseBevyDate("   ")).toBeNull();
+  });
+
+  it("returns null rather than an Invalid Date for garbage", () => {
+    // Critical: a truthy Invalid Date would read as "already checked in
+    // on Bevy" and make the sync skip this person entirely.
+    expect(parseBevyDate("not a date")).toBeNull();
+    expect(parseBevyDate("--")).toBeNull();
+  });
+});

--- a/functions/src/services/nameMatch.ts
+++ b/functions/src/services/nameMatch.ts
@@ -92,7 +92,15 @@ export function buildSearchTokens(a: {
   return [...tokens];
 }
 
-// Bevy's "Checkin Date (UTC)" cell, e.g. "Jul 06, 2026 - 03:10 PM".
+// The format the CSV export actually uses, confirmed against the sibling
+// "Paid date (UTC)" column of a real export: "2026-07-06 20:10:16+00:00".
+// Space or "T" separator, optional fractional seconds, optional offset.
+const ISO_DATE_RE =
+  /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})(?::(\d{2}))?(\.\d+)?\s*(z|[+-]\d{2}:?\d{2})?$/i;
+
+// The format the Bevy web dashboard DISPLAYS, e.g. "Jul 06, 2026 - 03:10 PM".
+// Accepted as a fallback because the two surfaces disagree and an organizer
+// may paste from either.
 const BEVY_DATE_RE =
   /^([a-z]{3})\s+(\d{1,2}),\s*(\d{4})\s*-\s*(\d{1,2}):(\d{2})\s*(am|pm)$/i;
 
@@ -112,18 +120,43 @@ const MONTHS: Record<string, number> = {
 };
 
 /**
- * Parses Bevy's check-in cell, returning null for anything that is not
- * exactly that format.
+ * Parses Bevy's "Checkin Date (UTC)" cell, returning null for anything that
+ * is not one of the two shapes Bevy actually produces.
  *
- * Deliberately strict rather than handing the string to `new Date()`. V8's
+ * Strict by design rather than handing the string to `new Date()`: V8's
  * legacy parser skips tokens it does not recognize, so "2026" and
- * "pending Jul 06, 2026" both yield valid Dates — and a non-null value here
- * means "already checked in on Bevy", which makes the sync skip a person who
- * never was. It also silently honours a trailing offset over the UTC the
- * column header promises. Rejecting the unexpected is the safer failure.
+ * "pending Jul 06, 2026" both yield valid Dates. A non-null value here means
+ * "already checked in on Bevy", which makes the sync skip that person — so
+ * guessing is the expensive failure and rejecting is the cheap one.
+ *
+ * Both formats are supported because the CSV export and the web dashboard
+ * disagree: the export writes "2026-07-06 20:10:16+00:00" (verified against
+ * a real export's "Paid date (UTC)" column) while the dashboard renders
+ * "Jul 06, 2026 - 03:10 PM". The check-in column is empty in an export where
+ * nobody checked in, so the format cannot be observed there directly —
+ * accepting both is what keeps this from silently parsing nothing.
  */
 export function parseBevyDate(raw: string): Date | null {
-  const m = BEVY_DATE_RE.exec(raw.trim());
+  const s = raw.trim();
+  if (!s) return null;
+
+  const iso = ISO_DATE_RE.exec(s);
+  if (iso) {
+    // Rebuild in canonical ISO 8601, which Date parses per spec rather than
+    // by V8-specific fallback. An absent offset means UTC, per the header.
+    const offset = iso[8]
+      ? iso[8].toLowerCase() === "z"
+        ? "Z"
+        : iso[8].replace(/^([+-]\d{2})(\d{2})$/, "$1:$2")
+      : "Z";
+    const d = new Date(
+      `${iso[1]}-${iso[2]}-${iso[3]}T${iso[4]}:${iso[5]}:${iso[6] ?? "00"}` +
+        `${iso[7] ?? ""}${offset}`
+    );
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+
+  const m = BEVY_DATE_RE.exec(s);
   if (!m) return null;
 
   const month = MONTHS[m[1].toLowerCase()];

--- a/functions/src/services/nameMatch.ts
+++ b/functions/src/services/nameMatch.ts
@@ -1,0 +1,81 @@
+// Name normalization shared by the check-in roster import (search tokens)
+// and, later, by the DNI lookup's candidate matching.
+
+// Dropped when tokenizing names: they carry no identifying signal and
+// their presence is inconsistent between RENIEC and self-typed Bevy names.
+const PARTICLES = new Set([
+  "de",
+  "del",
+  "la",
+  "las",
+  "los",
+  "y",
+  "da",
+  "dos",
+  "van",
+  "von",
+]);
+
+/**
+ * Lowercases, strips diacritics and punctuation, collapses whitespace.
+ *
+ * The diacritic strip is what makes "Ñañez" and "Nanez" comparable — a
+ * volunteer typing into the search box will not reach for ñ or í, and
+ * Bevy names are self-typed so they are inconsistently accented.
+ */
+export function normalizeName(input: string): string {
+  return input
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Normalized, de-particled, deduped tokens of a name. */
+export function nameTokens(input: string): string[] {
+  const seen = new Set<string>();
+  for (const t of normalizeName(input).split(" ")) {
+    if (t.length > 1 && !PARTICLES.has(t)) seen.add(t);
+  }
+  return [...seen];
+}
+
+/**
+ * Tokens the check-in panel filters on. Includes name parts, the email
+ * (both whole and local-part), and the ticket number, so a volunteer can
+ * type any of them into one search box.
+ */
+export function buildSearchTokens(a: {
+  firstName: string;
+  lastName: string;
+  email: string;
+  ticketNumber: string;
+}): string[] {
+  const tokens = new Set<string>(nameTokens(`${a.firstName} ${a.lastName}`));
+  const email = a.email.toLowerCase().trim();
+  if (email) {
+    tokens.add(email);
+    const local = email.split("@")[0];
+    if (local) tokens.add(local);
+  }
+  const ticket = a.ticketNumber.toLowerCase().trim();
+  if (ticket) tokens.add(ticket);
+  return [...tokens];
+}
+
+/**
+ * Parses Bevy's "Checkin Date (UTC)" cell, e.g.
+ * "Jul 06, 2026 - 03:10 PM". Returns null for an empty or unparseable
+ * cell — an unparseable date must not be mistaken for "already checked
+ * in on Bevy", since that would make the sync skip the person.
+ */
+export function parseBevyDate(raw: string): Date | null {
+  const s = raw.trim();
+  if (!s) return null;
+  // Drop the " - " between date and time, and pin to UTC as the header
+  // promises; without the suffix V8 would apply the server's local zone.
+  const d = new Date(`${s.replace(/\s+-\s+/, " ")} UTC`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}

--- a/functions/src/services/nameMatch.ts
+++ b/functions/src/services/nameMatch.ts
@@ -1,8 +1,18 @@
-// Name normalization shared by the check-in roster import (search tokens)
-// and, later, by the DNI lookup's candidate matching.
+// Search tokenization for the check-in roster, plus the Bevy date parser.
+//
+// The panel filters attendees by prefix-matching a volunteer's query against
+// the searchTokens this module builds at import time. Those two sides run in
+// different bundles (browser vs Cloud Function), so the normalization is
+// duplicated in src/components/react/admin/checkin/CheckinPanel.tsx. The
+// contract between them is pinned by
+// src/components/react/admin/checkin/__tests__/search.test.ts, which imports
+// BOTH implementations — a divergence fails silently otherwise, showing the
+// volunteer "no matches" for someone who is standing right in front of them.
 
-// Dropped when tokenizing names: they carry no identifying signal and
-// their presence is inconsistent between RENIEC and self-typed Bevy names.
+const DIACRITICS_RE = /[̀-ͯ]/g;
+
+// Dropped when tokenizing: they carry no identifying signal and appear
+// inconsistently between what someone types and how they registered.
 const PARTICLES = new Set([
   "de",
   "del",
@@ -17,35 +27,50 @@ const PARTICLES = new Set([
 ]);
 
 /**
- * Lowercases, strips diacritics and punctuation, collapses whitespace.
+ * Lowercases, strips diacritics, and turns punctuation into separators.
  *
- * The diacritic strip is what makes "Ñañez" and "Nanez" comparable — a
- * volunteer typing into the search box will not reach for ñ or í, and
- * Bevy names are self-typed so they are inconsistently accented.
+ * "@" and "." survive so an email address stays intact; every other
+ * character becomes a space. That is what makes "Ñañez" reachable by
+ * typing "nanez", and "Quintanilla-Garcia" reachable as two words.
  */
-export function normalizeName(input: string): string {
+export function normalizeSearchText(input: string): string {
   return input
     .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
+    .replace(DIACRITICS_RE, "")
     .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/[^a-z0-9\s@.]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
 }
 
-/** Normalized, de-particled, deduped tokens of a name. */
-export function nameTokens(input: string): string[] {
-  const seen = new Set<string>();
-  for (const t of normalizeName(input).split(" ")) {
-    if (t.length > 1 && !PARTICLES.has(t)) seen.add(t);
+/**
+ * The single tokenizer both sides use — on stored values when building the
+ * index, and on the query when filtering. Running the same function on both
+ * is what guarantees a match; hand-aligned character classes are what broke
+ * before (a hyphenated surname tokenized to two words but queried as one).
+ *
+ * A piece containing "@" keeps its dots, because it is an address. Any
+ * other piece splits on dots too, so a middle initial like "M." does not
+ * become a token that only matches when typed with its period.
+ */
+export function tokenize(input: string): string[] {
+  const out = new Set<string>();
+  for (const piece of normalizeSearchText(input).split(" ")) {
+    const parts = piece.includes("@") ? [piece] : piece.split(".");
+    for (const p of parts) {
+      if (p.length > 1 && !PARTICLES.has(p)) out.add(p);
+    }
   }
-  return [...seen];
+  return [...out];
 }
 
+/** Backwards-compatible alias — name tokens are just tokenize(). */
+export const nameTokens = tokenize;
+
 /**
- * Tokens the check-in panel filters on. Includes name parts, the email
- * (both whole and local-part), and the ticket number, so a volunteer can
- * type any of them into one search box.
+ * Tokens the panel filters on: name, email (whole address and local part
+ * separately, so both "luis.diaz" and the full address match), and ticket
+ * number. One search box covers all three.
  */
 export function buildSearchTokens(a: {
   firstName: string;
@@ -53,29 +78,71 @@ export function buildSearchTokens(a: {
   email: string;
   ticketNumber: string;
 }): string[] {
-  const tokens = new Set<string>(nameTokens(`${a.firstName} ${a.lastName}`));
+  const tokens = new Set<string>(tokenize(`${a.firstName} ${a.lastName}`));
+
   const email = a.email.toLowerCase().trim();
   if (email) {
-    tokens.add(email);
+    for (const t of tokenize(email)) tokens.add(t);
     const local = email.split("@")[0];
-    if (local) tokens.add(local);
+    if (local) for (const t of tokenize(local)) tokens.add(t);
   }
-  const ticket = a.ticketNumber.toLowerCase().trim();
-  if (ticket) tokens.add(ticket);
+
+  for (const t of tokenize(a.ticketNumber)) tokens.add(t);
+
   return [...tokens];
 }
 
+// Bevy's "Checkin Date (UTC)" cell, e.g. "Jul 06, 2026 - 03:10 PM".
+const BEVY_DATE_RE =
+  /^([a-z]{3})\s+(\d{1,2}),\s*(\d{4})\s*-\s*(\d{1,2}):(\d{2})\s*(am|pm)$/i;
+
+const MONTHS: Record<string, number> = {
+  jan: 0,
+  feb: 1,
+  mar: 2,
+  apr: 3,
+  may: 4,
+  jun: 5,
+  jul: 6,
+  aug: 7,
+  sep: 8,
+  oct: 9,
+  nov: 10,
+  dec: 11,
+};
+
 /**
- * Parses Bevy's "Checkin Date (UTC)" cell, e.g.
- * "Jul 06, 2026 - 03:10 PM". Returns null for an empty or unparseable
- * cell — an unparseable date must not be mistaken for "already checked
- * in on Bevy", since that would make the sync skip the person.
+ * Parses Bevy's check-in cell, returning null for anything that is not
+ * exactly that format.
+ *
+ * Deliberately strict rather than handing the string to `new Date()`. V8's
+ * legacy parser skips tokens it does not recognize, so "2026" and
+ * "pending Jul 06, 2026" both yield valid Dates — and a non-null value here
+ * means "already checked in on Bevy", which makes the sync skip a person who
+ * never was. It also silently honours a trailing offset over the UTC the
+ * column header promises. Rejecting the unexpected is the safer failure.
  */
 export function parseBevyDate(raw: string): Date | null {
-  const s = raw.trim();
-  if (!s) return null;
-  // Drop the " - " between date and time, and pin to UTC as the header
-  // promises; without the suffix V8 would apply the server's local zone.
-  const d = new Date(`${s.replace(/\s+-\s+/, " ")} UTC`);
-  return Number.isNaN(d.getTime()) ? null : d;
+  const m = BEVY_DATE_RE.exec(raw.trim());
+  if (!m) return null;
+
+  const month = MONTHS[m[1].toLowerCase()];
+  if (month === undefined) return null;
+
+  const day = Number(m[2]);
+  const year = Number(m[3]);
+  let hour = Number(m[4]);
+  const minute = Number(m[5]);
+
+  if (day < 1 || day > 31 || hour < 1 || hour > 12 || minute > 59) return null;
+
+  if (m[6].toLowerCase() === "pm") {
+    if (hour !== 12) hour += 12;
+  } else if (hour === 12) {
+    hour = 0;
+  }
+
+  const d = new Date(Date.UTC(year, month, day, hour, minute));
+  // Rejects impossible dates that Date.UTC would roll over (e.g. Feb 31).
+  return d.getUTCDate() === day && d.getUTCMonth() === month ? d : null;
 }

--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -17,6 +17,7 @@ import { LocationList } from "./locations/LocationList";
 import { MinigameTemplateList } from "./minigame-templates/MinigameTemplateList";
 import { EventMinigameManager } from "./event-minigames/EventMinigameManager";
 import { CertificateSender } from "./certificates/CertificateSender";
+import { CheckinPanel } from "./checkin/CheckinPanel";
 
 interface Props {
   page: string;
@@ -65,6 +66,8 @@ function renderPage(
       return <EventMinigameManager />;
     case "certificates":
       return <CertificateSender />;
+    case "checkin":
+      return <CheckinPanel />;
     default:
       return (
         <p className="text-gray-500 dark:text-gray-400">

--- a/src/components/react/admin/AdminShell.tsx
+++ b/src/components/react/admin/AdminShell.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "./AuthProvider";
 const NAV_ITEMS = [
   { label: "Dashboard", href: "/admin", icon: "📊" },
   { label: "Eventos", href: "/admin/events", icon: "📅" },
+  { label: "Check-in", href: "/admin/checkin", icon: "✅" },
   { label: "Equipo", href: "/admin/team", icon: "👥", adminOnly: true },
   { label: "Speakers", href: "/admin/speakers", icon: "🎤" },
   { label: "Ubicaciones", href: "/admin/locations", icon: "📍" },

--- a/src/components/react/admin/AuthProvider.tsx
+++ b/src/components/react/admin/AuthProvider.tsx
@@ -44,6 +44,9 @@ export function useAuth() {
 export function DevAuthProvider({ children }: { children: React.ReactNode }) {
   const mockValue: AuthContextType = {
     user: {
+      // uid is not decorative: any panel that attributes a write needs it,
+      // and passing undefined into a Firestore field throws at runtime.
+      uid: "dev-preview-uid",
       displayName: "Dev Preview",
       email: "dev@preview.local",
       photoURL: "",

--- a/src/components/react/admin/checkin/AttendeeRow.tsx
+++ b/src/components/react/admin/checkin/AttendeeRow.tsx
@@ -1,0 +1,74 @@
+import type { Attendee } from "./types";
+
+interface Props {
+  attendee: Attendee;
+  /** Attendees whose lastImportId is older than the newest import. */
+  stale: boolean;
+  onToggle: (a: Attendee) => void;
+}
+
+const time = (d: Date | null) =>
+  d
+    ? d.toLocaleTimeString("es-PE", { hour: "2-digit", minute: "2-digit" })
+    : "";
+
+export function AttendeeRow({ attendee, stale, onToggle }: Props) {
+  const { checkedIn, pending } = attendee;
+
+  return (
+    <li
+      className={`flex items-center gap-3 border-l-4 px-4 py-3 ${
+        pending
+          ? "border-l-amber-400"
+          : checkedIn
+            ? "border-l-green-500"
+            : "border-l-transparent"
+      } ${checkedIn ? "bg-green-50/60 dark:bg-green-900/10" : ""}`}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-medium text-gray-900 dark:text-white">
+          {attendee.firstName} {attendee.lastName}
+        </p>
+        <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+          {attendee.email}
+        </p>
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          {attendee.ticketTitle && (
+            <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              {attendee.ticketTitle}
+            </span>
+          )}
+          {stale && (
+            <span className="rounded bg-orange-100 px-1.5 py-0.5 text-xs text-orange-700 dark:bg-orange-900/30 dark:text-orange-300">
+              ya no está en el CSV
+            </span>
+          )}
+          {attendee.bevyCheckinAt && (
+            <span className="rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+              ya marcado en Bevy
+            </span>
+          )}
+          {checkedIn && attendee.checkedInAt && (
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              {time(attendee.checkedInAt)}
+              {attendee.checkedInByName ? ` · ${attendee.checkedInByName}` : ""}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <button
+        onClick={() => onToggle(attendee)}
+        aria-pressed={checkedIn}
+        // Large tap target: this is used one-handed on a phone at the door.
+        className={`min-w-[104px] shrink-0 rounded-lg px-4 py-3 text-sm font-semibold transition-colors ${
+          checkedIn
+            ? "bg-green-600 text-white hover:bg-green-700"
+            : "bg-blue-600 text-white hover:bg-blue-700"
+        }`}
+      >
+        {checkedIn ? "✓ Presente" : "Marcar"}
+      </button>
+    </li>
+  );
+}

--- a/src/components/react/admin/checkin/CheckinPanel.tsx
+++ b/src/components/react/admin/checkin/CheckinPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { isDevPreview } from "@/lib/api";
 import { useAuth } from "../AuthProvider";
 import { Toast } from "../ui/Toast";
 import { AttendeeRow } from "./AttendeeRow";
@@ -23,32 +24,12 @@ function slugFromUrl(): string | null {
   return raw && SLUG_RE.test(raw) ? raw : null;
 }
 
-/**
- * Mirrors normalizeName() in functions/src/services/nameMatch.ts, which
- * built the stored searchTokens — both sides must treat characters the
- * same way or the search silently misses people.
- *
- * That server-side function turns every non-alphanumeric character into a
- * separator, so "Quintanilla-Garcia" is stored as two tokens. Keeping the
- * hyphen here would produce the single term "quintanilla-garcia", which
- * prefix-matches neither of them — the attendee becomes unfindable by
- * typing their surname exactly as registered.
- *
- * "@" and "." are the deliberate exceptions: buildSearchTokens stores the
- * email verbatim alongside the name tokens, so they must survive for a
- * full-address search to work.
- */
-export function normalizeQuery(q: string): string {
-  return q
-    .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9\s@.]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-// Mirrors the PARTICLES set in functions/src/services/nameMatch.ts.
+// Byte-for-byte mirror of tokenize() in functions/src/services/nameMatch.ts,
+// which built the stored searchTokens. It cannot be imported: that module
+// ships in the Cloud Function bundle, not the browser one. The two are held
+// in sync by __tests__/search.test.ts, which imports BOTH and asserts they
+// agree — without that, a divergence fails silently, telling the volunteer
+// "no matches" for someone standing in front of them.
 const PARTICLES = new Set([
   "de",
   "del",
@@ -62,18 +43,34 @@ const PARTICLES = new Set([
   "von",
 ]);
 
+export function normalizeQuery(q: string): string {
+  return q
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s@.]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 /**
- * Splits a query into the terms actually matched against searchTokens.
+ * Splits a query into the terms matched against searchTokens.
  *
- * nameTokens() drops single characters and connective particles when it
- * builds the stored tokens, so the query has to drop them too. Otherwise
- * every term must match and these never can: typing "Juan de la Cruz" in
- * full would find nobody, because no stored token starts with "de".
+ * Runs the identical algorithm the server ran over the stored values, which
+ * is the only thing that makes matching reliable. Hand-aligning the two by
+ * eye is what failed before: "Quintanilla-Garcia" was indexed as two tokens
+ * but queried as one, and emails containing "+" or "_" were indexed verbatim
+ * but split by the query.
  */
 export function queryTerms(q: string): string[] {
-  return normalizeQuery(q)
-    .split(" ")
-    .filter((t) => t.length > 1 && !PARTICLES.has(t));
+  const out = new Set<string>();
+  for (const piece of normalizeQuery(q).split(" ")) {
+    const parts = piece.includes("@") ? [piece] : piece.split(".");
+    for (const p of parts) {
+      if (p.length > 1 && !PARTICLES.has(p)) out.add(p);
+    }
+  }
+  return [...out];
 }
 
 export function CheckinPanel({ initialSlug }: Props) {
@@ -88,12 +85,30 @@ export function CheckinPanel({ initialSlug }: Props) {
   } | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
-  const { attendees, meta, loading, error, fromCache, pendingCount } =
-    useRoster(slug);
+  const {
+    attendees,
+    meta,
+    loading,
+    error,
+    offline,
+    syncedOnce,
+    metaError,
+    pendingCount,
+    // Hooks cannot be skipped, so the subscription is disabled by passing a
+    // null slug — the early return for preview mode below happens after
+    // this call and would not prevent the listener on its own.
+  } = useRoster(isDevPreview ? null : slug);
 
+  const hasRoster = attendees.length > 0;
+
+  // Keyed on whether the input is actually mounted, not just on `loading`.
+  // The input only exists once the roster has rows, so depending on
+  // `loading` alone left it unfocused whenever the roster arrived after the
+  // first snapshot — an import finishing, or the server replacing an empty
+  // cached snapshot.
   useEffect(() => {
     searchRef.current?.focus();
-  }, [loading]);
+  }, [loading, hasRoster]);
 
   const present = useMemo(
     () => attendees.filter((a) => a.checkedIn).length,
@@ -124,6 +139,31 @@ export function CheckinPanel({ initialSlug }: Props) {
     );
   }
 
+  // Every other admin panel reads through `api`, which isDevPreview swaps
+  // for mockApi. This one talks to Firestore directly, so preview mode
+  // would otherwise open a listener against the live appgdgica project
+  // with no real credentials — a permission-denied panel that looks broken.
+  if (isDevPreview) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-8 dark:border-gray-700 dark:bg-gray-800">
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+          Check-in
+        </h1>
+        <p className="mt-2 text-gray-600 dark:text-gray-400">
+          Este panel lee Firestore en vivo, así que no funciona con datos de
+          ejemplo.
+        </p>
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-500">
+          Para probarlo, levanta los emuladores y arranca con{" "}
+          <code className="rounded bg-gray-100 px-1 dark:bg-gray-700">
+            PUBLIC_USE_FIREBASE_EMULATOR=true
+          </code>
+          .
+        </p>
+      </div>
+    );
+  }
+
   if (!slug) {
     return (
       <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
@@ -151,13 +191,24 @@ export function CheckinPanel({ initialSlug }: Props) {
       <SyncStatusBar
         present={present}
         total={attendees.length}
-        fromCache={fromCache}
+        offline={offline}
         pendingCount={pendingCount}
       />
 
       {error && (
         <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
-          {error}
+          <p className="font-medium">{error}</p>
+          <p className="mt-1">
+            La lista dejó de actualizarse. Recarga la página para reconectar.
+          </p>
+        </div>
+      )}
+
+      {metaError && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+          No se pudo leer la información de la última importación, así que no
+          se marcará a quienes ya no figuran en el CSV. El check-in funciona
+          normal.
         </div>
       )}
 
@@ -182,17 +233,36 @@ export function CheckinPanel({ initialSlug }: Props) {
         />
       )}
 
-      {attendees.length === 0 ? (
+      {!hasRoster ? (
         <div className="rounded-xl border border-gray-200 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
-          <p className="text-gray-600 dark:text-gray-400">
-            Todavía no hay nadie en el roster de este evento.
-          </p>
-          <button
-            onClick={() => setShowImporter(true)}
-            className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-          >
-            Importar el CSV de Bevy
-          </button>
+          {syncedOnce ? (
+            // Only claim the roster is empty once the SERVER has said so.
+            // Asserting it from a cold cache told a volunteer at the door
+            // that a fully populated event had nobody in it, and offered
+            // them a re-import as the fix.
+            <>
+              <p className="text-gray-600 dark:text-gray-400">
+                Todavía no hay nadie en el roster de este evento.
+              </p>
+              <button
+                onClick={() => setShowImporter(true)}
+                className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                Importar el CSV de Bevy
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+              <p className="mt-4 text-gray-600 dark:text-gray-400">
+                Conectando con el servidor…
+              </p>
+              <p className="mt-1 text-sm text-gray-400 dark:text-gray-500">
+                Sin datos en caché todavía. Si no hay señal, espera a
+                reconectar antes de importar nada.
+              </p>
+            </>
+          )}
         </div>
       ) : (
         <>
@@ -223,7 +293,14 @@ export function CheckinPanel({ initialSlug }: Props) {
           <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             {filtered.length === 0 ? (
               <p className="p-8 text-center text-gray-500 dark:text-gray-400">
-                Nadie coincide con “{query}”.
+                {/* The filter is not always the query — with the checkbox on
+                    and an empty box, the old message rendered a bare pair of
+                    quotes at the exact moment everyone had been marked. */}
+                {query.trim()
+                  ? `Nadie coincide con “${query}”.`
+                  : present === attendees.length
+                    ? "Ya marcaste a todos los registrados. 🎉"
+                    : "Nadie coincide con el filtro activo."}
               </p>
             ) : (
               <ul className="divide-y divide-gray-100 dark:divide-gray-700">

--- a/src/components/react/admin/checkin/CheckinPanel.tsx
+++ b/src/components/react/admin/checkin/CheckinPanel.tsx
@@ -123,7 +123,9 @@ export function CheckinPanel({ initialSlug }: Props) {
       if (terms.length === 0) return true;
       // Every term must prefix-match some token, so "qui gar" finds
       // "Quintanilla Garcia" without needing the full spelling.
-      return terms.every((t) => a.searchTokens.some((tok) => tok.startsWith(t)));
+      return terms.every((t) =>
+        a.searchTokens.some((tok) => tok.startsWith(t))
+      );
     });
   }, [attendees, query, onlyPending]);
 
@@ -150,7 +152,11 @@ export function CheckinPanel({ initialSlug }: Props) {
     link.href = url;
     link.download = bevyCsvFilename(slug, new Date());
     link.click();
-    URL.revokeObjectURL(url);
+    // Revoked on a later tick, not on the next line. Chromium starts the
+    // download synchronously inside click(), but Firefox and Safari read
+    // the blob afterwards — revoking immediately cancels the download
+    // there, and the success toast below would still claim it worked.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
 
     setToast({
       message:
@@ -242,8 +248,8 @@ export function CheckinPanel({ initialSlug }: Props) {
 
       {metaError && (
         <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
-          No se pudo leer la información de la última importación, así que no
-          se marcará a quienes ya no figuran en el CSV. El check-in funciona
+          No se pudo leer la información de la última importación, así que no se
+          marcará a quienes ya no figuran en el CSV. El check-in funciona
           normal.
         </div>
       )}
@@ -274,7 +280,10 @@ export function CheckinPanel({ initialSlug }: Props) {
         <RosterImporter
           slug={slug}
           onImported={(summary) =>
-            setToast({ message: `Roster importado: ${summary}`, type: "success" })
+            setToast({
+              message: `Roster importado: ${summary}`,
+              type: "success",
+            })
           }
         />
       )}
@@ -309,8 +318,8 @@ export function CheckinPanel({ initialSlug }: Props) {
                 Conectando con el servidor…
               </p>
               <p className="mt-1 text-sm text-gray-400 dark:text-gray-500">
-                Sin datos en caché todavía. Si no hay señal, espera a
-                reconectar antes de importar nada.
+                Sin datos en caché todavía. Si no hay señal, espera a reconectar
+                antes de importar nada.
               </p>
             </>
           )}
@@ -360,7 +369,8 @@ export function CheckinPanel({ initialSlug }: Props) {
                     key={a.id}
                     attendee={a}
                     stale={
-                      !!meta?.lastImportId && a.lastImportId !== meta.lastImportId
+                      !!meta?.lastImportId &&
+                      a.lastImportId !== meta.lastImportId
                     }
                     onToggle={handleToggle}
                   />

--- a/src/components/react/admin/checkin/CheckinPanel.tsx
+++ b/src/components/react/admin/checkin/CheckinPanel.tsx
@@ -3,6 +3,7 @@ import { isDevPreview } from "@/lib/api";
 import { useAuth } from "../AuthProvider";
 import { Toast } from "../ui/Toast";
 import { AttendeeRow } from "./AttendeeRow";
+import { bevyCsvFilename, buildBevyCheckinCsv } from "./buildBevyCsv";
 import { RosterImporter } from "./RosterImporter";
 import { SyncStatusBar } from "./SyncStatusBar";
 import { setCheckedIn, useRoster } from "./useRoster";
@@ -126,6 +127,41 @@ export function CheckinPanel({ initialSlug }: Props) {
     });
   }, [attendees, query, onlyPending]);
 
+  function handleExportBevyCsv() {
+    if (!slug) return;
+    const { csv, rows, alreadyInBevy } = buildBevyCheckinCsv(attendees);
+    if (rows === 0) {
+      setToast({
+        message:
+          alreadyInBevy > 0
+            ? "Bevy ya tiene marcados a todos los presentes."
+            : "Todavía no has marcado a nadie.",
+        type: "success",
+      });
+      return;
+    }
+
+    // Blob + object URL rather than a data: URI — a few hundred rows of
+    // names exceeds what some browsers accept in a URL.
+    const url = URL.createObjectURL(
+      new Blob([csv], { type: "text/csv;charset=utf-8" })
+    );
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = bevyCsvFilename(slug, new Date());
+    link.click();
+    URL.revokeObjectURL(url);
+
+    setToast({
+      message:
+        `CSV con ${rows} check-in(s) para subir a Bevy` +
+        (alreadyInBevy > 0
+          ? `. Se omitieron ${alreadyInBevy} que Bevy ya tenía.`
+          : "."),
+      type: "success",
+    });
+  }
+
   function handleToggle(a: Attendee) {
     if (!slug || !user) return;
     // Fire-and-forget on purpose — see setCheckedIn's comment. Awaiting
@@ -216,12 +252,22 @@ export function CheckinPanel({ initialSlug }: Props) {
         <h1 className="text-xl font-bold text-gray-900 dark:text-white">
           Check-in · {slug}
         </h1>
-        <button
-          onClick={() => setShowImporter((v) => !v)}
-          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
-        >
-          {showImporter ? "Ocultar importador" : "Importar CSV"}
-        </button>
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={handleExportBevyCsv}
+            disabled={present === 0}
+            title="Descarga un CSV listo para el Bulk upload de Bevy"
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            Exportar para Bevy
+          </button>
+          <button
+            onClick={() => setShowImporter((v) => !v)}
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            {showImporter ? "Ocultar importador" : "Importar CSV"}
+          </button>
+        </div>
       </div>
 
       {showImporter && (

--- a/src/components/react/admin/checkin/CheckinPanel.tsx
+++ b/src/components/react/admin/checkin/CheckinPanel.tsx
@@ -12,22 +12,68 @@ interface Props {
   initialSlug?: string;
 }
 
+/** Firestore paths are built from this, and a slug with a "/" would
+ *  silently address the wrong collection depth. The API validates it
+ *  server-side too (validateParamId), but the listener runs first. */
+const SLUG_RE = /^[a-zA-Z0-9_-]{1,100}$/;
+
 function slugFromUrl(): string | null {
   if (typeof window === "undefined") return null;
-  return new URLSearchParams(window.location.search).get("slug");
+  const raw = new URLSearchParams(window.location.search).get("slug");
+  return raw && SLUG_RE.test(raw) ? raw : null;
 }
 
-/** Mirrors normalizeName() in functions/src/services/nameMatch.ts, which
- *  built the stored searchTokens — both sides must strip diacritics the
- *  same way or typing "nanez" would not find "Ñañez". */
-function normalizeQuery(q: string): string {
+/**
+ * Mirrors normalizeName() in functions/src/services/nameMatch.ts, which
+ * built the stored searchTokens — both sides must treat characters the
+ * same way or the search silently misses people.
+ *
+ * That server-side function turns every non-alphanumeric character into a
+ * separator, so "Quintanilla-Garcia" is stored as two tokens. Keeping the
+ * hyphen here would produce the single term "quintanilla-garcia", which
+ * prefix-matches neither of them — the attendee becomes unfindable by
+ * typing their surname exactly as registered.
+ *
+ * "@" and "." are the deliberate exceptions: buildSearchTokens stores the
+ * email verbatim alongside the name tokens, so they must survive for a
+ * full-address search to work.
+ */
+export function normalizeQuery(q: string): string {
   return q
     .normalize("NFD")
     .replace(/[̀-ͯ]/g, "")
     .toLowerCase()
-    .replace(/[^a-z0-9\s@._-]/g, " ")
+    .replace(/[^a-z0-9\s@.]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+// Mirrors the PARTICLES set in functions/src/services/nameMatch.ts.
+const PARTICLES = new Set([
+  "de",
+  "del",
+  "la",
+  "las",
+  "los",
+  "y",
+  "da",
+  "dos",
+  "van",
+  "von",
+]);
+
+/**
+ * Splits a query into the terms actually matched against searchTokens.
+ *
+ * nameTokens() drops single characters and connective particles when it
+ * builds the stored tokens, so the query has to drop them too. Otherwise
+ * every term must match and these never can: typing "Juan de la Cruz" in
+ * full would find nobody, because no stored token starts with "de".
+ */
+export function queryTerms(q: string): string[] {
+  return normalizeQuery(q)
+    .split(" ")
+    .filter((t) => t.length > 1 && !PARTICLES.has(t));
 }
 
 export function CheckinPanel({ initialSlug }: Props) {
@@ -55,7 +101,7 @@ export function CheckinPanel({ initialSlug }: Props) {
   );
 
   const filtered = useMemo(() => {
-    const terms = normalizeQuery(query).split(" ").filter(Boolean);
+    const terms = queryTerms(query);
     return attendees.filter((a) => {
       if (onlyPending && a.checkedIn) return false;
       if (terms.length === 0) return true;

--- a/src/components/react/admin/checkin/CheckinPanel.tsx
+++ b/src/components/react/admin/checkin/CheckinPanel.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useAuth } from "../AuthProvider";
+import { Toast } from "../ui/Toast";
+import { AttendeeRow } from "./AttendeeRow";
+import { RosterImporter } from "./RosterImporter";
+import { SyncStatusBar } from "./SyncStatusBar";
+import { setCheckedIn, useRoster } from "./useRoster";
+import type { Attendee } from "./types";
+
+interface Props {
+  // Injection point so tests need not touch window.location.
+  initialSlug?: string;
+}
+
+function slugFromUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search).get("slug");
+}
+
+/** Mirrors normalizeName() in functions/src/services/nameMatch.ts, which
+ *  built the stored searchTokens — both sides must strip diacritics the
+ *  same way or typing "nanez" would not find "Ñañez". */
+function normalizeQuery(q: string): string {
+  return q
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s@._-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function CheckinPanel({ initialSlug }: Props) {
+  const { user } = useAuth();
+  const [slug] = useState<string | null>(initialSlug ?? slugFromUrl());
+  const [query, setQuery] = useState("");
+  const [showImporter, setShowImporter] = useState(false);
+  const [onlyPending, setOnlyPending] = useState(false);
+  const [toast, setToast] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const { attendees, meta, loading, error, fromCache, pendingCount } =
+    useRoster(slug);
+
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, [loading]);
+
+  const present = useMemo(
+    () => attendees.filter((a) => a.checkedIn).length,
+    [attendees]
+  );
+
+  const filtered = useMemo(() => {
+    const terms = normalizeQuery(query).split(" ").filter(Boolean);
+    return attendees.filter((a) => {
+      if (onlyPending && a.checkedIn) return false;
+      if (terms.length === 0) return true;
+      // Every term must prefix-match some token, so "qui gar" finds
+      // "Quintanilla Garcia" without needing the full spelling.
+      return terms.every((t) => a.searchTokens.some((tok) => tok.startsWith(t)));
+    });
+  }, [attendees, query, onlyPending]);
+
+  function handleToggle(a: Attendee) {
+    if (!slug || !user) return;
+    // Fire-and-forget on purpose — see setCheckedIn's comment. Awaiting
+    // would hang the button for as long as the venue wifi is down.
+    void setCheckedIn(
+      slug,
+      a.id,
+      !a.checkedIn,
+      { uid: user.uid, name: user.displayName || user.email || user.uid },
+      (message) => setToast({ message, type: "error" })
+    );
+  }
+
+  if (!slug) {
+    return (
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+        <p className="font-medium">Falta indicar el evento.</p>
+        <p className="mt-1 text-sm">
+          Abre esta página como{" "}
+          <code className="rounded bg-amber-100 px-1 dark:bg-amber-900/40">
+            /admin/checkin?slug=devfest-ica-2026
+          </code>
+        </p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <SyncStatusBar
+        present={present}
+        total={attendees.length}
+        fromCache={fromCache}
+        pendingCount={pendingCount}
+      />
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+          Check-in · {slug}
+        </h1>
+        <button
+          onClick={() => setShowImporter((v) => !v)}
+          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+        >
+          {showImporter ? "Ocultar importador" : "Importar CSV"}
+        </button>
+      </div>
+
+      {showImporter && (
+        <RosterImporter
+          slug={slug}
+          onImported={(summary) =>
+            setToast({ message: `Roster importado: ${summary}`, type: "success" })
+          }
+        />
+      )}
+
+      {attendees.length === 0 ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
+          <p className="text-gray-600 dark:text-gray-400">
+            Todavía no hay nadie en el roster de este evento.
+          </p>
+          <button
+            onClick={() => setShowImporter(true)}
+            className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            Importar el CSV de Bevy
+          </button>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-2">
+            <input
+              ref={searchRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Nombre, correo o número de ticket…"
+              // Phones at the door: no autocorrect fighting surnames.
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+              className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+            />
+            <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+              <input
+                type="checkbox"
+                checked={onlyPending}
+                onChange={(e) => setOnlyPending(e.target.checked)}
+                className="rounded border-gray-300"
+              />
+              Ocultar a los que ya marqué
+            </label>
+          </div>
+
+          <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+            {filtered.length === 0 ? (
+              <p className="p-8 text-center text-gray-500 dark:text-gray-400">
+                Nadie coincide con “{query}”.
+              </p>
+            ) : (
+              <ul className="divide-y divide-gray-100 dark:divide-gray-700">
+                {filtered.map((a) => (
+                  <AttendeeRow
+                    key={a.id}
+                    attendee={a}
+                    stale={
+                      !!meta?.lastImportId && a.lastImportId !== meta.lastImportId
+                    }
+                    onToggle={handleToggle}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <p className="text-center text-xs text-gray-400 dark:text-gray-500">
+            Mostrando {filtered.length} de {attendees.length}
+          </p>
+        </>
+      )}
+
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onClose={() => setToast(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/react/admin/checkin/CheckinPanel.tsx
+++ b/src/components/react/admin/checkin/CheckinPanel.tsx
@@ -233,8 +233,13 @@ export function CheckinPanel({ initialSlug }: Props) {
         />
       )}
 
-      {!hasRoster ? (
+      {error ? null : !hasRoster ? (
         <div className="rounded-xl border border-gray-200 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
+          {/* Suppressed while `error` is set: the listener error handler
+              clears the roster, and without this guard a mid-event
+              permission-denied would render "nobody is registered" plus a
+              prominent Import button right below the error banner —
+              inviting exactly the re-import this panel must never provoke. */}
           {syncedOnce ? (
             // Only claim the roster is empty once the SERVER has said so.
             // Asserting it from a cold cache told a volunteer at the door

--- a/src/components/react/admin/checkin/RosterImporter.tsx
+++ b/src/components/react/admin/checkin/RosterImporter.tsx
@@ -7,6 +7,11 @@ interface Props {
   onImported: (summary: string) => void;
 }
 
+// Must match checkinImportSchema in functions/src/schemas/index.ts. Past
+// this, the endpoint answers with an opaque Zod error, so catch it here
+// where we can say something the organizer can act on.
+const MAX_ROWS = 2000;
+
 /**
  * Uploads the Bevy registrations CSV. Parsing happens here in the
  * browser; the handler only ever receives validated rows.
@@ -28,6 +33,14 @@ export function RosterImporter({ slug, onImported }: Props) {
     const text = await file.text();
     const result = parseBevyCsv(text);
     setWarnings(result.warnings);
+    if (result.rows.length > MAX_ROWS) {
+      setRows(null);
+      setError(
+        `El CSV trae ${result.rows.length} registrados y el máximo por ` +
+          `importación es ${MAX_ROWS}.`
+      );
+      return;
+    }
     setRows(result.rows.length > 0 ? result.rows : null);
   }
 

--- a/src/components/react/admin/checkin/RosterImporter.tsx
+++ b/src/components/react/admin/checkin/RosterImporter.tsx
@@ -1,0 +1,101 @@
+import { useRef, useState } from "react";
+import { api } from "@/lib/api";
+import { parseBevyCsv, type BevyRegistration } from "./parseBevyCsv";
+
+interface Props {
+  slug: string;
+  onImported: (summary: string) => void;
+}
+
+/**
+ * Uploads the Bevy registrations CSV. Parsing happens here in the
+ * browser; the handler only ever receives validated rows.
+ *
+ * Re-importing is the normal case — people register right up to the
+ * doors opening — and it never clobbers check-ins already recorded.
+ */
+export function RosterImporter({ slug, onImported }: Props) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [rows, setRows] = useState<BevyRegistration[] | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
+
+  async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError(null);
+    const text = await file.text();
+    const result = parseBevyCsv(text);
+    setWarnings(result.warnings);
+    setRows(result.rows.length > 0 ? result.rows : null);
+  }
+
+  async function handleImport() {
+    if (!rows) return;
+    setImporting(true);
+    setError(null);
+    const res = await api.importCheckinRoster(slug, rows);
+    setImporting(false);
+    if (res.success && res.data) {
+      const { created, updated, stale } = res.data;
+      onImported(
+        `${created} nuevos, ${updated} actualizados` +
+          (stale > 0 ? `, ${stale} ya no figuran en el CSV` : "")
+      );
+      setRows(null);
+      if (fileRef.current) fileRef.current.value = "";
+    } else {
+      setError(res.error || "No se pudo importar el roster.");
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+        Importar registrados de Bevy
+      </h2>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        En Bevy: evento → Registrations → Download. Puedes reimportar todas
+        las veces que quieras; los check-ins ya marcados se conservan.
+      </p>
+
+      <input
+        ref={fileRef}
+        type="file"
+        accept=".csv,text/csv"
+        onChange={handleFile}
+        className="mt-4 block w-full text-sm text-gray-600 file:mr-4 file:rounded-lg file:border-0 file:bg-blue-600 file:px-4 file:py-2 file:text-sm file:font-medium file:text-white hover:file:bg-blue-700 dark:text-gray-400"
+      />
+
+      {warnings.length > 0 && (
+        <ul className="mt-4 space-y-1 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+          {warnings.map((w) => (
+            <li key={w}>⚠ {w}</li>
+          ))}
+        </ul>
+      )}
+
+      {error && (
+        <div className="mt-4 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {rows && (
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <span className="text-sm text-gray-700 dark:text-gray-300">
+            {rows.length} registrados listos para importar.
+          </span>
+          <button
+            onClick={handleImport}
+            disabled={importing}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {importing ? "Importando…" : "Importar"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/react/admin/checkin/RosterImporter.tsx
+++ b/src/components/react/admin/checkin/RosterImporter.tsx
@@ -48,18 +48,34 @@ export function RosterImporter({ slug, onImported }: Props) {
     if (!rows) return;
     setImporting(true);
     setError(null);
-    const res = await api.importCheckinRoster(slug, rows);
-    setImporting(false);
-    if (res.success && res.data) {
-      const { created, updated, stale } = res.data;
-      onImported(
-        `${created} nuevos, ${updated} actualizados` +
-          (stale > 0 ? `, ${stale} ya no figuran en el CSV` : "")
+    // try/finally, because api.importCheckinRoster can REJECT rather than
+    // resolve {success:false}: request() awaits getIdToken() outside its own
+    // try, and that refreshes over the network once the cached token is an
+    // hour old. Without this, an organizer who has had the panel open all
+    // morning taps Importar on flaky wifi and the button stays disabled
+    // reading "Importando…" until they reload the page.
+    try {
+      const res = await api.importCheckinRoster(slug, rows);
+      if (res.success && res.data) {
+        const { created, updated, stale, unusableTickets } = res.data;
+        onImported(
+          `${created} nuevos, ${updated} actualizados` +
+            (stale > 0 ? `, ${stale} ya no figuran en el CSV` : "") +
+            (unusableTickets > 0
+              ? `, ${unusableTickets} sin ticket utilizable`
+              : "")
+        );
+        setRows(null);
+        if (fileRef.current) fileRef.current.value = "";
+      } else {
+        setError(res.error || "No se pudo importar el roster.");
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "No se pudo importar el roster."
       );
-      setRows(null);
-      if (fileRef.current) fileRef.current.value = "";
-    } else {
-      setError(res.error || "No se pudo importar el roster.");
+    } finally {
+      setImporting(false);
     }
   }
 

--- a/src/components/react/admin/checkin/SyncStatusBar.tsx
+++ b/src/components/react/admin/checkin/SyncStatusBar.tsx
@@ -1,0 +1,48 @@
+interface Props {
+  present: number;
+  total: number;
+  fromCache: boolean;
+  pendingCount: number;
+}
+
+/**
+ * Always-visible header at the door. The connection state matters more
+ * here than anywhere else in the admin panel: a volunteer needs to know
+ * their taps are safe even when the venue wifi drops.
+ */
+export function SyncStatusBar({
+  present,
+  total,
+  fromCache,
+  pendingCount,
+}: Props) {
+  let tone: string;
+  let label: string;
+
+  if (fromCache && pendingCount > 0) {
+    tone =
+      "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-300";
+    label = `Sin conexión — ${pendingCount} cambio${
+      pendingCount === 1 ? "" : "s"
+    } en cola. Se guardarán solos.`;
+  } else if (fromCache) {
+    tone =
+      "border-gray-300 bg-gray-50 text-gray-600 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400";
+    label = "Sin conexión — mostrando datos en caché.";
+  } else {
+    tone =
+      "border-green-300 bg-green-50 text-green-800 dark:border-green-700 dark:bg-green-900/20 dark:text-green-300";
+    label = "Sincronizado";
+  }
+
+  return (
+    <div
+      className={`sticky top-0 z-10 flex flex-wrap items-center justify-between gap-2 rounded-lg border px-4 py-2 text-sm ${tone}`}
+    >
+      <span>{label}</span>
+      <span className="font-semibold tabular-nums">
+        {present}/{total} presentes
+      </span>
+    </div>
+  );
+}

--- a/src/components/react/admin/checkin/SyncStatusBar.tsx
+++ b/src/components/react/admin/checkin/SyncStatusBar.tsx
@@ -1,7 +1,8 @@
 interface Props {
   present: number;
   total: number;
-  fromCache: boolean;
+  /** True only when actually disconnected — see useRoster's State.offline. */
+  offline: boolean;
   pendingCount: number;
 }
 
@@ -10,22 +11,17 @@ interface Props {
  * here than anywhere else in the admin panel: a volunteer needs to know
  * their taps are safe even when the venue wifi drops.
  */
-export function SyncStatusBar({
-  present,
-  total,
-  fromCache,
-  pendingCount,
-}: Props) {
+export function SyncStatusBar({ present, total, offline, pendingCount }: Props) {
   let tone: string;
   let label: string;
 
-  if (fromCache && pendingCount > 0) {
+  if (offline && pendingCount > 0) {
     tone =
       "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-300";
     label = `Sin conexión — ${pendingCount} cambio${
       pendingCount === 1 ? "" : "s"
     } en cola. Se guardarán solos.`;
-  } else if (fromCache) {
+  } else if (offline) {
     tone =
       "border-gray-300 bg-gray-50 text-gray-600 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400";
     label = "Sin conexión — mostrando datos en caché.";

--- a/src/components/react/admin/checkin/__tests__/AttendeeRow.test.tsx
+++ b/src/components/react/admin/checkin/__tests__/AttendeeRow.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AttendeeRow } from "../AttendeeRow";
+import type { Attendee } from "../types";
+
+afterEach(() => cleanup());
+
+const attendee = (over: Partial<Attendee> = {}): Attendee => ({
+  id: "t_GOOGA263171317",
+  ticketNumber: "GOOGA263171317",
+  orderNumber: "ORD-1",
+  firstName: "Alex Alberto",
+  lastName: "Quintanilla Garcia",
+  email: "wcandry@gmail.com",
+  company: "",
+  title: "",
+  ticketTitle: "General Admission",
+  searchTokens: ["alex", "quintanilla"],
+  bevyCheckinAt: null,
+  lastImportId: "imp_1",
+  checkedIn: false,
+  checkedInAt: null,
+  checkedInBy: null,
+  checkedInByName: null,
+  note: null,
+  dniVerified: false,
+  pending: false,
+  ...over,
+});
+
+describe("AttendeeRow", () => {
+  it("shows who the row is for", () => {
+    render(
+      <AttendeeRow attendee={attendee()} stale={false} onToggle={vi.fn()} />
+    );
+    expect(screen.getByText("Alex Alberto Quintanilla Garcia")).toBeVisible();
+    expect(screen.getByText("wcandry@gmail.com")).toBeVisible();
+  });
+
+  it("offers to mark someone who is not checked in", async () => {
+    const onToggle = vi.fn();
+    render(<AttendeeRow attendee={attendee()} stale={false} onToggle={onToggle} />);
+    const button = screen.getByRole("button", { name: "Marcar" });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    await userEvent.click(button);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("reflects an already-present attendee and allows undoing it", async () => {
+    const onToggle = vi.fn();
+    render(
+      <AttendeeRow
+        attendee={attendee({ checkedIn: true })}
+        stale={false}
+        onToggle={onToggle}
+      />
+    );
+    const button = screen.getByRole("button", { name: "✓ Presente" });
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    await userEvent.click(button);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  // The attribution the Firestore rules go out of their way to require is
+  // useless if the UI never shows it. This regressed once already, when a
+  // pending serverTimestamp read back as null and hid the whole line.
+  it("shows the time and who marked them", () => {
+    render(
+      <AttendeeRow
+        attendee={attendee({
+          checkedIn: true,
+          checkedInAt: new Date("2026-07-18T14:22:10Z"),
+          checkedInByName: "Alvaro",
+        })}
+        stale={false}
+        onToggle={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Alvaro/)).toBeVisible();
+  });
+
+  it("flags someone who dropped out of the latest CSV", () => {
+    render(
+      <AttendeeRow attendee={attendee()} stale={true} onToggle={vi.fn()} />
+    );
+    expect(screen.getByText("ya no está en el CSV")).toBeVisible();
+  });
+
+  it("flags someone Bevy already has checked in", () => {
+    render(
+      <AttendeeRow
+        attendee={attendee({ bevyCheckinAt: new Date("2026-07-18T09:15:00Z") })}
+        stale={false}
+        onToggle={vi.fn()}
+      />
+    );
+    expect(screen.getByText("ya marcado en Bevy")).toBeVisible();
+  });
+
+  it("does not flag a normal attendee", () => {
+    render(
+      <AttendeeRow attendee={attendee()} stale={false} onToggle={vi.fn()} />
+    );
+    expect(screen.queryByText("ya no está en el CSV")).not.toBeInTheDocument();
+    expect(screen.queryByText("ya marcado en Bevy")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/react/admin/checkin/__tests__/CheckinPanel.test.tsx
+++ b/src/components/react/admin/checkin/__tests__/CheckinPanel.test.tsx
@@ -174,6 +174,55 @@ describe("CheckinPanel — marking someone present", () => {
   });
 });
 
+describe("CheckinPanel — exporting for Bevy", () => {
+  it("is disabled until somebody has been marked present", () => {
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    expect(
+      screen.getByRole("button", { name: "Exportar para Bevy" })
+    ).toBeDisabled();
+  });
+
+  it("downloads a file named for the event once there are check-ins", async () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    mocks.useRoster.mockReturnValue(
+      rosterState({ attendees: [attendee({ checkedIn: true })] })
+    );
+
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Exportar para Bevy" })
+    );
+
+    expect(click).toHaveBeenCalledTimes(1);
+    const anchor = click.mock.instances[0] as HTMLAnchorElement;
+    expect(anchor.download).toMatch(/^bevy-checkin-devfest-ica-2026-/);
+    expect(await screen.findByText(/1 check-in\(s\) para subir/)).toBeVisible();
+    click.mockRestore();
+  });
+
+  it("says so instead of downloading an empty file when Bevy is in sync", async () => {
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    mocks.useRoster.mockReturnValue(
+      rosterState({
+        attendees: [attendee({ checkedIn: true, bevyCheckinAt: new Date() })],
+      })
+    );
+
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Exportar para Bevy" })
+    );
+
+    expect(click).not.toHaveBeenCalled();
+    expect(await screen.findByText(/Bevy ya tiene marcados/)).toBeVisible();
+    click.mockRestore();
+  });
+});
+
 describe("CheckinPanel — empty and error states", () => {
   // Regression: a cold cache reported a fully populated event as empty and
   // offered a re-import — the one action a volunteer must not take mid-door.

--- a/src/components/react/admin/checkin/__tests__/CheckinPanel.test.tsx
+++ b/src/components/react/admin/checkin/__tests__/CheckinPanel.test.tsx
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Attendee } from "../types";
+
+const mocks = vi.hoisted(() => ({
+  useRoster: vi.fn(),
+  setCheckedIn: vi.fn(),
+  useAuth: vi.fn(),
+  isDevPreview: { value: false },
+}));
+
+vi.mock("../useRoster", () => ({
+  useRoster: mocks.useRoster,
+  setCheckedIn: mocks.setCheckedIn,
+}));
+
+vi.mock("../../AuthProvider", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock("@/lib/api", () => ({
+  get isDevPreview() {
+    return mocks.isDevPreview.value;
+  },
+  api: { importCheckinRoster: vi.fn() },
+}));
+
+import { CheckinPanel } from "../CheckinPanel";
+
+const attendee = (over: Partial<Attendee> = {}): Attendee => ({
+  id: `t_${over.ticketNumber ?? "T1"}`,
+  ticketNumber: "T1",
+  orderNumber: "ORD-1",
+  firstName: "Alex Alberto",
+  lastName: "Quintanilla Garcia",
+  email: "wcandry@gmail.com",
+  company: "",
+  title: "",
+  ticketTitle: "General Admission",
+  searchTokens: ["alex", "alberto", "quintanilla", "garcia", "wcandry@gmail.com"],
+  bevyCheckinAt: null,
+  lastImportId: "imp_1",
+  checkedIn: false,
+  checkedInAt: null,
+  checkedInBy: null,
+  checkedInByName: null,
+  note: null,
+  dniVerified: false,
+  pending: false,
+  ...over,
+});
+
+/** Default hook state: one synced attendee, online, no errors. */
+function rosterState(over: Record<string, unknown> = {}) {
+  return {
+    attendees: [attendee()],
+    meta: { lastImportId: "imp_1", lastImportAt: null, lastImportByName: null, rosterCount: 1 },
+    loading: false,
+    error: null,
+    offline: false,
+    syncedOnce: true,
+    metaError: null,
+    pendingCount: 0,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mocks.useRoster.mockReset();
+  mocks.setCheckedIn.mockReset();
+  mocks.useAuth.mockReset();
+  mocks.isDevPreview.value = false;
+  mocks.useRoster.mockReturnValue(rosterState());
+  mocks.useAuth.mockReturnValue({
+    user: { uid: "org-1", displayName: "Alvaro", email: "a@x.com" },
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("CheckinPanel — it renders at all", () => {
+  // The floor. Astro bundles the island without executing it, so a render
+  // error here would pass the build and only surface at the door.
+  it("mounts and shows the roster", () => {
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    expect(screen.getByText(/Check-in · devfest-ica-2026/)).toBeVisible();
+    expect(screen.getByText("Alex Alberto Quintanilla Garcia")).toBeVisible();
+  });
+
+  it("explains itself when no event was given", () => {
+    render(<CheckinPanel />);
+    expect(screen.getByText(/Falta indicar el evento/)).toBeVisible();
+  });
+
+  it("does not hit live Firestore in dev preview", () => {
+    mocks.isDevPreview.value = true;
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    // A null slug is what stops useRoster subscribing.
+    expect(mocks.useRoster).toHaveBeenCalledWith(null);
+    expect(screen.getByText(/no funciona con datos de ejemplo/)).toBeVisible();
+  });
+});
+
+describe("CheckinPanel — searching at the door", () => {
+  it("filters by a partial surname", async () => {
+    mocks.useRoster.mockReturnValue(
+      rosterState({
+        attendees: [
+          attendee(),
+          attendee({
+            ticketNumber: "T2",
+            firstName: "Maria",
+            lastName: "Rodriguez",
+            searchTokens: ["maria", "rodriguez"],
+          }),
+        ],
+      })
+    );
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    await userEvent.type(screen.getByRole("textbox"), "rodri");
+    expect(screen.getByText("Maria Rodriguez")).toBeVisible();
+    expect(
+      screen.queryByText("Alex Alberto Quintanilla Garcia")
+    ).not.toBeInTheDocument();
+  });
+
+  it("says who was searched for when nothing matches", async () => {
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    await userEvent.type(screen.getByRole("textbox"), "zzz");
+    expect(screen.getByText(/Nadie coincide con “zzz”/)).toBeVisible();
+  });
+
+  // Regression: the message quoted the (empty) query even when the filter
+  // was the checkbox, rendering a bare pair of quotes at the exact moment
+  // everyone had been marked.
+  it("celebrates instead of quoting an empty query", async () => {
+    mocks.useRoster.mockReturnValue(
+      rosterState({ attendees: [attendee({ checkedIn: true })] })
+    );
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    await userEvent.click(screen.getByRole("checkbox"));
+    expect(screen.getByText(/Ya marcaste a todos/)).toBeVisible();
+    expect(screen.queryByText(/coincide con “”/)).not.toBeInTheDocument();
+  });
+});
+
+describe("CheckinPanel — marking someone present", () => {
+  it("attributes the check-in to the signed-in volunteer", async () => {
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    await userEvent.click(screen.getByRole("button", { name: "Marcar" }));
+    expect(mocks.setCheckedIn).toHaveBeenCalledWith(
+      "devfest-ica-2026",
+      "t_T1",
+      true,
+      { uid: "org-1", name: "Alvaro" },
+      expect.any(Function)
+    );
+  });
+
+  it("unmarks someone already present", async () => {
+    mocks.useRoster.mockReturnValue(
+      rosterState({ attendees: [attendee({ checkedIn: true })] })
+    );
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    await userEvent.click(screen.getByRole("button", { name: "✓ Presente" }));
+    expect(mocks.setCheckedIn).toHaveBeenCalledWith(
+      "devfest-ica-2026",
+      "t_T1",
+      false,
+      expect.anything(),
+      expect.any(Function)
+    );
+  });
+});
+
+describe("CheckinPanel — empty and error states", () => {
+  // Regression: a cold cache reported a fully populated event as empty and
+  // offered a re-import — the one action a volunteer must not take mid-door.
+  it("does not claim the roster is empty before the server confirms it", () => {
+    mocks.useRoster.mockReturnValue(
+      rosterState({ attendees: [], syncedOnce: false })
+    );
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    expect(screen.getByText(/Conectando con el servidor/)).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /Importar el CSV/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers the import only once the server says the roster is empty", () => {
+    mocks.useRoster.mockReturnValue(
+      rosterState({ attendees: [], syncedOnce: true })
+    );
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    expect(screen.getByText(/Todavía no hay nadie en el roster/)).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /Importar el CSV/ })
+    ).toBeVisible();
+  });
+
+  // Regression: the listener error handler clears the roster, which made
+  // the empty-state CTA appear directly under the error banner.
+  it("never offers a re-import underneath an error", () => {
+    mocks.useRoster.mockReturnValue(
+      rosterState({
+        attendees: [],
+        syncedOnce: true,
+        error: "Missing or insufficient permissions.",
+      })
+    );
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    expect(screen.getByText(/insufficient permissions/)).toBeVisible();
+    expect(screen.getByText(/Recarga la página/)).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /Importar el CSV/ })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Todavía no hay nadie en el roster/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("warns that stale badges are unavailable when meta fails", () => {
+    mocks.useRoster.mockReturnValue(rosterState({ metaError: "unavailable" }));
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    expect(screen.getByText(/El check-in funciona normal/)).toBeVisible();
+  });
+
+  it("passes the offline state through to the status bar", () => {
+    mocks.useRoster.mockReturnValue(
+      rosterState({ offline: true, pendingCount: 2 })
+    );
+    render(<CheckinPanel initialSlug="devfest-ica-2026" />);
+    expect(screen.getByText(/Sin conexión — 2 cambios en cola/)).toBeVisible();
+  });
+});

--- a/src/components/react/admin/checkin/__tests__/RosterImporter.test.tsx
+++ b/src/components/react/admin/checkin/__tests__/RosterImporter.test.tsx
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mocks = vi.hoisted(() => ({
+  importCheckinRoster: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  isDevPreview: false,
+  api: { importCheckinRoster: mocks.importCheckinRoster },
+}));
+
+import { RosterImporter } from "../RosterImporter";
+
+const HEADER =
+  "Order number,Ticket number,First Name,Last Name,Email,Twitter,Company," +
+  "Title,Featured,Ticket title,Ticket venue,Access code,Discount,Price," +
+  "Currency,Number of tickets,Paid by (name),Paid by (email)," +
+  "Paid date (UTC),Checkin Date (UTC),Ticket Price Paid";
+
+const row = (ticket: string, email: string, first = "Ana", last = "Lopez") =>
+  [
+    "ORD-1",
+    ticket,
+    first,
+    last,
+    email,
+    "",
+    "",
+    "",
+    "",
+    "General Admission",
+    "In-person",
+    "",
+    "",
+    "0.00",
+    "USD",
+    "1",
+    "",
+    "",
+    "2026-07-06 20:10:16+00:00",
+    "",
+    "0.00",
+  ].join(",");
+
+function csvFile(lines: string[]) {
+  return new File([lines.join("\n")], "bevy.csv", { type: "text/csv" });
+}
+
+const ok = (over: Record<string, number | string> = {}) => ({
+  success: true as const,
+  data: {
+    importId: "imp_1",
+    total: 1,
+    created: 1,
+    updated: 0,
+    stale: 0,
+    unusableTickets: 0,
+    ...over,
+  },
+});
+
+beforeEach(() => {
+  mocks.importCheckinRoster.mockReset();
+  mocks.importCheckinRoster.mockResolvedValue(ok());
+});
+
+afterEach(() => cleanup());
+
+// The file input has no visible label, so query it by role/type instead.
+function fileInput(): HTMLInputElement {
+  const el = document.querySelector('input[type="file"]');
+  if (!el) throw new Error("file input not found");
+  return el as HTMLInputElement;
+}
+
+describe("RosterImporter", () => {
+  it("shows how many registrations are ready before committing", async () => {
+    render(<RosterImporter slug="devfest-ica-2026" onImported={vi.fn()} />);
+    await userEvent.upload(
+      fileInput(),
+      csvFile([HEADER, row("T1", "a@x.com"), row("T2", "b@x.com")])
+    );
+    expect(
+      await screen.findByText(/2 registrados listos para importar/)
+    ).toBeVisible();
+  });
+
+  it("sends the parsed rows and reports the outcome", async () => {
+    const onImported = vi.fn();
+    mocks.importCheckinRoster.mockResolvedValue(
+      ok({ created: 2, updated: 3, stale: 1 })
+    );
+    render(<RosterImporter slug="devfest-ica-2026" onImported={onImported} />);
+    await userEvent.upload(fileInput(), csvFile([HEADER, row("T1", "a@x.com")]));
+    await userEvent.click(await screen.findByRole("button", { name: "Importar" }));
+
+    await waitFor(() => expect(onImported).toHaveBeenCalledTimes(1));
+    expect(mocks.importCheckinRoster).toHaveBeenCalledWith(
+      "devfest-ica-2026",
+      expect.arrayContaining([expect.objectContaining({ ticketNumber: "T1" })])
+    );
+    expect(onImported.mock.calls[0][0]).toMatch(
+      /2 nuevos, 3 actualizados, 1 ya no figuran/
+    );
+  });
+
+  it("surfaces the parser's warnings before the organizer commits", async () => {
+    render(<RosterImporter slug="devfest-ica-2026" onImported={vi.fn()} />);
+    await userEvent.upload(
+      fileInput(),
+      csvFile([HEADER, row("T1", "a@x.com"), row("", "b@x.com")])
+    );
+    expect(await screen.findByText(/Ticket number/)).toBeVisible();
+  });
+
+  it("refuses a file past the server's row cap with an actionable message", async () => {
+    render(<RosterImporter slug="devfest-ica-2026" onImported={vi.fn()} />);
+    const many = Array.from({ length: 2001 }, (_, i) =>
+      row(`T${i}`, `u${i}@x.com`)
+    );
+    await userEvent.upload(fileInput(), csvFile([HEADER, ...many]));
+    expect(await screen.findByText(/máximo por importación es 2000/)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Importar" })).not.toBeInTheDocument();
+    expect(mocks.importCheckinRoster).not.toHaveBeenCalled();
+  });
+
+  it("shows the server's error instead of failing silently", async () => {
+    mocks.importCheckinRoster.mockResolvedValue({
+      success: false,
+      error: "Sesión expirada",
+    });
+    render(<RosterImporter slug="devfest-ica-2026" onImported={vi.fn()} />);
+    await userEvent.upload(fileInput(), csvFile([HEADER, row("T1", "a@x.com")]));
+    await userEvent.click(await screen.findByRole("button", { name: "Importar" }));
+    expect(await screen.findByText("Sesión expirada")).toBeVisible();
+  });
+
+  // Regression: request() awaits getIdToken() OUTSIDE its try block, so a
+  // token refresh on flaky venue wifi rejects instead of resolving
+  // {success:false}. Without try/finally the button stayed disabled reading
+  // "Importando…" until a full page reload.
+  it("recovers the button when the request rejects outright", async () => {
+    mocks.importCheckinRoster.mockRejectedValue(new Error("Network down"));
+    render(<RosterImporter slug="devfest-ica-2026" onImported={vi.fn()} />);
+    await userEvent.upload(fileInput(), csvFile([HEADER, row("T1", "a@x.com")]));
+    await userEvent.click(await screen.findByRole("button", { name: "Importar" }));
+
+    expect(await screen.findByText("Network down")).toBeVisible();
+    const button = await screen.findByRole("button", { name: "Importar" });
+    expect(button).toBeEnabled();
+  });
+
+  it("reports tickets the server could not use", async () => {
+    const onImported = vi.fn();
+    mocks.importCheckinRoster.mockResolvedValue(ok({ unusableTickets: 2 }));
+    render(<RosterImporter slug="devfest-ica-2026" onImported={onImported} />);
+    await userEvent.upload(fileInput(), csvFile([HEADER, row("T1", "a@x.com")]));
+    await userEvent.click(await screen.findByRole("button", { name: "Importar" }));
+    await waitFor(() => expect(onImported).toHaveBeenCalled());
+    expect(onImported.mock.calls[0][0]).toMatch(/2 sin ticket utilizable/);
+  });
+});

--- a/src/components/react/admin/checkin/__tests__/SyncStatusBar.test.tsx
+++ b/src/components/react/admin/checkin/__tests__/SyncStatusBar.test.tsx
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { SyncStatusBar } from "../SyncStatusBar";
+
+afterEach(() => cleanup());
+
+describe("SyncStatusBar", () => {
+  it("shows the present/total count", () => {
+    render(
+      <SyncStatusBar present={42} total={134} offline={false} pendingCount={0} />
+    );
+    expect(screen.getByText("42/134 presentes")).toBeInTheDocument();
+  });
+
+  it("reads as synced when online", () => {
+    render(
+      <SyncStatusBar present={1} total={2} offline={false} pendingCount={0} />
+    );
+    expect(screen.getByText("Sincronizado")).toBeInTheDocument();
+  });
+
+  // The reassuring message is the whole point of the offline indicator: a
+  // volunteer who keeps tapping needs to know the taps are not being lost.
+  it("reassures the volunteer when writes are queued offline", () => {
+    render(
+      <SyncStatusBar present={1} total={2} offline={true} pendingCount={3} />
+    );
+    expect(
+      screen.getByText(/Sin conexión — 3 cambios en cola/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Se guardarán solos/)).toBeInTheDocument();
+  });
+
+  it("singularizes a lone queued change", () => {
+    render(
+      <SyncStatusBar present={1} total={2} offline={true} pendingCount={1} />
+    );
+    expect(screen.getByText(/1 cambio en cola/)).toBeInTheDocument();
+  });
+
+  it("distinguishes offline-with-nothing-queued from offline-with-queue", () => {
+    render(
+      <SyncStatusBar present={1} total={2} offline={true} pendingCount={0} />
+    );
+    expect(screen.getByText(/datos en caché/)).toBeInTheDocument();
+    expect(screen.queryByText(/en cola/)).not.toBeInTheDocument();
+  });
+
+  // Regression: an over-eager fix made `offline` unreachable before the
+  // first server snapshot, so a volunteer standing at the door with no
+  // signal saw a green "Sincronizado" bar. Never claim synced when offline.
+  it("never reads as synced while offline", () => {
+    render(
+      <SyncStatusBar present={0} total={5} offline={true} pendingCount={0} />
+    );
+    expect(screen.queryByText("Sincronizado")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/react/admin/checkin/__tests__/buildBevyCsv.test.ts
+++ b/src/components/react/admin/checkin/__tests__/buildBevyCsv.test.ts
@@ -132,8 +132,26 @@ describe("buildBevyCheckinCsv — escaping", () => {
 
 describe("bevyCsvFilename", () => {
   it("identifies the event and the moment", () => {
-    expect(
-      bevyCsvFilename("devfest-ica-2026", new Date("2026-07-18T14:22:10Z"))
-    ).toBe("bevy-checkin-devfest-ica-2026-2026-07-18-14-22.csv");
+    // Local time, not UTC: constructed from local components so the
+    // assertion holds in any timezone the suite runs in.
+    const at = new Date(2026, 6, 18, 14, 22, 10);
+    expect(bevyCsvFilename("devfest-ica-2026", at)).toBe(
+      "bevy-checkin-devfest-ica-2026-2026-07-18-14-22.csv"
+    );
+  });
+
+  // Regression: toISOString() stamped UTC, so an export at 4:17 pm in Ica
+  // was named ...-21-17 — five hours off the clock the organizer is
+  // reading while deciding which file is the latest.
+  it("uses the organizer's local clock, not UTC", () => {
+    const at = new Date(2026, 6, 18, 16, 17, 0);
+    expect(bevyCsvFilename("e", at)).toContain("-16-17.csv");
+  });
+
+  it("zero-pads so names sort chronologically", () => {
+    const at = new Date(2026, 0, 5, 9, 4, 0);
+    expect(bevyCsvFilename("e", at)).toBe(
+      "bevy-checkin-e-2026-01-05-09-04.csv"
+    );
   });
 });

--- a/src/components/react/admin/checkin/__tests__/buildBevyCsv.test.ts
+++ b/src/components/react/admin/checkin/__tests__/buildBevyCsv.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { bevyCsvFilename, buildBevyCheckinCsv } from "../buildBevyCsv";
+import type { Attendee } from "../types";
+
+const attendee = (over: Partial<Attendee> = {}): Attendee => ({
+  id: "t_T1",
+  ticketNumber: "T1",
+  orderNumber: "ORD-1",
+  firstName: "Alex Alberto",
+  lastName: "Quintanilla Garcia",
+  email: "wcandry@gmail.com",
+  company: "",
+  title: "",
+  ticketTitle: "General Admission",
+  searchTokens: [],
+  bevyCheckinAt: null,
+  lastImportId: "imp_1",
+  checkedIn: false,
+  checkedInAt: null,
+  checkedInBy: null,
+  checkedInByName: null,
+  note: null,
+  dniVerified: false,
+  pending: false,
+  ...over,
+});
+
+const lines = (csv: string) => csv.trimEnd().split("\n");
+
+describe("buildBevyCheckinCsv — shape Bevy expects", () => {
+  it("writes exactly the four columns the upload uses", () => {
+    const { csv } = buildBevyCheckinCsv([]);
+    expect(lines(csv)[0]).toBe("first_name,last_name,email,checked_in");
+  });
+
+  it("writes one row per person marked present", () => {
+    const { csv, rows } = buildBevyCheckinCsv([
+      attendee({ checkedIn: true }),
+      attendee({
+        id: "t_T2",
+        checkedIn: true,
+        firstName: "Maria",
+        lastName: "Rodriguez",
+        email: "maria@x.com",
+      }),
+    ]);
+    expect(rows).toBe(2);
+    expect(lines(csv)).toEqual([
+      "first_name,last_name,email,checked_in",
+      "Alex Alberto,Quintanilla Garcia,wcandry@gmail.com,TRUE",
+      "Maria,Rodriguez,maria@x.com,TRUE",
+    ]);
+  });
+
+  it("ends with a newline so the last row is terminated", () => {
+    const { csv } = buildBevyCheckinCsv([attendee({ checkedIn: true })]);
+    expect(csv.endsWith("\n")).toBe(true);
+  });
+
+  it("produces a header-only file when nobody was marked", () => {
+    const { csv, rows } = buildBevyCheckinCsv([attendee(), attendee()]);
+    expect(rows).toBe(0);
+    expect(lines(csv)).toEqual(["first_name,last_name,email,checked_in"]);
+  });
+});
+
+describe("buildBevyCheckinCsv — what it deliberately leaves out", () => {
+  // Bevy is the system of record and a volunteer may have used the Bevy
+  // app directly. A checked_in=FALSE row would undo that, so absentees are
+  // never written: this upload only ever adds check-ins.
+  it("never includes absentees", () => {
+    const { csv, rows } = buildBevyCheckinCsv([
+      attendee({ checkedIn: true }),
+      attendee({ id: "t_T2", email: "absent@x.com", checkedIn: false }),
+    ]);
+    expect(rows).toBe(1);
+    expect(csv).not.toContain("absent@x.com");
+    expect(csv).not.toContain("FALSE");
+  });
+
+  it("skips people Bevy already has checked in", () => {
+    const { csv, rows, alreadyInBevy } = buildBevyCheckinCsv([
+      attendee({ checkedIn: true }),
+      attendee({
+        id: "t_T2",
+        email: "done@x.com",
+        checkedIn: true,
+        bevyCheckinAt: new Date("2026-07-18T09:15:00Z"),
+      }),
+    ]);
+    expect(rows).toBe(1);
+    expect(alreadyInBevy).toBe(1);
+    expect(csv).not.toContain("done@x.com");
+  });
+
+  // Re-running after a partial upload should shrink to nothing, not
+  // re-send the same people.
+  it("produces an empty upload once Bevy is fully in sync", () => {
+    const { rows, alreadyInBevy } = buildBevyCheckinCsv([
+      attendee({ checkedIn: true, bevyCheckinAt: new Date() }),
+      attendee({ id: "t_T2", checkedIn: true, bevyCheckinAt: new Date() }),
+    ]);
+    expect(rows).toBe(0);
+    expect(alreadyInBevy).toBe(2);
+  });
+});
+
+describe("buildBevyCheckinCsv — escaping", () => {
+  it("quotes a surname containing a comma", () => {
+    const { csv } = buildBevyCheckinCsv([
+      attendee({ checkedIn: true, lastName: "Quintanilla, Garcia" }),
+    ]);
+    expect(lines(csv)[1]).toBe(
+      'Alex Alberto,"Quintanilla, Garcia",wcandry@gmail.com,TRUE'
+    );
+  });
+
+  it("escapes embedded double quotes", () => {
+    const { csv } = buildBevyCheckinCsv([
+      attendee({ checkedIn: true, firstName: 'Ana "Ani"' }),
+    ]);
+    expect(lines(csv)[1]).toContain('"Ana ""Ani"""');
+  });
+
+  it("preserves diacritics — Bevy matches on the email anyway", () => {
+    const { csv } = buildBevyCheckinCsv([
+      attendee({ checkedIn: true, firstName: "María", lastName: "Ñañez" }),
+    ]);
+    expect(csv).toContain("María,Ñañez");
+  });
+});
+
+describe("bevyCsvFilename", () => {
+  it("identifies the event and the moment", () => {
+    expect(
+      bevyCsvFilename("devfest-ica-2026", new Date("2026-07-18T14:22:10Z"))
+    ).toBe("bevy-checkin-devfest-ica-2026-2026-07-18-14-22.csv");
+  });
+});

--- a/src/components/react/admin/checkin/__tests__/parseBevyCsv.test.ts
+++ b/src/components/react/admin/checkin/__tests__/parseBevyCsv.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { parseBevyCsv, tokenizeCsv } from "../parseBevyCsv";
+
+// The exact 21-column header row emitted by the Bevy dashboard export,
+// verified against google-gdg-ica-presents-devfest-ica-2026.csv.
+const HEADER =
+  "Order number,Ticket number,First Name,Last Name,Email,Twitter,Company," +
+  "Title,Featured,Ticket title,Ticket venue,Access code,Discount,Price," +
+  "Currency,Number of tickets,Paid by (name),Paid by (email)," +
+  "Paid date (UTC),Checkin Date (UTC),Ticket Price Paid";
+
+// Quotes a cell the way a real CSV writer would. Several Bevy columns
+// ("Paid date (UTC)" → "Jul 06, 2026 - 03:10 PM", and "Price" → "0,00" in
+// an ES locale) contain commas, so a fixture that naively joins on ","
+// produces a shifted, invalid file.
+const cell = (v: string) =>
+  /[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
+
+const row = (over: Partial<Record<string, string>> = {}) => {
+  const c = {
+    order: "ORD-1",
+    ticket: "GOOGA263171317",
+    first: "Alex Alberto",
+    last: "Quintanilla Garcia",
+    email: "wcandry@gmail.com",
+    company: "",
+    title: "",
+    ticketTitle: "General Admission",
+    checkin: "",
+    ...over,
+  };
+  return [
+    c.order,
+    c.ticket,
+    c.first,
+    c.last,
+    c.email,
+    "", // Twitter
+    c.company,
+    c.title,
+    "", // Featured
+    c.ticketTitle,
+    "In-person",
+    "", // Access code
+    "", // Discount
+    "0,00", // Price, ES locale — contains a comma
+    "USD",
+    "1",
+    "",
+    "",
+    "Jul 06, 2026 - 03:10 PM", // also contains a comma
+    c.checkin,
+    "0.00",
+  ]
+    .map(cell)
+    .join(",");
+};
+
+describe("tokenizeCsv — RFC 4180 behaviour", () => {
+  it("keeps commas that live inside quoted fields", () => {
+    const out = tokenizeCsv('a,"Acme, Inc.",c');
+    expect(out).toEqual([["a", "Acme, Inc.", "c"]]);
+  });
+
+  it("unescapes doubled quotes", () => {
+    const out = tokenizeCsv('a,"She said ""hi""",c');
+    expect(out).toEqual([["a", 'She said "hi"', "c"]]);
+  });
+
+  it("keeps newlines inside quoted fields as content, not row breaks", () => {
+    const out = tokenizeCsv('a,"line one\nline two",c\nd,e,f');
+    expect(out).toEqual([
+      ["a", "line one\nline two", "c"],
+      ["d", "e", "f"],
+    ]);
+  });
+
+  it("handles CRLF line endings", () => {
+    expect(tokenizeCsv("a,b\r\nc,d")).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+  });
+
+  it("strips a UTF-8 BOM so the first header name stays clean", () => {
+    expect(tokenizeCsv("﻿Order number,Email")).toEqual([
+      ["Order number", "Email"],
+    ]);
+  });
+
+  it("preserves empty trailing fields", () => {
+    expect(tokenizeCsv("a,,c")).toEqual([["a", "", "c"]]);
+  });
+});
+
+describe("parseBevyCsv — the real export shape", () => {
+  it("maps every field from a well-formed row", () => {
+    const { rows, warnings } = parseBevyCsv([HEADER, row()].join("\n"));
+    expect(warnings).toEqual([]);
+    expect(rows).toEqual([
+      {
+        ticketNumber: "GOOGA263171317",
+        orderNumber: "ORD-1",
+        firstName: "Alex Alberto",
+        lastName: "Quintanilla Garcia",
+        email: "wcandry@gmail.com",
+        company: "",
+        title: "",
+        ticketTitle: "General Admission",
+        bevyCheckinAt: "",
+      },
+    ]);
+  });
+
+  it("lowercases the email so re-imports match regardless of casing", () => {
+    const { rows } = parseBevyCsv(
+      [HEADER, row({ email: "Alex.QUINTANILLA@Gmail.com" })].join("\n")
+    );
+    expect(rows[0].email).toBe("alex.quintanilla@gmail.com");
+  });
+
+  it("preserves diacritics in names", () => {
+    const { rows } = parseBevyCsv(
+      [HEADER, row({ first: "María", last: "Ñañez Solís" })].join("\n")
+    );
+    expect(rows[0].firstName).toBe("María");
+    expect(rows[0].lastName).toBe("Ñañez Solís");
+  });
+
+  it("carries the Bevy check-in date through when present", () => {
+    const { rows } = parseBevyCsv(
+      [HEADER, row({ checkin: "Jul 18, 2026 - 09:15 AM" })].join("\n")
+    );
+    expect(rows[0].bevyCheckinAt).toBe("Jul 18, 2026 - 09:15 AM");
+  });
+});
+
+// This is the whole reason parseCsv.ts could not be reused.
+describe("parseBevyCsv — comma inside a quoted field", () => {
+  it("does not shift columns when Company contains a comma", () => {
+    const raw = [HEADER, row({ company: "Acme, Inc.", title: "Dev" })].join(
+      "\n"
+    );
+    const { rows } = parseBevyCsv(raw);
+    expect(rows[0].company).toBe("Acme, Inc.");
+    // The real assertion: everything after the comma still lines up.
+    expect(rows[0].title).toBe("Dev");
+    expect(rows[0].ticketTitle).toBe("General Admission");
+    expect(rows[0].email).toBe("wcandry@gmail.com");
+  });
+});
+
+describe("parseBevyCsv — header-name mapping", () => {
+  it("tolerates reordered columns", () => {
+    const raw = [
+      "Email,Ticket number,Last Name,First Name",
+      "ana@x.com,TKT-9,Lopez,Ana",
+    ].join("\n");
+    const { rows } = parseBevyCsv(raw);
+    expect(rows[0]).toMatchObject({
+      email: "ana@x.com",
+      ticketNumber: "TKT-9",
+      firstName: "Ana",
+      lastName: "Lopez",
+    });
+  });
+
+  it("does not confuse 'Title' with 'Ticket title'", () => {
+    const raw = [
+      "Ticket number,First Name,Last Name,Email,Title,Ticket title",
+      "TKT-9,Ana,Lopez,ana@x.com,Engineer,VIP",
+    ].join("\n");
+    const { rows } = parseBevyCsv(raw);
+    expect(rows[0].title).toBe("Engineer");
+    expect(rows[0].ticketTitle).toBe("VIP");
+  });
+
+  it("is case- and spacing-insensitive on header names", () => {
+    const raw = [
+      "  TICKET NUMBER ,First   Name,Last Name,EMAIL",
+      "TKT-9,Ana,Lopez,ana@x.com",
+    ].join("\n");
+    const { rows } = parseBevyCsv(raw);
+    expect(rows[0].ticketNumber).toBe("TKT-9");
+    expect(rows[0].firstName).toBe("Ana");
+  });
+
+  it("refuses the file when required columns are absent", () => {
+    const { rows, warnings } = parseBevyCsv("Name,Email\nAna,ana@x.com");
+    expect(rows).toEqual([]);
+    expect(warnings[0]).toContain("columnas obligatorias");
+  });
+
+  it("warns when the check-in column is missing but still imports", () => {
+    const raw = [
+      "Ticket number,First Name,Last Name,Email",
+      "TKT-9,Ana,Lopez,ana@x.com",
+    ].join("\n");
+    const { rows, warnings } = parseBevyCsv(raw);
+    expect(rows).toHaveLength(1);
+    expect(warnings.join(" ")).toContain("Checkin Date");
+  });
+});
+
+describe("parseBevyCsv — row-level validation", () => {
+  it("skips and reports rows with a blank ticket number", () => {
+    const raw = [HEADER, row(), row({ ticket: "" })].join("\n");
+    const { rows, warnings } = parseBevyCsv(raw);
+    expect(rows).toHaveLength(1);
+    expect(warnings.join(" ")).toContain("Ticket number");
+  });
+
+  it("skips and reports rows with no email", () => {
+    const raw = [HEADER, row(), row({ ticket: "TKT-2", email: "" })].join("\n");
+    const { rows, warnings } = parseBevyCsv(raw);
+    expect(rows).toHaveLength(1);
+    expect(warnings.join(" ")).toContain("sin email");
+  });
+
+  it("keeps the first occurrence of a duplicated ticket number", () => {
+    const raw = [
+      HEADER,
+      row({ email: "first@x.com" }),
+      row({ email: "second@x.com" }),
+    ].join("\n");
+    const { rows, warnings } = parseBevyCsv(raw);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].email).toBe("first@x.com");
+    expect(warnings.join(" ")).toContain("ticket repetido");
+  });
+
+  it("skips blank lines, including a trailing newline", () => {
+    const raw = [HEADER, row(), "", row({ ticket: "TKT-2" }), ""].join("\n");
+    expect(parseBevyCsv(raw).rows).toHaveLength(2);
+  });
+
+  it("returns a warning for an empty file", () => {
+    expect(parseBevyCsv("").rows).toEqual([]);
+    expect(parseBevyCsv("").warnings[0]).toContain("vacío");
+  });
+
+  it("returns no rows when only a header is present", () => {
+    expect(parseBevyCsv(HEADER).rows).toEqual([]);
+  });
+});

--- a/src/components/react/admin/checkin/__tests__/search.test.ts
+++ b/src/components/react/admin/checkin/__tests__/search.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { buildSearchTokens } from "../../../../../../functions/src/services/nameMatch";
+import { normalizeQuery, queryTerms } from "../CheckinPanel";
+
+// The panel and the import handler live on opposite sides of the wire but
+// must agree on normalization: the handler builds searchTokens, the panel
+// matches against them. These tests pin that contract, because a mismatch
+// fails silently — the attendee is simply never found, with no error.
+
+/** Same predicate the panel applies to each attendee. */
+function finds(query: string, tokens: string[]): boolean {
+  const terms = queryTerms(query);
+  if (terms.length === 0) return true;
+  return terms.every((t) => tokens.some((tok) => tok.startsWith(t)));
+}
+
+const attendee = (over: Partial<Parameters<typeof buildSearchTokens>[0]> = {}) =>
+  buildSearchTokens({
+    firstName: "Alex Alberto",
+    lastName: "Quintanilla Garcia",
+    email: "wcandry@gmail.com",
+    ticketNumber: "GOOGA263171317",
+    ...over,
+  });
+
+describe("door search — the ways a volunteer actually types", () => {
+  it("finds by first name", () => {
+    expect(finds("alex", attendee())).toBe(true);
+  });
+
+  it("finds by surname alone", () => {
+    expect(finds("quintanilla", attendee())).toBe(true);
+  });
+
+  it("finds by partial prefixes across both names", () => {
+    expect(finds("qui gar", attendee())).toBe(true);
+  });
+
+  it("is order-independent", () => {
+    expect(finds("garcia alex", attendee())).toBe(true);
+  });
+
+  it("finds by full email", () => {
+    expect(finds("wcandry@gmail.com", attendee())).toBe(true);
+  });
+
+  it("finds by email local part", () => {
+    expect(finds("wcandry", attendee())).toBe(true);
+  });
+
+  it("finds by ticket number, case-insensitively", () => {
+    expect(finds("googa263171317", attendee())).toBe(true);
+    expect(finds("GOOGA263171317", attendee())).toBe(true);
+  });
+
+  it("rejects someone who does not match", () => {
+    expect(finds("rodriguez", attendee())).toBe(false);
+  });
+});
+
+describe("door search — accents", () => {
+  const maria = attendee({
+    firstName: "María",
+    lastName: "Ñañez Solís",
+    email: "maria@x.com",
+  });
+
+  it("finds an accented name typed without accents", () => {
+    expect(finds("maria", maria)).toBe(true);
+    expect(finds("nanez", maria)).toBe(true);
+    expect(finds("solis", maria)).toBe(true);
+  });
+
+  it("still finds it when typed with accents", () => {
+    expect(finds("Ñañez", maria)).toBe(true);
+    expect(finds("Solís", maria)).toBe(true);
+  });
+});
+
+describe("door search — punctuation must not split the two sides apart", () => {
+  const hyphenated = attendee({
+    firstName: "Ana",
+    lastName: "Quintanilla-Garcia",
+    email: "ana@x.com",
+  });
+
+  // Regression: normalizeQuery used to keep "-", producing the single term
+  // "quintanilla-garcia". buildSearchTokens splits on it, so the stored
+  // tokens are ["quintanilla", "garcia"] and neither is prefixed by that
+  // term — typing the surname exactly as registered found nobody.
+  it("finds a hyphenated surname typed with the hyphen", () => {
+    expect(finds("quintanilla-garcia", hyphenated)).toBe(true);
+  });
+
+  it("finds the same surname typed with a space", () => {
+    expect(finds("quintanilla garcia", hyphenated)).toBe(true);
+  });
+
+  it("handles an apostrophe", () => {
+    const obrien = attendee({ firstName: "Sean", lastName: "O'Brien" });
+    expect(finds("o'brien", obrien)).toBe(true);
+    expect(finds("brien", obrien)).toBe(true);
+  });
+});
+
+describe("door search — particles and initials the server strips", () => {
+  const juan = attendee({
+    firstName: "Juan",
+    lastName: "de la Cruz Rojas",
+    email: "juan@x.com",
+  });
+
+  // Regression: nameTokens() drops particles when building searchTokens,
+  // so no stored token starts with "de" or "la". Since every term has to
+  // match, keeping them in the query made the full name find nobody —
+  // exactly what a volunteer reading off an ID would type.
+  it("finds someone whose full name is typed with its particles", () => {
+    expect(finds("juan de la cruz", juan)).toBe(true);
+  });
+
+  it("finds them by the significant parts alone", () => {
+    expect(finds("cruz rojas", juan)).toBe(true);
+  });
+
+  it("ignores a middle initial, which is never tokenized", () => {
+    const ana = attendee({ firstName: "Ana M", lastName: "Lopez" });
+    expect(finds("ana m lopez", ana)).toBe(true);
+  });
+
+  it("treats a query of only particles as no filter at all", () => {
+    expect(queryTerms("de la")).toEqual([]);
+  });
+
+  it("still rejects a genuine non-match", () => {
+    expect(finds("de la cruz mendoza", juan)).toBe(false);
+  });
+});
+
+describe("normalizeQuery", () => {
+  it("collapses whitespace and lowercases", () => {
+    expect(normalizeQuery("  ALEX   Alberto ")).toBe("alex alberto");
+  });
+
+  it("keeps @ and . so a full email survives", () => {
+    expect(normalizeQuery("WCandry@Gmail.com")).toBe("wcandry@gmail.com");
+  });
+
+  it("turns other punctuation into separators, matching the server", () => {
+    expect(normalizeQuery("Quintanilla-Garcia")).toBe("quintanilla garcia");
+  });
+
+  it("returns empty for a blank query", () => {
+    expect(normalizeQuery("   ")).toBe("");
+  });
+});

--- a/src/components/react/admin/checkin/__tests__/search.test.ts
+++ b/src/components/react/admin/checkin/__tests__/search.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildSearchTokens } from "../../../../../../functions/src/services/nameMatch";
+import {
+  buildSearchTokens,
+  tokenize,
+} from "../../../../../../functions/src/services/nameMatch";
 import { normalizeQuery, queryTerms } from "../CheckinPanel";
 
 // The panel and the import handler live on opposite sides of the wire but
@@ -22,6 +25,32 @@ const attendee = (over: Partial<Parameters<typeof buildSearchTokens>[0]> = {}) =
     ticketNumber: "GOOGA263171317",
     ...over,
   });
+
+// The load-bearing test. The panel and the import handler ship in different
+// bundles and cannot share a module, so the tokenizer is duplicated. If the
+// copies ever drift, nothing throws — the volunteer is just told "no
+// matches" for someone standing in front of them. This asserts the two
+// implementations produce identical output on the inputs that have actually
+// broken before.
+describe("client and server tokenizers must stay identical", () => {
+  it.each([
+    "Quintanilla-Garcia",
+    "Ñañez Solís",
+    "Ana M. Torres",
+    "Juan de la Cruz Rojas",
+    "O'Brien",
+    "juan+gdg@gmail.com",
+    "ana_lopez@gmail.com",
+    "luis.diaz@gmail.com",
+    "maria-jose@empresa-x.com",
+    "ABC-123",
+    "GOOGA263171317",
+    "  MÚLTIPLES   espacios  ",
+    "",
+  ])("agrees on %j", (input) => {
+    expect(queryTerms(input)).toEqual(tokenize(input));
+  });
+});
 
 describe("door search — the ways a volunteer actually types", () => {
   it("finds by first name", () => {
@@ -51,6 +80,28 @@ describe("door search — the ways a volunteer actually types", () => {
   it("finds by ticket number, case-insensitively", () => {
     expect(finds("googa263171317", attendee())).toBe(true);
     expect(finds("GOOGA263171317", attendee())).toBe(true);
+  });
+
+  // Regression: these were all indexed verbatim but split by the query, so
+  // typing the address exactly as registered found nobody. Plus-addressing
+  // and underscores are common in a developer audience.
+  it.each([
+    ["juan+gdg@gmail.com", "plus-addressed"],
+    ["ana_lopez@gmail.com", "underscored"],
+    ["maria-jose@empresa-x.com", "hyphenated"],
+    ["luis.diaz@gmail.com", "dotted"],
+  ])("finds %s (%s) typed in full", (email) => {
+    expect(finds(email, attendee({ email }))).toBe(true);
+  });
+
+  it("finds a dotted local part typed without the domain", () => {
+    expect(finds("luis.diaz", attendee({ email: "luis.diaz@gmail.com" }))).toBe(
+      true
+    );
+  });
+
+  it("finds a ticket number containing a hyphen", () => {
+    expect(finds("ABC-123", attendee({ ticketNumber: "ABC-123" }))).toBe(true);
   });
 
   it("rejects someone who does not match", () => {
@@ -100,6 +151,14 @@ describe("door search — punctuation must not split the two sides apart", () =>
     const obrien = attendee({ firstName: "Sean", lastName: "O'Brien" });
     expect(finds("o'brien", obrien)).toBe(true);
     expect(finds("brien", obrien)).toBe(true);
+  });
+
+  // A period is kept inside addresses but is a separator elsewhere, so a
+  // written-out middle initial matches whether or not it is typed with one.
+  it("handles a middle initial written with its period", () => {
+    const ana = attendee({ firstName: "Ana M.", lastName: "Torres" });
+    expect(finds("Ana M. Torres", ana)).toBe(true);
+    expect(finds("ana torres", ana)).toBe(true);
   });
 });
 

--- a/src/components/react/admin/checkin/buildBevyCsv.ts
+++ b/src/components/react/admin/checkin/buildBevyCsv.ts
@@ -58,8 +58,18 @@ export function buildBevyCheckinCsv(attendees: Attendee[]): BevyCsvResult {
   };
 }
 
-/** Filename that identifies the event and the moment, for the audit trail. */
+/**
+ * Filename that identifies the event and the moment.
+ *
+ * Built from LOCAL time, not toISOString(). The organizer exports two or
+ * three times during an event and picks the latest by eye; a UTC stamp
+ * would read five hours ahead of the clock they are looking at in Ica.
+ * Zero-padded so the names still sort chronologically.
+ */
 export function bevyCsvFilename(slug: string, now: Date): string {
-  const stamp = now.toISOString().slice(0, 16).replace(/[:T]/g, "-");
+  const p = (n: number) => String(n).padStart(2, "0");
+  const stamp =
+    `${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}` +
+    `-${p(now.getHours())}-${p(now.getMinutes())}`;
   return `bevy-checkin-${slug}-${stamp}.csv`;
 }

--- a/src/components/react/admin/checkin/buildBevyCsv.ts
+++ b/src/components/react/admin/checkin/buildBevyCsv.ts
@@ -1,0 +1,65 @@
+import type { Attendee } from "./types";
+
+// Builds the CSV consumed by Bevy's "Bulk upload attendees" dialog.
+//
+// The template Bevy hands out carries more columns (job_title, company,
+// ticket_type and one survey:* per configured question), but only these
+// four are relevant to reconciling check-in, so the rest are omitted
+// deliberately rather than filled with blanks.
+const COLUMNS = ["first_name", "last_name", "email", "checked_in"] as const;
+
+export interface BevyCsvResult {
+  csv: string;
+  /** Rows written — i.e. people this upload would mark present. */
+  rows: number;
+  /** Marked here but Bevy already has them; left out to keep the upload minimal. */
+  alreadyInBevy: number;
+}
+
+/** RFC 4180 quoting. Surnames with commas are common enough to matter. */
+function cell(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/**
+ * Produces an upload for everyone marked present in the panel.
+ *
+ * Two deliberate omissions:
+ *
+ * - Absentees are never included. Bevy is the system of record, and a
+ *   volunteer may have checked someone in from the Bevy app directly; a
+ *   row saying checked_in=FALSE would undo that. This upload only ever
+ *   adds check-ins, never removes them.
+ * - Anyone Bevy already has checked in is skipped, so re-running after a
+ *   partial upload stays small and touches as little as possible.
+ */
+export function buildBevyCheckinCsv(attendees: Attendee[]): BevyCsvResult {
+  const present = attendees.filter((a) => a.checkedIn);
+  const pending = present.filter((a) => !a.bevyCheckinAt);
+
+  const lines = [COLUMNS.join(",")];
+  for (const a of pending) {
+    lines.push(
+      [
+        cell(a.firstName),
+        cell(a.lastName),
+        cell(a.email),
+        // The template's own example row uses uppercase TRUE.
+        "TRUE",
+      ].join(",")
+    );
+  }
+
+  return {
+    // Trailing newline: some importers drop a final unterminated row.
+    csv: `${lines.join("\n")}\n`,
+    rows: pending.length,
+    alreadyInBevy: present.length - pending.length,
+  };
+}
+
+/** Filename that identifies the event and the moment, for the audit trail. */
+export function bevyCsvFilename(slug: string, now: Date): string {
+  const stamp = now.toISOString().slice(0, 16).replace(/[:T]/g, "-");
+  return `bevy-checkin-${slug}-${stamp}.csv`;
+}

--- a/src/components/react/admin/checkin/parseBevyCsv.ts
+++ b/src/components/react/admin/checkin/parseBevyCsv.ts
@@ -5,6 +5,9 @@
 // one splits on /[,;\t]/ with no quote handling, which is fine for a
 // two-column name/email list but shatters on Bevy's 21-column export the
 // first time someone's Company or Title contains a comma ("Acme, Inc.").
+// Its EMAIL_RE is still the right shared definition, so we reuse that.
+
+import { EMAIL_RE } from "../certificates/parseCsv";
 
 export interface BevyRegistration {
   ticketNumber: string;
@@ -150,6 +153,7 @@ export function parseBevyCsv(text: string): ParseBevyCsvResult {
   const seenTickets = new Set<string>();
   let skippedNoTicket = 0;
   let skippedNoEmail = 0;
+  let skippedBadEmail = 0;
   let duplicates = 0;
 
   for (const raw of table.slice(1)) {
@@ -164,6 +168,13 @@ export function parseBevyCsv(text: string): ParseBevyCsvResult {
     }
     if (!email) {
       skippedNoEmail++;
+      continue;
+    }
+    // The import endpoint validates emails with Zod, which rejects the
+    // WHOLE request on the first bad one. Screening here turns "your
+    // 300-row import failed" into "one row was skipped, here's how many".
+    if (!EMAIL_RE.test(email)) {
+      skippedBadEmail++;
       continue;
     }
     if (seenTickets.has(ticketNumber)) {
@@ -193,6 +204,11 @@ export function parseBevyCsv(text: string): ParseBevyCsvResult {
   }
   if (skippedNoEmail > 0) {
     warnings.push(`${skippedNoEmail} fila(s) sin email fueron omitidas.`);
+  }
+  if (skippedBadEmail > 0) {
+    warnings.push(
+      `${skippedBadEmail} fila(s) con un email mal formado fueron omitidas.`
+    );
   }
   if (duplicates > 0) {
     warnings.push(`${duplicates} fila(s) con ticket repetido fueron omitidas.`);

--- a/src/components/react/admin/checkin/parseBevyCsv.ts
+++ b/src/components/react/admin/checkin/parseBevyCsv.ts
@@ -1,0 +1,208 @@
+// Parser for the registrations CSV exported from the Bevy dashboard
+// (gdg.community.dev → event → Registrations → Download).
+//
+// This deliberately does NOT reuse parseCsv.ts from ../certificates: that
+// one splits on /[,;\t]/ with no quote handling, which is fine for a
+// two-column name/email list but shatters on Bevy's 21-column export the
+// first time someone's Company or Title contains a comma ("Acme, Inc.").
+
+export interface BevyRegistration {
+  ticketNumber: string;
+  orderNumber: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  company: string;
+  title: string;
+  ticketTitle: string;
+  /** Raw "Checkin Date (UTC)" cell. Empty string means not checked in on
+   *  Bevy. Kept as the original string — the import handler parses it. */
+  bevyCheckinAt: string;
+}
+
+export interface ParseBevyCsvResult {
+  rows: BevyRegistration[];
+  /** Non-fatal problems worth showing the organizer before they import. */
+  warnings: string[];
+}
+
+/**
+ * Splits CSV text into rows of raw cells, per RFC 4180: double-quoted
+ * fields, "" as an escaped quote, and commas/newlines inside quotes.
+ */
+export function tokenizeCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  // Excel and some Bevy exports prepend a UTF-8 BOM, which would
+  // otherwise become part of the first header name and break lookup.
+  let i = text.charCodeAt(0) === 0xfeff ? 1 : 0;
+
+  const endRow = () => {
+    row.push(field);
+    rows.push(row);
+    row = [];
+    field = "";
+  };
+
+  while (i < text.length) {
+    const c = text[i];
+
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+        } else {
+          inQuotes = false;
+          i++;
+        }
+      } else {
+        // Note: a \r or \n here is real content, not a row break.
+        field += c;
+        i++;
+      }
+      continue;
+    }
+
+    if (c === '"') {
+      inQuotes = true;
+      i++;
+    } else if (c === ",") {
+      row.push(field);
+      field = "";
+      i++;
+    } else if (c === "\n") {
+      endRow();
+      i++;
+    } else if (c === "\r") {
+      i++; // CRLF: the \n does the row break
+    } else {
+      field += c;
+      i++;
+    }
+  }
+
+  if (field !== "" || row.length > 0) endRow();
+  return rows;
+}
+
+const normalizeHeader = (h: string) =>
+  h.trim().toLowerCase().replace(/\s+/g, " ");
+
+// Header aliases, matched by EXACT normalized equality. Substring
+// matching would be a bug here: the export has both "Title" and "Ticket
+// title", and a loose match would silently map one onto the other.
+const COLUMN_ALIASES: Record<keyof BevyRegistration, string[]> = {
+  ticketNumber: ["ticket number"],
+  orderNumber: ["order number"],
+  firstName: ["first name"],
+  lastName: ["last name"],
+  email: ["email"],
+  company: ["company"],
+  title: ["title"],
+  ticketTitle: ["ticket title"],
+  bevyCheckinAt: ["checkin date (utc)", "check-in date (utc)", "checkin date"],
+};
+
+// Without these we cannot build a usable roster entry.
+const REQUIRED: (keyof BevyRegistration)[] = [
+  "ticketNumber",
+  "email",
+  "firstName",
+  "lastName",
+];
+
+export function parseBevyCsv(text: string): ParseBevyCsvResult {
+  const table = tokenizeCsv(text).filter((r) => r.some((c) => c.trim() !== ""));
+  if (table.length === 0) {
+    return { rows: [], warnings: ["El archivo está vacío."] };
+  }
+
+  const header = table[0].map(normalizeHeader);
+  const warnings: string[] = [];
+
+  // Resolve each field to a column index by header name, never by
+  // position — Bevy is free to reorder or add columns between exports.
+  const index = {} as Record<keyof BevyRegistration, number>;
+  for (const key of Object.keys(COLUMN_ALIASES) as (keyof BevyRegistration)[]) {
+    index[key] = header.findIndex((h) => COLUMN_ALIASES[key].includes(h));
+  }
+
+  const missing = REQUIRED.filter((k) => index[k] === -1);
+  if (missing.length > 0) {
+    return {
+      rows: [],
+      warnings: [
+        `Al CSV le faltan columnas obligatorias: ${missing.join(", ")}. ` +
+          `¿Es el export de registraciones de Bevy?`,
+      ],
+    };
+  }
+
+  const cell = (row: string[], key: keyof BevyRegistration) => {
+    const i = index[key];
+    return i === -1 ? "" : (row[i] ?? "").trim();
+  };
+
+  const rows: BevyRegistration[] = [];
+  const seenTickets = new Set<string>();
+  let skippedNoTicket = 0;
+  let skippedNoEmail = 0;
+  let duplicates = 0;
+
+  for (const raw of table.slice(1)) {
+    const ticketNumber = cell(raw, "ticketNumber");
+    const email = cell(raw, "email");
+
+    // The ticket number is the document ID, so a blank one is fatal for
+    // that row — importing it would collide with every other blank.
+    if (!ticketNumber) {
+      skippedNoTicket++;
+      continue;
+    }
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    if (seenTickets.has(ticketNumber)) {
+      duplicates++;
+      continue;
+    }
+    seenTickets.add(ticketNumber);
+
+    rows.push({
+      ticketNumber,
+      orderNumber: cell(raw, "orderNumber"),
+      firstName: cell(raw, "firstName"),
+      lastName: cell(raw, "lastName"),
+      email: email.toLowerCase(),
+      company: cell(raw, "company"),
+      title: cell(raw, "title"),
+      ticketTitle: cell(raw, "ticketTitle"),
+      bevyCheckinAt: cell(raw, "bevyCheckinAt"),
+    });
+  }
+
+  if (skippedNoTicket > 0) {
+    warnings.push(
+      `${skippedNoTicket} fila(s) sin "Ticket number" fueron omitidas. ` +
+        `Revisa el export antes de continuar.`
+    );
+  }
+  if (skippedNoEmail > 0) {
+    warnings.push(`${skippedNoEmail} fila(s) sin email fueron omitidas.`);
+  }
+  if (duplicates > 0) {
+    warnings.push(`${duplicates} fila(s) con ticket repetido fueron omitidas.`);
+  }
+  if (index.bevyCheckinAt === -1) {
+    warnings.push(
+      `El CSV no trae la columna "Checkin Date (UTC)". El sync con Bevy ` +
+        `no podrá saber a quién ya marcaste allá.`
+    );
+  }
+
+  return { rows, warnings };
+}

--- a/src/components/react/admin/checkin/parseBevyCsv.ts
+++ b/src/components/react/admin/checkin/parseBevyCsv.ts
@@ -80,7 +80,13 @@ export function tokenizeCsv(text: string): string[][] {
       endRow();
       i++;
     } else if (c === "\r") {
-      i++; // CRLF: the \n does the row break
+      // Break the row here and swallow a following \n, so CRLF, LF and a
+      // lone CR all behave. Treating \r as filler collapsed a CR-only file
+      // (some Excel export paths still emit them) into a single row, and
+      // the organizer got "faltan columnas obligatorias" — a message
+      // pointing at entirely the wrong cause.
+      endRow();
+      i += text[i + 1] === "\n" ? 2 : 1;
     } else {
       field += c;
       i++;
@@ -154,6 +160,7 @@ export function parseBevyCsv(text: string): ParseBevyCsvResult {
   let skippedNoTicket = 0;
   let skippedNoEmail = 0;
   let skippedBadEmail = 0;
+  let skippedNoName = 0;
   let duplicates = 0;
 
   for (const raw of table.slice(1)) {
@@ -175,6 +182,15 @@ export function parseBevyCsv(text: string): ParseBevyCsvResult {
     // 300-row import failed" into "one row was skipped, here's how many".
     if (!EMAIL_RE.test(email)) {
       skippedBadEmail++;
+      continue;
+    }
+    // REQUIRED only proves the name COLUMNS exist. A row with both name
+    // cells blank imports fine, produces no name tokens, and renders as an
+    // empty line that cannot be found by typing the person's surname —
+    // which is the entire job of the search box. Every other skip reason
+    // warns; this one used to pass silently.
+    if (!cell(raw, "firstName") && !cell(raw, "lastName")) {
+      skippedNoName++;
       continue;
     }
     if (seenTickets.has(ticketNumber)) {
@@ -208,6 +224,12 @@ export function parseBevyCsv(text: string): ParseBevyCsvResult {
   if (skippedBadEmail > 0) {
     warnings.push(
       `${skippedBadEmail} fila(s) con un email mal formado fueron omitidas.`
+    );
+  }
+  if (skippedNoName > 0) {
+    warnings.push(
+      `${skippedNoName} fila(s) sin nombre ni apellido fueron omitidas: ` +
+        `no se podría buscarlas por nombre en la puerta.`
     );
   }
   if (duplicates > 0) {

--- a/src/components/react/admin/checkin/types.ts
+++ b/src/components/react/admin/checkin/types.ts
@@ -1,0 +1,34 @@
+export interface Attendee {
+  /** Firestore document ID: `t_${ticketNumber}`. */
+  id: string;
+  ticketNumber: string;
+  orderNumber: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  company: string;
+  title: string;
+  ticketTitle: string;
+  searchTokens: string[];
+  /** When Bevy itself has them checked in. Null for almost everyone. */
+  bevyCheckinAt: Date | null;
+  lastImportId: string;
+
+  checkedIn: boolean;
+  checkedInAt: Date | null;
+  checkedInBy: string | null;
+  checkedInByName: string | null;
+  note: string | null;
+
+  dniVerified: boolean;
+
+  /** True while this row's write is still queued in the local cache. */
+  pending: boolean;
+}
+
+export interface CheckinMeta {
+  lastImportId: string | null;
+  lastImportAt: Date | null;
+  lastImportByName: string | null;
+  rosterCount: number;
+}

--- a/src/components/react/admin/checkin/useRoster.ts
+++ b/src/components/react/admin/checkin/useRoster.ts
@@ -7,8 +7,23 @@ interface State {
   meta: CheckinMeta | null;
   loading: boolean;
   error: string | null;
-  /** Snapshot served from the local cache — i.e. we are offline. */
-  fromCache: boolean;
+  /**
+   * True only when we believe we are actually disconnected.
+   *
+   * NOT the same as snapshot.metadata.fromCache. With persistence enabled
+   * Firestore serves a cached snapshot on every load before the server
+   * responds, so fromCache alone flags a perfectly healthy page as offline.
+   */
+  offline: boolean;
+  /** True once a server-backed snapshot has arrived at least once. */
+  syncedOnce: boolean;
+  /**
+   * Import metadata failed to load. Kept separate from `error` because the
+   * roster itself is still usable — it only means the "ya no está en el
+   * CSV" badges cannot be computed, which is worth saying out loud rather
+   * than letting the feature quietly do nothing.
+   */
+  metaError: string | null;
   /** Rows whose write has not reached the server yet. */
   pendingCount: number;
 }
@@ -34,7 +49,9 @@ export function useRoster(slug: string | null): State {
     meta: null,
     loading: true,
     error: null,
-    fromCache: false,
+    offline: false,
+    syncedOnce: false,
+    metaError: null,
     pendingCount: 0,
   });
 
@@ -63,7 +80,12 @@ export function useRoster(slug: string | null): State {
           { includeMetadataChanges: true },
           (snap) => {
             const attendees = snap.docs.map((d) => {
-              const data = d.data();
+              // "estimate" resolves a still-pending serverTimestamp() to the
+              // local clock instead of null. With the default ("none") a
+              // just-marked attendee showed "✓ Presente" with no time and no
+              // volunteer name until the server acked — which on venue wifi,
+              // the whole reason this feature exists, can be the entire event.
+              const data = d.data({ serverTimestamps: "estimate" });
               return {
                 id: d.id,
                 ticketNumber: data.ticketNumber ?? "",
@@ -94,17 +116,38 @@ export function useRoster(slug: string | null): State {
               )
             );
 
-            setState((s) => ({
-              ...s,
-              attendees,
-              loading: false,
-              error: null,
-              fromCache: snap.metadata.fromCache,
-              pendingCount: attendees.filter((a) => a.pending).length,
-            }));
+            setState((s) => {
+              // A server-backed snapshot is the only proof we are online.
+              // Before the first one arrives, fromCache just means the cache
+              // answered first — treat that as still loading, not offline,
+              // or a cold cache renders "this roster is empty" for an event
+              // that is fully populated server-side and invites a re-import.
+              const syncedOnce = s.syncedOnce || !snap.metadata.fromCache;
+              return {
+                ...s,
+                attendees,
+                loading: !syncedOnce && attendees.length === 0,
+                error: null,
+                syncedOnce,
+                offline: snap.metadata.fromCache && syncedOnce,
+                pendingCount: attendees.filter((a) => a.pending).length,
+              };
+            });
           },
           (err) => {
-            setState((s) => ({ ...s, loading: false, error: err.message }));
+            // Firestore does not re-attach a listener after an error, so
+            // this state is terminal until remount. Clear the roster: on a
+            // permission error (role revoked mid-event) the cached snapshot
+            // would otherwise stay on screen, fully tappable, behind a
+            // banner, with every tap rejected and nothing else updating.
+            setState((s) => ({
+              ...s,
+              attendees: [],
+              loading: false,
+              offline: false,
+              pendingCount: 0,
+              error: err.message,
+            }));
           }
         );
 
@@ -124,9 +167,17 @@ export function useRoster(slug: string | null): State {
                 : null,
             }));
           },
-          // A missing meta doc is normal before the first import, so a
-          // failure here must not blank out a working roster.
-          () => {}
+          // The previous comment here claimed this guarded a missing meta
+          // doc before the first import. That was wrong: a non-existent
+          // document goes to the SUCCESS callback with exists === false,
+          // which the branch above already handles. So a no-op only ever
+          // swallowed real errors, and `meta` staying null silently
+          // disables the "ya no está en el CSV" badge the import handler
+          // depends on. Record it instead of hiding it — but keep it out of
+          // `error`, which would blank a perfectly working roster.
+          (err) => {
+            setState((s) => ({ ...s, metaError: err.message }));
+          }
         );
       } catch (err) {
         setState((s) => ({

--- a/src/components/react/admin/checkin/useRoster.ts
+++ b/src/components/react/admin/checkin/useRoster.ts
@@ -117,19 +117,29 @@ export function useRoster(slug: string | null): State {
             );
 
             setState((s) => {
-              // A server-backed snapshot is the only proof we are online.
-              // Before the first one arrives, fromCache just means the cache
-              // answered first — treat that as still loading, not offline,
-              // or a cold cache renders "this roster is empty" for an event
-              // that is fully populated server-side and invites a re-import.
+              // A server-backed snapshot is the only proof we reached the
+              // server. Before the first one, fromCache is ambiguous: it
+              // means either "the cache answered first while online" or
+              // "we are offline and this is all we have".
               const syncedOnce = s.syncedOnce || !snap.metadata.fromCache;
+
+              // navigator.onLine breaks the tie. Without it, a volunteer who
+              // opens the panel at the venue with no signal but a warm cache
+              // sees a green "Sincronizado" bar — the one situation the
+              // offline indicator exists for.
+              const disconnected =
+                typeof navigator !== "undefined" && !navigator.onLine;
+
               return {
                 ...s,
                 attendees,
-                loading: !syncedOnce && attendees.length === 0,
+                // Any snapshot means we have something to render. Whether
+                // an empty roster is real or just unsynced is decided by
+                // syncedOnce, not by holding a spinner up indefinitely.
+                loading: false,
                 error: null,
                 syncedOnce,
-                offline: snap.metadata.fromCache && syncedOnce,
+                offline: snap.metadata.fromCache && (syncedOnce || disconnected),
                 pendingCount: attendees.filter((a) => a.pending).length,
               };
             });
@@ -157,6 +167,9 @@ export function useRoster(slug: string | null): State {
             const data = snap.data();
             setState((s) => ({
               ...s,
+              // Cleared on recovery: a latched banner that contradicts a
+              // working UI underneath is worse than no banner at all.
+              metaError: null,
               meta: data
                 ? {
                     lastImportId: data.lastImportId ?? null,

--- a/src/components/react/admin/checkin/useRoster.ts
+++ b/src/components/react/admin/checkin/useRoster.ts
@@ -1,0 +1,183 @@
+import { useEffect, useState } from "react";
+import { getFirestore } from "@/lib/firebase";
+import type { Attendee, CheckinMeta } from "./types";
+
+interface State {
+  attendees: Attendee[];
+  meta: CheckinMeta | null;
+  loading: boolean;
+  error: string | null;
+  /** Snapshot served from the local cache — i.e. we are offline. */
+  fromCache: boolean;
+  /** Rows whose write has not reached the server yet. */
+  pendingCount: number;
+}
+
+const toDate = (v: unknown): Date | null => {
+  if (!v) return null;
+  if (v instanceof Date) return v;
+  const ts = v as { toDate?: () => Date };
+  return typeof ts.toDate === "function" ? ts.toDate() : null;
+};
+
+/**
+ * Subscribes to events/{slug}/roster in real time so several volunteers
+ * working the door see the same state.
+ *
+ * Follows the same lazy-import + `cancelled` flag shape as the public
+ * event islands (see ../../event/useLiveMinigames.ts), with one addition:
+ * `includeMetadataChanges`, which the game hooks do not need.
+ */
+export function useRoster(slug: string | null): State {
+  const [state, setState] = useState<State>({
+    attendees: [],
+    meta: null,
+    loading: true,
+    error: null,
+    fromCache: false,
+    pendingCount: 0,
+  });
+
+  useEffect(() => {
+    if (!slug) {
+      setState((s) => ({ ...s, loading: false }));
+      return;
+    }
+    let unsubRoster: (() => void) | null = null;
+    let unsubMeta: (() => void) | null = null;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const db = await getFirestore();
+        const { collection, doc, onSnapshot } = await import(
+          "firebase/firestore"
+        );
+        if (cancelled) return;
+
+        unsubRoster = onSnapshot(
+          collection(db, `events/${slug}/roster`),
+          // Without this the pending -> committed transition fires no
+          // callback, so the "sin conexión" badge would stick forever
+          // after the writes have actually landed.
+          { includeMetadataChanges: true },
+          (snap) => {
+            const attendees = snap.docs.map((d) => {
+              const data = d.data();
+              return {
+                id: d.id,
+                ticketNumber: data.ticketNumber ?? "",
+                orderNumber: data.orderNumber ?? "",
+                firstName: data.firstName ?? "",
+                lastName: data.lastName ?? "",
+                email: data.email ?? "",
+                company: data.company ?? "",
+                title: data.title ?? "",
+                ticketTitle: data.ticketTitle ?? "",
+                searchTokens: data.searchTokens ?? [],
+                bevyCheckinAt: toDate(data.bevyCheckinAt),
+                lastImportId: data.lastImportId ?? "",
+                checkedIn: data.checkedIn === true,
+                checkedInAt: toDate(data.checkedInAt),
+                checkedInBy: data.checkedInBy ?? null,
+                checkedInByName: data.checkedInByName ?? null,
+                note: data.note ?? null,
+                dniVerified: data.dniVerified === true,
+                pending: d.metadata.hasPendingWrites,
+              } satisfies Attendee;
+            });
+
+            attendees.sort((a, b) =>
+              `${a.firstName} ${a.lastName}`.localeCompare(
+                `${b.firstName} ${b.lastName}`,
+                "es"
+              )
+            );
+
+            setState((s) => ({
+              ...s,
+              attendees,
+              loading: false,
+              error: null,
+              fromCache: snap.metadata.fromCache,
+              pendingCount: attendees.filter((a) => a.pending).length,
+            }));
+          },
+          (err) => {
+            setState((s) => ({ ...s, loading: false, error: err.message }));
+          }
+        );
+
+        unsubMeta = onSnapshot(
+          doc(db, `events/${slug}/checkinMeta/current`),
+          (snap) => {
+            const data = snap.data();
+            setState((s) => ({
+              ...s,
+              meta: data
+                ? {
+                    lastImportId: data.lastImportId ?? null,
+                    lastImportAt: toDate(data.lastImportAt),
+                    lastImportByName: data.lastImportByName ?? null,
+                    rosterCount: data.rosterCount ?? 0,
+                  }
+                : null,
+            }));
+          },
+          // A missing meta doc is normal before the first import, so a
+          // failure here must not blank out a working roster.
+          () => {}
+        );
+      } catch (err) {
+        setState((s) => ({
+          ...s,
+          loading: false,
+          error: err instanceof Error ? err.message : "Listener error",
+        }));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (unsubRoster) unsubRoster();
+      if (unsubMeta) unsubMeta();
+    };
+  }, [slug]);
+
+  return state;
+}
+
+/**
+ * Toggles a check-in.
+ *
+ * Deliberately NOT awaited by callers: while offline, updateDoc's promise
+ * does not settle until the connection returns. The local cache fires a
+ * snapshot immediately, so the row flips instantly either way; `onError`
+ * exists for the rules-rejection path, which surfaces only on reconnect
+ * and would otherwise silently revert a row minutes later.
+ */
+export async function setCheckedIn(
+  slug: string,
+  attendeeId: string,
+  checkedIn: boolean,
+  by: { uid: string; name: string },
+  onError: (message: string) => void
+): Promise<void> {
+  try {
+    const db = await getFirestore();
+    const { doc, updateDoc, serverTimestamp } = await import(
+      "firebase/firestore"
+    );
+    void updateDoc(doc(db, `events/${slug}/roster/${attendeeId}`), {
+      checkedIn,
+      checkedInAt: checkedIn ? serverTimestamp() : null,
+      // The rules require attribution when marking present.
+      checkedInBy: checkedIn ? by.uid : null,
+      checkedInByName: checkedIn ? by.name : null,
+    }).catch((err) => {
+      onError(err instanceof Error ? err.message : "No se pudo guardar");
+    });
+  } catch (err) {
+    onError(err instanceof Error ? err.message : "No se pudo guardar");
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -200,6 +200,7 @@ const realApi = {
       created: number;
       updated: number;
       stale: number;
+      unusableTickets: number;
     }>("POST", `/events/${encodeURIComponent(slug)}/checkin/import`, { rows }),
 
   // Rebuild

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -190,6 +190,18 @@ const realApi = {
       results: { email: string; name: string; ok: boolean; error?: string }[];
     }>("POST", "/certificates/send", data),
 
+  // On-site check-in. Only the roster import goes through the API —
+  // volunteers toggle check-in directly against Firestore so the write
+  // survives a venue wifi drop.
+  importCheckinRoster: (slug: string, rows: unknown[]) =>
+    request<{
+      importId: string;
+      total: number;
+      created: number;
+      updated: number;
+      stale: number;
+    }>("POST", `/events/${encodeURIComponent(slug)}/checkin/import`, { rows }),
+
   // Rebuild
   triggerRebuild: () => request("POST", "/rebuild"),
 };

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -60,6 +60,22 @@ export async function getFirestore() {
       // The multi-tab manager is not optional — a second tab otherwise
       // fails to take the IndexedDB lock and silently degrades to an
       // in-memory cache, which would drop queued check-ins.
+      //
+      // Known tradeoff, considered and accepted: this caches whatever the
+      // page subscribes to on disk, and the SDK does not clear it on sign
+      // out. On /admin/checkin that includes attendee names and emails.
+      // Reading the roster already requires the organizer role, so this
+      // crosses no privilege boundary — the exposure is someone with
+      // physical access to an unlocked profile, who on a venue phone is
+      // typically another organizer. Clearing it in signOut() via
+      // terminate() + clearIndexedDbPersistence() is possible, but it also
+      // discards check-ins still queued offline, which is worse mid-event.
+      //
+      // Persistence is deliberately NOT behind a per-caller opt-in.
+      // getUserRole() in ./auth.ts calls this helper on every admin page
+      // before the panel mounts, so a first-caller-wins flag would let it
+      // initialize the memory cache and silently disable the offline queue
+      // this whole feature depends on.
       let db: import("firebase/firestore").Firestore;
       try {
         db = initializeFirestore(app, {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -17,6 +17,14 @@ function getApp() {
         ? initializeApp(firebaseConfig)
         : getApps()[0];
     })();
+    // Same reasoning as the reset in getFirestore below: memoizing a promise
+    // memoizes its rejection too. This is the FIRST chunk loaded, so without
+    // a reset here a single failed import("firebase/app") on flaky wifi
+    // poisons getAuth() and getFirestore() alike for the page's lifetime —
+    // clearing only the db slot would rebuild it around the same dead app.
+    _appPromise.catch(() => {
+      _appPromise = null;
+    });
   }
   return _appPromise;
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -23,7 +23,7 @@ function getApp() {
 
 const USE_EMULATOR = import.meta.env.PUBLIC_USE_FIREBASE_EMULATOR === "true";
 let _authEmulatorConnected = false;
-let _firestoreEmulatorConnected = false;
+let _dbPromise: Promise<import("firebase/firestore").Firestore> | null = null;
 
 export async function getAuth() {
   const app = await getApp();
@@ -40,16 +40,47 @@ export async function getAuth() {
   return auth;
 }
 
+// Memoized: initializeFirestore() must be the first Firestore call on the
+// app instance, and it throws "already started" on the second. Memoizing
+// the db promise (not just the app) is what guarantees it runs once.
 export async function getFirestore() {
-  const app = await getApp();
-  const { getFirestore: firebaseGetFirestore, connectFirestoreEmulator } =
-    await import("firebase/firestore");
-  const db = firebaseGetFirestore(app);
-  if (USE_EMULATOR && !_firestoreEmulatorConnected) {
-    connectFirestoreEmulator(db, "127.0.0.1", 8080);
-    _firestoreEmulatorConnected = true;
+  if (!_dbPromise) {
+    _dbPromise = (async () => {
+      const app = await getApp();
+      const {
+        initializeFirestore,
+        getFirestore: firebaseGetFirestore,
+        persistentLocalCache,
+        persistentMultipleTabManager,
+        connectFirestoreEmulator,
+      } = await import("firebase/firestore");
+
+      // Offline persistence keeps the check-in panel usable on venue wifi:
+      // the SDK queues writes in IndexedDB and replays them on reconnect.
+      // The multi-tab manager is not optional — a second tab otherwise
+      // fails to take the IndexedDB lock and silently degrades to an
+      // in-memory cache, which would drop queued check-ins.
+      let db;
+      try {
+        db = initializeFirestore(app, {
+          localCache: persistentLocalCache({
+            tabManager: persistentMultipleTabManager(),
+          }),
+        });
+      } catch {
+        // Throws in Safari private mode (no IndexedDB) and if something
+        // already started Firestore. This helper is on the critical path
+        // for the public mini-game islands, so degrade instead of break.
+        db = firebaseGetFirestore(app);
+      }
+
+      if (USE_EMULATOR) {
+        connectFirestoreEmulator(db, "127.0.0.1", 8080);
+      }
+      return db;
+    })();
   }
-  return db;
+  return _dbPromise;
 }
 
 // Used by the public event island in PR4. No-ops when there is already

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -60,7 +60,7 @@ export async function getFirestore() {
       // The multi-tab manager is not optional — a second tab otherwise
       // fails to take the IndexedDB lock and silently degrades to an
       // in-memory cache, which would drop queued check-ins.
-      let db;
+      let db: import("firebase/firestore").Firestore;
       try {
         db = initializeFirestore(app, {
           localCache: persistentLocalCache({
@@ -79,6 +79,16 @@ export async function getFirestore() {
       }
       return db;
     })();
+
+    // Memoizing a promise also memoizes its rejection. Without this, one
+    // transient failure (a chunk that fails to load on flaky wifi) would
+    // leave every later call rejecting for the lifetime of the page —
+    // permanently breaking the public mini-game islands that share this
+    // helper. Clearing the slot lets the next caller retry, which is how
+    // this behaved before it was memoized.
+    _dbPromise.catch(() => {
+      _dbPromise = null;
+    });
   }
   return _dbPromise;
 }

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -96,5 +96,14 @@ export const mockApi = {
     });
   },
 
+  importCheckinRoster: (_slug: string, rows: unknown[]) =>
+    ok({
+      importId: "imp_mock",
+      total: rows.length,
+      created: rows.length,
+      updated: 0,
+      stale: 0,
+    }),
+
   triggerRebuild: () => ok(null),
 };

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -103,6 +103,7 @@ export const mockApi = {
       created: rows.length,
       updated: 0,
       stale: 0,
+      unusableTickets: 0,
     }),
 
   triggerRebuild: () => ok(null),

--- a/src/pages/admin/checkin/index.astro
+++ b/src/pages/admin/checkin/index.astro
@@ -1,0 +1,8 @@
+---
+import AdminLayout from "@/layouts/AdminLayout.astro";
+import { AdminApp } from "@/components/react/admin/AdminApp";
+---
+
+<AdminLayout title="Check-in">
+  <AdminApp client:load page="checkin" currentPath="/admin/checkin" />
+</AdminLayout>

--- a/tests/rules/checkin-roster.test.ts
+++ b/tests/rules/checkin-roster.test.ts
@@ -1,0 +1,263 @@
+import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
+import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
+import { deleteDoc, doc, getDoc, setDoc, updateDoc } from "firebase/firestore";
+import { cleanup, clearAll, getTestEnv } from "./setup";
+
+const SLUG = "devfest-ica-2026";
+const ATTENDEE = `events/${SLUG}/roster/t_GOOGA263171317`;
+
+/** Seeds a users/{uid} doc with the given role, bypassing rules. */
+async function seedRole(uid: string, role: string) {
+  const env = await getTestEnv();
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), `users/${uid}`), { uid, role });
+  });
+}
+
+/** Seeds a roster doc the way the import Cloud Function would. */
+async function seedAttendee(over: Record<string, unknown> = {}) {
+  const env = await getTestEnv();
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), ATTENDEE), {
+      ticketNumber: "GOOGA263171317",
+      firstName: "Alex Alberto",
+      lastName: "Quintanilla Garcia",
+      email: "wcandry@gmail.com",
+      bevyCheckinAt: null,
+      checkedIn: false,
+      checkedInAt: null,
+      checkedInBy: null,
+      checkedInByName: null,
+      note: null,
+      dniVerified: false,
+      ...over,
+    });
+  });
+}
+
+describe("checkin roster rules", () => {
+  beforeAll(async () => {
+    await getTestEnv();
+  });
+  afterEach(async () => {
+    await clearAll();
+  });
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  describe("read access", () => {
+    it("denies anonymous reads — the roster holds attendee emails", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      const anon = env.unauthenticatedContext().firestore();
+      await assertFails(getDoc(doc(anon, ATTENDEE)));
+    });
+
+    it("denies a signed-in member (public read on events/ must not cascade)", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("member-1", "member");
+      const member = env.authenticatedContext("member-1").firestore();
+      await assertFails(getDoc(doc(member, ATTENDEE)));
+    });
+
+    it("denies a signed-in user with no users/ doc at all", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      const ghost = env.authenticatedContext("ghost").firestore();
+      await assertFails(getDoc(doc(ghost, ATTENDEE)));
+    });
+
+    it("allows an organizer", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertSucceeds(getDoc(doc(org, ATTENDEE)));
+    });
+
+    it("allows an admin", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("adm-1", "admin");
+      const adm = env.authenticatedContext("adm-1").firestore();
+      await assertSucceeds(getDoc(doc(adm, ATTENDEE)));
+    });
+  });
+
+  describe("check-in writes", () => {
+    it("allows an organizer to mark someone present", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertSucceeds(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInAt: new Date(),
+          checkedInBy: "org-1",
+          checkedInByName: "Alvaro",
+        })
+      );
+    });
+
+    it("allows un-checking without attribution", async () => {
+      const env = await getTestEnv();
+      await seedAttendee({ checkedIn: true, checkedInBy: "org-1" });
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertSucceeds(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: false,
+          checkedInAt: null,
+          checkedInBy: null,
+        })
+      );
+    });
+
+    it("denies a member marking someone present", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("member-1", "member");
+      const member = env.authenticatedContext("member-1").firestore();
+      await assertFails(
+        updateDoc(doc(member, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "member-1",
+        })
+      );
+    });
+
+    it("denies attributing a check-in to somebody else", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "someone-else",
+        })
+      );
+    });
+  });
+
+  describe("roster fields are immutable from the client", () => {
+    it("denies rewriting the attendee email", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), { email: "attacker@evil.com" })
+      );
+    });
+
+    it("denies rewriting the name", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(updateDoc(doc(org, ATTENDEE), { firstName: "Otro" }));
+    });
+
+    it("denies faking bevyCheckinAt, which the Bevy sync diffs against", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), { bevyCheckinAt: new Date() })
+      );
+    });
+
+    it("denies smuggling a roster field alongside a valid check-in", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "org-1",
+          email: "attacker@evil.com",
+        })
+      );
+    });
+
+    it("denies a non-boolean checkedIn", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), { checkedIn: "yes", checkedInBy: "org-1" })
+      );
+    });
+
+    it("denies an over-long note", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "org-1",
+          note: "x".repeat(201),
+        })
+      );
+    });
+  });
+
+  describe("create and delete are Admin SDK only", () => {
+    it("denies an organizer creating a roster doc directly", async () => {
+      const env = await getTestEnv();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        setDoc(doc(org, `events/${SLUG}/roster/t_FAKE`), {
+          ticketNumber: "FAKE",
+          email: "x@x.com",
+          checkedIn: false,
+        })
+      );
+    });
+
+    it("denies an admin deleting a roster doc", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("adm-1", "admin");
+      const adm = env.authenticatedContext("adm-1").firestore();
+      await assertFails(deleteDoc(doc(adm, ATTENDEE)));
+    });
+  });
+
+  describe("checkinMeta", () => {
+    it("allows an organizer to read import metadata", async () => {
+      const env = await getTestEnv();
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), `events/${SLUG}/checkinMeta/current`), {
+          rosterCount: 34,
+        });
+      });
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertSucceeds(
+        getDoc(doc(org, `events/${SLUG}/checkinMeta/current`))
+      );
+    });
+
+    it("denies client writes to import metadata", async () => {
+      const env = await getTestEnv();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        setDoc(doc(org, `events/${SLUG}/checkinMeta/current`), {
+          rosterCount: 999,
+        })
+      );
+    });
+  });
+});

--- a/tests/rules/checkin-roster.test.ts
+++ b/tests/rules/checkin-roster.test.ts
@@ -69,6 +69,46 @@ describe("checkin roster rules", () => {
       await assertFails(getDoc(doc(ghost, ATTENDEE)));
     });
 
+    // The full chain an outsider would actually attempt. The public event
+    // pages mint anonymous Firebase tokens (signInAnonymouslyIfNeeded), so
+    // request.auth != null is free to anyone who loads the site. The
+    // pre-existing users/ rule then lets them self-register — capped at
+    // role "member". This asserts the two halves compose safely: a real
+    // token plus a real users/ doc still must not reach attendee PII.
+    it("denies an anonymous user who self-registers as member", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      const anonUid = "anon-visitor";
+      const anon = env.authenticatedContext(anonUid).firestore();
+
+      // Goes through the real rule, not withSecurityRulesDisabled — if
+      // this ever starts failing, self-registration changed and the
+      // premise of the test needs revisiting.
+      await assertSucceeds(
+        setDoc(doc(anon, `users/${anonUid}`), {
+          uid: anonUid,
+          email: "",
+          displayName: "",
+          photoURL: "",
+          role: "member",
+        })
+      );
+
+      await assertFails(getDoc(doc(anon, ATTENDEE)));
+    });
+
+    it("denies self-escalation to organizer to reach the roster", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("climber", "member");
+      const climber = env.authenticatedContext("climber").firestore();
+      // users/ denies update outright, so the role cannot be raised.
+      await assertFails(
+        updateDoc(doc(climber, "users/climber"), { role: "organizer" })
+      );
+      await assertFails(getDoc(doc(climber, ATTENDEE)));
+    });
+
     it("allows an organizer", async () => {
       const env = await getTestEnv();
       await seedAttendee();

--- a/tests/rules/checkin-roster.test.ts
+++ b/tests/rules/checkin-roster.test.ts
@@ -126,6 +126,105 @@ describe("checkin roster rules", () => {
     });
   });
 
+  describe("first check-in on a freshly imported document", () => {
+    /**
+     * Seeds a document exactly as importRoster leaves it: roster fields
+     * only, with NO checkedIn/checkedInAt/checkedInBy keys at all.
+     */
+    async function seedImportedOnly() {
+      const env = await getTestEnv();
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), ATTENDEE), {
+          ticketNumber: "GOOGA263171317",
+          firstName: "Alex Alberto",
+          lastName: "Quintanilla Garcia",
+          email: "wcandry@gmail.com",
+          searchTokens: ["alex", "quintanilla"],
+          bevyCheckinAt: null,
+          lastImportId: "imp_1",
+        });
+      });
+    }
+
+    // The import deliberately writes no check-in fields, so the very first
+    // check-in ADDS those keys rather than changing them. Every other test
+    // seeds them up front, which would keep passing even if a future rules
+    // edit started requiring them to pre-exist — and that would break every
+    // first check-in in production while the suite stayed green.
+    it("allows an organizer to add the check-in keys", async () => {
+      const env = await getTestEnv();
+      await seedImportedOnly();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertSucceeds(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInAt: new Date(),
+          checkedInBy: "org-1",
+          checkedInByName: "Alvaro",
+        })
+      );
+    });
+
+    it("still rejects a roster field smuggled into that first write", async () => {
+      const env = await getTestEnv();
+      await seedImportedOnly();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "org-1",
+          email: "attacker@evil.com",
+        })
+      );
+    });
+  });
+
+  describe("bounds on the remaining allowlisted fields", () => {
+    it("rejects an over-long checkedInByName", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "org-1",
+          checkedInByName: "x".repeat(121),
+        })
+      );
+    });
+
+    it("rejects a dniMatchScore outside 0..1", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "org-1",
+          dniMatchScore: 7,
+        })
+      );
+    });
+
+    it("rejects a non-boolean dniVerified", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "org-1",
+          dniVerified: "yes",
+        })
+      );
+    });
+  });
+
   describe("check-in writes", () => {
     it("allows an organizer to mark someone present", async () => {
       const env = await getTestEnv();


### PR DESCRIPTION
## What changed

Adds `/admin/checkin`, an admin page where volunteers check attendees in by name or email instead of scanning each person's Bevy QR code. Several volunteers work the same roster from their phones in real time, and taps survive a venue wifi drop.

Also adds a CSV export shaped for Bevy's "Bulk upload attendees" dialog, so the event can be reconciled back into Bevy afterwards.

**11 commits, meant to be read in order.** The `feat:` commits build the feature; the `fix:` commits apply findings from three review rounds and are worth reading for the reasoning.

## Why

Today check-in requires each attendee to find the QR code Bevy emailed them so a volunteer can scan it with the Bevy app. That queues people at the door: many cannot find the email, have no mobile data, or arrive with a dead battery.

This inverts the flow — the volunteer has the roster on screen and the attendee just says their name. Bevy goes stale during the event and is reconciled in batch afterwards, because Bevy exposes no check-in API.

## Where to focus review

**`src/lib/firebase.ts` is the risky change.** It is on the critical path for the public mini-game islands, not just the admin panel, so a bug there breaks the event for anonymous attendees. It enables Firestore offline persistence and memoizes the db promise, because `initializeFirestore` must be the first Firestore call on the app instance.

Three design decisions worth a second opinion:

- **One document per attendee, not a single roster doc.** With a single doc, two volunteers who are both offline each write the full array, last-write-wins, and one check-in is silently lost.
- **Volunteers write straight to Firestore, not through a Cloud Function.** Only a direct write can be queued in the local cache and replayed when wifi drops. The trade-off is that `firestore.rules` carries the whole authorization burden, so `hasOnly()` pins volunteers to the check-in fields.
- **The import writes no check-in fields at all, not even defaults.** Absence reads as "not checked in" on both the client and in the rules, which makes "an import can never disturb a check-in" structural rather than conditional on a prior existence read that two concurrent imports could race.

## Review history

Three rounds ran against this branch. Recorded because the pattern is informative, not for credit:

| Round | Found | Notable |
|---|---|---|
| `code-review high` | 5 | Search missed hyphenated surnames; a memoized promise cached its own rejection |
| `security-review` | 0 | No HIGH/MEDIUM vulnerabilities. The one candidate — attendee PII in IndexedDB — was filed as a hardening gap, since reading the roster already requires the organizer role |
| `code-review max` | 15 | Two findings were regressions introduced by the previous round's fixes |

The most valuable finding came from reading the real CSV, not the code: `parseBevyDate` was built against `Jul 06, 2026 - 03:10 PM`, which is what the Bevy **dashboard renders**. The **export writes** `2026-07-06 20:10:16+00:00`. Every genuinely checked-in registrant would have parsed to null and the sync would have silently believed nobody was checked in. Both formats are now accepted.

## How to test

```bash
npm test               # 248 passed
npm run test:functions # 111 passed
npm run test:rules     # 66 passed — real rules, via @firebase/rules-unit-testing
npm run lint && npm run build
```

Manual, with emulators running:

1. Open `/admin/checkin?slug=devfest-ica-2026` and import a Bevy registrations CSV.
2. Search without accents — `nanez` finds `Ñañez`, `qui gar` finds `Quintanilla Garcia`, and a full email containing `+` or `_` finds its owner.
3. Mark 3 people present, then re-import the same CSV. All 3 must still be present, with timestamp and attribution intact.
4. DevTools → Network offline. Mark someone: the amber "N cambios en cola" bar appears and the row flips immediately. Reconnect and confirm it syncs.
5. Open a second browser as a different organizer and confirm check-ins appear without refreshing.
6. Click "Exportar para Bevy" and check the CSV contains only people marked present.

### Verified against production data

The import was exercised end-to-end against a real Firestore emulator using the actual DevFest Ica 2026 export (34 registrations) — **30 assertions, all passing**. Covers re-import preserving check-ins, a cancelled-but-already-checked-in attendee, ticket numbers that sanitize to the same document ID, and the concurrent-import race.

## Open items — neither blocks merge

- **Bevy's bulk upload semantics are unknown.** The modal says "add to this event" but the template carries a `checked_in` column. The dialog's own "Validate file" step (`nothing is imported until you confirm`) resolves this without writing anything — but it should be run against a throwaway event, since the bad outcome is a duplicated roster. If it updates, phase 2 is finished; if it duplicates, a Playwright skill clicks the boxes one by one, searching by email (verified unique across the roster; the table shows no ticket number column).
- **`initializeFirestore`'s try/catch may not fire for Safari private mode**, where IndexedDB is acquired asynchronously. Unconfirmed — the `firebase` package is not installed at the repo root — so it was deliberately left untouched rather than changed on a hypothesis.

## Dropped from the original plan

The planned DNI lookup (Cloud Function proxying a Peruvian DNI API, token in Secrets, rate limiting, Jaccard name matching) is **not built and is not recommended**. It would return a name from a DNI, which then needs fuzzy-matching against self-typed Bevy names — adding a paid dependency and personal-data handling under Ley 29733 to reach a name the attendee can simply say out loud. Search by name and email covers the need; email disambiguates homonyms.