### PR TITLE
fix(api): return a legible 403 for blocked origins and stop breaking the rate limiter

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -2487,9 +2487,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,9 +2504,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2527,9 +2521,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2547,9 +2538,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2567,9 +2555,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2587,9 +2572,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7761,9 +7743,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7785,9 +7764,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7809,9 +7785,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7833,9 +7806,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,10 +1,12 @@
 import * as admin from "firebase-admin";
+import { logger } from "firebase-functions";
 import { onRequest } from "firebase-functions/v2/https";
 import express from "express";
 import cors from "cors";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { GITHUB_TOKEN, GMAIL_USER, GMAIL_APP_PASSWORD } from "./config";
 import { requireRole, requireAuth } from "./middleware/auth";
+import { isAllowedOrigin, rejectDisallowedOrigin } from "./middleware/cors";
 import { validateParamId } from "./middleware/validate";
 import { validateBody } from "./middleware/validateBody";
 import {
@@ -41,30 +43,28 @@ import * as checkin from "./handlers/checkin";
 
 admin.initializeApp();
 
-const ALLOWED_ORIGINS = [
-  "https://gdgica.com",
-  "https://appgdgica.web.app",
-  "https://appgdgica.firebaseapp.com",
-  "http://localhost:4321",
-];
-
 const app = express();
 // Firebase Hosting + Cloud Functions sits behind exactly one Google
 // Frontend hop, so trust a single proxy. Setting `true` would let
 // callers spoof X-Forwarded-For and bypass IP-based rate limiting.
 app.set("trust proxy", 1);
+
+// Registered BEFORE cors(), which answers OPTIONS itself and never calls
+// next() — anything after it would be dead code for preflight. See the
+// note in middleware/cors.ts for what this does and does not cover.
+app.use(rejectDisallowedOrigin);
 app.use(
   cors({
-    origin: (origin, callback) => {
-      if (!origin || ALLOWED_ORIGINS.includes(origin)) {
-        callback(null, true);
-      } else {
-        callback(new Error("Not allowed by CORS"));
-      }
-    },
+    // Disallowed origins were already answered with 403 above, so this
+    // only decides which headers to attach for callers let through.
+    origin: (origin, callback) =>
+      callback(null, !origin || isAllowedOrigin(origin)),
   })
 );
 app.use(express.json({ limit: "1mb" }));
+
+// Latched so the warning below fires once per cold start, not per request.
+let warnedMissingIp = false;
 
 // Outer perimeter limit: large window, generous cap. Protects against
 // raw IP floods that haven't yet been authenticated.
@@ -74,6 +74,30 @@ app.use(
     max: 300,
     standardHeaders: true,
     legacyHeaders: false,
+    // Skip rather than fall back to a shared key. Keying every caller
+    // into one bucket would turn an undefined req.ip into a global 429
+    // for everyone after 300 requests — including the check-in panel
+    // mid-event. Losing the perimeter limit is the milder failure: the
+    // per-uid writeLimiter still guards every expensive route.
+    //
+    // Announced once per cold start rather than per request: skipping is
+    // a real weakening of the outer defence, and the previous behaviour
+    // at least made noise (it threw ERR_ERL_UNDEFINED_IP_ADDRESS, which
+    // is how this was noticed). Silence here would mean the API serves
+    // unlimited unauthenticated traffic with nothing saying so.
+    skip: (req) => {
+      if (req.ip) return false;
+      if (!warnedMissingIp) {
+        warnedMissingIp = true;
+        logger.warn(
+          "req.ip is undefined; perimeter rate limit is being skipped. " +
+            "Check the proxy configuration — the per-uid writeLimiter is " +
+            "still active."
+        );
+      }
+      return true;
+    },
+    keyGenerator: (req) => `ip:${ipKeyGenerator(req.ip as string)}`,
     message: { success: false, error: "Too many requests, try again later" },
   })
 );

--- a/functions/src/middleware/cors.test.ts
+++ b/functions/src/middleware/cors.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Request, Response } from "express";
+
+vi.mock("firebase-functions", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+import { ALLOWED_ORIGINS, isAllowedOrigin, rejectDisallowedOrigin } from "./cors";
+
+const ORIGINAL = process.env.FUNCTIONS_EMULATOR;
+
+function asEmulator() {
+  process.env.FUNCTIONS_EMULATOR = "true";
+}
+function asProduction() {
+  delete process.env.FUNCTIONS_EMULATOR;
+}
+
+beforeEach(() => asProduction());
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.FUNCTIONS_EMULATOR;
+  else process.env.FUNCTIONS_EMULATOR = ORIGINAL;
+});
+
+describe("isAllowedOrigin — production", () => {
+  it.each(ALLOWED_ORIGINS)("accepts the deployed origin %s", (origin) => {
+    expect(isAllowedOrigin(origin)).toBe(true);
+  });
+
+  // The whole point of gating the loopback bypass. If this ever passes,
+  // any page served from a developer machine — or anything that can bind
+  // a local port on a visitor's box — can call the production API.
+  it.each([
+    "http://localhost:9999",
+    "http://localhost:4322",
+    "http://127.0.0.1:4321",
+    "http://[::1]:4321",
+  ])("rejects loopback origin %s outside the emulator", (origin) => {
+    expect(isAllowedOrigin(origin)).toBe(false);
+  });
+
+  it.each([
+    "https://evil.example.com",
+    "http://gdgica.com", // http, not https
+    "https://gdgica.com.evil.example",
+    "https://sub.gdgica.com",
+    "null",
+    "",
+  ])("rejects %j", (origin) => {
+    expect(isAllowedOrigin(origin)).toBe(false);
+  });
+});
+
+describe("isAllowedOrigin — emulator", () => {
+  beforeEach(() => asEmulator());
+
+  // Astro moves to the next free port when 4321 is taken, and some
+  // machines resolve localhost to IPv6. Pinning one origin meant every
+  // API call failed with no usable diagnostic.
+  it.each([
+    "http://localhost:4321",
+    "http://localhost:4324",
+    "http://localhost",
+    "http://127.0.0.1:5173",
+    "http://[::1]:4321",
+  ])("accepts loopback origin %s", (origin) => {
+    expect(isAllowedOrigin(origin)).toBe(true);
+  });
+
+  it("still rejects a non-loopback origin", () => {
+    expect(isAllowedOrigin("https://evil.example.com")).toBe(false);
+  });
+
+  it("does not accept https loopback, which we never serve", () => {
+    expect(isAllowedOrigin("https://localhost:4321")).toBe(false);
+  });
+
+  it("does not accept a host merely containing localhost", () => {
+    expect(isAllowedOrigin("http://localhost.evil.example")).toBe(false);
+    expect(isAllowedOrigin("http://notlocalhost:4321")).toBe(false);
+  });
+});
+
+describe("rejectDisallowedOrigin", () => {
+  function mockRes() {
+    const res = { statusCode: 0, body: null as unknown } as unknown as Response;
+    (res as unknown as { status: (c: number) => Response }).status = (c) => {
+      (res as unknown as { statusCode: number }).statusCode = c;
+      return res;
+    };
+    (res as unknown as { json: (b: unknown) => Response }).json = (b) => {
+      (res as unknown as { body: unknown }).body = b;
+      return res;
+    };
+    return res as Response & { statusCode: number; body: { error?: string } };
+  }
+  const reqWith = (origin?: string) =>
+    ({ headers: origin ? { origin } : {} }) as unknown as Request;
+
+  it("answers 403 with the offending origin instead of a bare 500", () => {
+    const res = mockRes();
+    const next = vi.fn();
+    rejectDisallowedOrigin(reqWith("https://evil.example.com"), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error).toContain("https://evil.example.com");
+  });
+
+  it("lets an allowed origin through", () => {
+    const res = mockRes();
+    const next = vi.fn();
+    rejectDisallowedOrigin(reqWith("https://gdgica.com"), res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(0);
+  });
+
+  // curl, server-to-server calls and health checks send no Origin. They
+  // were never subject to CORS and must not start failing now.
+  it("lets a request with no Origin header through", () => {
+    const res = mockRes();
+    const next = vi.fn();
+    rejectDisallowedOrigin(reqWith(), res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  // Origin is caller-controlled and unbounded, and it is echoed into both
+  // the body and the log. Without a cap, a caller can inflate responses
+  // and Cloud Logging entries at will, one large string per request.
+  it("truncates an oversized origin instead of echoing it whole", () => {
+    const res = mockRes();
+    const huge = `https://${"a".repeat(5000)}.example.com`;
+    rejectDisallowedOrigin(reqWith(huge), res, vi.fn());
+
+    expect(res.statusCode).toBe(403);
+    const message = res.body.error ?? "";
+    expect(message.length).toBeLessThan(300);
+    expect(message).toContain("…");
+  });
+
+  // If express ever does start seeing preflight, this must keep holding.
+  // Today something upstream answers OPTIONS before we run — see the note
+  // on rejectDisallowedOrigin — so this pins the unit behaviour only.
+  it("rejects a preflight from a disallowed origin", () => {
+    const res = mockRes();
+    const next = vi.fn();
+    const req = {
+      method: "OPTIONS",
+      headers: { origin: "https://evil.example.com" },
+    } as unknown as Request;
+    rejectDisallowedOrigin(req, res, next);
+    expect(res.statusCode).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/middleware/cors.ts
+++ b/functions/src/middleware/cors.ts
@@ -1,0 +1,87 @@
+import { Request, Response, NextFunction } from "express";
+import { logger } from "firebase-functions";
+
+export const ALLOWED_ORIGINS = [
+  "https://gdgica.com",
+  "https://appgdgica.web.app",
+  "https://appgdgica.firebaseapp.com",
+  "http://localhost:4321",
+];
+
+// Any loopback host, with or without a port. Astro moves to the next free
+// port when 4321 is taken (a second dev server, a leftover process), and
+// some machines resolve localhost to IPv6, so the browser sends
+// http://[::1]:4321. Pinning a single origin meant every API call failed
+// and the only symptom was an opaque error.
+const LOCALHOST_RE = /^http:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/;
+
+/**
+ * Read at call time rather than captured at module load, so tests can
+ * exercise both sides of the branch. FUNCTIONS_EMULATOR is set by the
+ * emulator itself and never exists in a deployed function.
+ */
+function isEmulator(): boolean {
+  return process.env.FUNCTIONS_EMULATOR === "true";
+}
+
+/**
+ * The deployed allowlist is exactly ALLOWED_ORIGINS. The loopback bypass
+ * is gated on the emulator, so a development convenience can never widen
+ * what production accepts.
+ */
+export function isAllowedOrigin(origin: string): boolean {
+  if (ALLOWED_ORIGINS.includes(origin)) return true;
+  return isEmulator() && LOCALHOST_RE.test(origin);
+}
+
+// Origin is caller-controlled and unbounded. It is echoed back to make the
+// failure diagnosable, so cap it: otherwise a caller can inflate response
+// bodies and log entries at will, one large string per request.
+const MAX_ECHOED_ORIGIN = 200;
+
+const truncate = (s: string) =>
+  s.length <= MAX_ECHOED_ORIGIN ? s : `${s.slice(0, MAX_ECHOED_ORIGIN)}…`;
+
+/**
+ * Rejects disallowed origins with a legible 403, replacing an opaque 500.
+ *
+ * Registered BEFORE cors(), which defaults to preflightContinue: false and
+ * so answers OPTIONS itself without calling next(). Anything after it is
+ * dead code for a preflight.
+ *
+ * SCOPE, measured rather than assumed: running first is still not enough
+ * to cover preflight. Against the emulator, an OPTIONS from a disallowed
+ * origin returns 204 and this middleware's log line never fires — the
+ * function is invoked, so the request arrives, but something ahead of the
+ * express app answers it. So:
+ *
+ *   - simple requests get the 403;
+ *   - preflighted ones (every POST with a JSON body) still surface to the
+ *     caller as a generic browser CORS message.
+ *
+ * Security is unaffected either way: Access-Control-Allow-Origin is
+ * attached only for allowed origins, so the browser blocks the real
+ * request regardless. The gap is diagnostics. Closing it means moving the
+ * check above express — into the onRequest/Hosting layer — not reordering
+ * middleware here, which has already been tried.
+ *
+ * Requests with no Origin header (server-to-server, curl, health checks)
+ * pass through untouched, matching the cors() configuration.
+ */
+export function rejectDisallowedOrigin(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const origin = req.headers.origin;
+  if (origin && !isAllowedOrigin(origin)) {
+    const shown = truncate(origin);
+    logger.warn("Blocked request from disallowed origin", { origin: shown });
+    res.status(403).json({
+      success: false,
+      error: `Origen no permitido: ${shown}`,
+    });
+    return;
+  }
+  next();
+}


### PR DESCRIPTION
## What changed

Three problems found while running the app locally against the Firebase emulators and a real browser. None blocks a feature; two cost a debugging session to whoever hits them.

Split out of #277 (the check-in panel), where they were originally fixed in passing. They touch a security policy, so they belong in their own reviewable change with tests. Rebased on top of #277 now that it has merged.

### 1. A blocked origin returned 500 instead of a reason

`cors()` was handed an `Error`, which it forwards to express's default handler — so the caller saw a bare `Error 500` with nothing pointing at the origin, the actual cause. A dedicated middleware now answers **403 naming the origin**, and logs it. The echoed origin is truncated at 200 characters, since it is caller-controlled and unbounded.

**Scope, measured rather than assumed:** this covers simple requests, not preflight. See the limitation below.

### 2. The perimeter rate limiter threw on every request under the emulator

It had no `keyGenerator`, so it used `req.ip` and raised `ERR_ERL_UNDEFINED_IP_ADDRESS` when that was undefined.

Fixed by **skipping** the limit when there is no IP, rather than falling back to a shared key. Collapsing every caller into one bucket would turn an undefined `req.ip` into a global 429 for everyone after 300 requests — including the check-in panel mid-event.

Skipping is a real weakening of the outer defence, so it announces itself once per cold start. The previous behaviour at least made noise, which is how this was noticed; silent degradation would be worse than the bug.

### 3. The localhost allowlist pinned one port

Astro moves to the next free port when 4321 is taken, and some machines resolve localhost to IPv6 and send `http://[::1]:4321`. Any loopback origin is now accepted — **only under the emulator**, so the deployed allowlist stays exactly the four production origins.

## Known limitation: preflight does not get the 403

The middleware runs before `cors()` precisely so preflight would be covered — `cors` defaults to `preflightContinue: false` and answers `OPTIONS` without calling `next()`.

**Measured against the emulator, that is not enough.** An `OPTIONS` from a disallowed origin returns `204`, and this middleware's log line never fires for it. Something ahead of the express app answers the preflight; the function is invoked, so the request arrives, but express never sees it.

- **Security is unaffected.** `Access-Control-Allow-Origin` is attached only for allowed origins (verified), so a browser still blocks the real request.
- **The diagnostic win is partial.** Simple requests get the 403; preflighted ones still surface as a generic browser CORS message. Better than an opaque 500, but not the full goal.

Closing the gap means moving the check above express, into the `onRequest`/Hosting layer — not reordering middleware, which has already been tried. This is recorded in the code so the next attempt does not repeat it.

## Where to focus review

**The security boundary is `isEmulator()`.** Everything else is diagnostics. The loopback bypass must be inert in production, and the tests pin exactly that: every loopback origin is rejected unless `FUNCTIONS_EMULATOR === "true"`.

It reads `process.env` at call time rather than capturing it at module load — so tests can exercise both branches, and so the value cannot be frozen before the runtime populates it.

Worth a second opinion on the rate limiter trade-off: `skip` preserves availability at the cost of the perimeter limit in a scenario that should not happen behind Firebase Hosting. The alternative — a shared bucket — trades a silent global outage for a limit that still nominally works.

## How to test

```bash
cd functions && npm test   # 138 passed, 27 of them in middleware/cors.test.ts
npm run lint && npm run build
```

Measured against the emulator, on the rebased branch (so the same `index.ts` that carries the check-in route):

| request | result |
|---|---|
| `GET` + `Origin: https://evil.example.com` | **403** `Origen no permitido: https://evil.example.com` |
| `GET` + a 3000-character `Origin` | 403, response body 252 bytes — truncated |
| `OPTIONS` + `Origin: https://evil.example.com` | 204, no `ACAO` — browser blocks, but no 403 (see limitation) |
| `GET` + `Origin: http://localhost:4324` | passes CORS with `ACAO`, 401 for the missing token |
| `POST /api/events/:slug/checkin/import` | 401 — the route from #277 is intact after the rebase |
| `GET`, no `Origin` | unaffected, 401 |

`ERR_ERL_UNDEFINED_IP_ADDRESS` and `Not allowed by CORS` no longer appear in the emulator log; exactly two blocked-origin warnings do.