### PR TITLE
fix(bingo): server-verify the win instead of trusting the client

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -13,6 +13,24 @@ service cloud.firestore {
       return request.auth != null && callerRole() in ['organizer', 'admin'];
     }
 
+    // True when the 16-cell bingo card `m` (row-major) has a fully marked
+    // row, column or diagonal. Mirrors ALL_LINES in src/lib/bingo.ts.
+    // Rules cannot loop, so the ten lines are spelled out. Only reached
+    // when bingoMarked is already asserted to be a 16-element list, so the
+    // fixed indexing is safe.
+    function bingoHasLine(m) {
+      return (m[0] && m[1] && m[2] && m[3])
+          || (m[4] && m[5] && m[6] && m[7])
+          || (m[8] && m[9] && m[10] && m[11])
+          || (m[12] && m[13] && m[14] && m[15])
+          || (m[0] && m[4] && m[8] && m[12])
+          || (m[1] && m[5] && m[9] && m[13])
+          || (m[2] && m[6] && m[10] && m[14])
+          || (m[3] && m[7] && m[11] && m[15])
+          || (m[0] && m[5] && m[10] && m[15])
+          || (m[3] && m[6] && m[9] && m[12]);
+    }
+
     match /users/{userId} {
       allow read: if request.auth != null && request.auth.uid == userId;
       allow create: if request.auth != null
@@ -61,7 +79,21 @@ service cloud.firestore {
                                      'quizScore', 'quizAnsweredQuestions'])
                         && (!('bingoMarked' in request.resource.data)
                             || (request.resource.data.bingoMarked is list
-                                && request.resource.data.bingoMarked.size() == 16));
+                                && request.resource.data.bingoMarked.size() == 16))
+                        // A win is server-verified, not self-reported. Only
+                        // gate the write that actually SETS bingoWonAt (it
+                        // is in affectedKeys then); later marking that keeps
+                        // the same win value passes untouched. Without this,
+                        // any participant could open the console and write
+                        // bingoWonAt with an empty card.
+                        && (!request.resource.data.diff(resource.data)
+                              .affectedKeys().hasAny(['bingoWonAt'])
+                            || (request.resource.data.bingoMarked is list
+                                && request.resource.data.bingoMarked.size() == 16
+                                && bingoHasLine(request.resource.data.bingoMarked)
+                                // Pin to server time so a cheater cannot
+                                // backdate the win to jump the winners queue.
+                                && request.resource.data.bingoWonAt == request.time));
           allow delete: if false;
         }
         match /responses/{responseId} {

--- a/tests/rules/bingo-win.test.ts
+++ b/tests/rules/bingo-win.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
+import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
+import { doc, serverTimestamp, setDoc, Timestamp } from "firebase/firestore";
+import { cleanup, clearAll, getTestEnv } from "./setup";
+
+const SLUG = "devfest-2025";
+const INSTANCE_ID = "bingo-A";
+const UID = "player-1";
+const PATH = `events/${SLUG}/minigames/${INSTANCE_ID}/participants/${UID}`;
+
+// A bingo card is 16 cells row-major; the win lines are the 4 rows, 4
+// columns and 2 diagonals. These tests defend the property that a win is
+// server-verified: bingoWonAt may only be set when bingoMarked genuinely
+// contains a completed line, and only with the server's own timestamp.
+const marks = (...on: number[]) => {
+  const a = Array.from({ length: 16 }, () => false);
+  for (const i of on) a[i] = true;
+  return a;
+};
+const ROW0 = marks(0, 1, 2, 3);
+const COL0 = marks(0, 4, 8, 12);
+const DIAG = marks(0, 5, 10, 15);
+const NO_LINE = marks(0, 1, 6, 11); // scattered, no full line
+const EMPTY = marks();
+
+/** Seeds the participant doc exactly as the join Cloud Function leaves it:
+ *  identity + card, and NO check-in / win fields. */
+async function seedParticipant() {
+  const env = await getTestEnv();
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), PATH), {
+      uid: UID,
+      alias: "Jugador",
+      joinedAt: 0,
+      bingoCard: Array.from({ length: 16 }, (_, i) => `term-${i}`),
+    });
+  });
+}
+
+let env2: Awaited<ReturnType<typeof getTestEnv>>;
+const asPlayer = () => env2.authenticatedContext(UID).firestore();
+
+describe("firestore.rules — bingo win verification", () => {
+  beforeAll(async () => {
+    env2 = await getTestEnv();
+  });
+  afterEach(async () => {
+    await clearAll();
+  });
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  describe("marking without claiming a win", () => {
+    it("allows marking any cell (no bingoWonAt in the write)", async () => {
+      await seedParticipant();
+      const db = asPlayer();
+      await assertSucceeds(
+        setDoc(doc(db, PATH), { bingoMarked: NO_LINE }, { merge: true })
+      );
+    });
+
+    it("rejects a bingoMarked that is not 16 cells", async () => {
+      await seedParticipant();
+      const db = asPlayer();
+      await assertFails(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: marks(0).slice(0, 8) },
+          { merge: true }
+        )
+      );
+    });
+  });
+
+  describe("claiming a win — must be a real, server-timed line", () => {
+    it("allows a win on a completed row", async () => {
+      await seedParticipant();
+      const db = asPlayer();
+      await assertSucceeds(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: ROW0, bingoWonAt: serverTimestamp() },
+          { merge: true }
+        )
+      );
+    });
+
+    it("allows a win on a completed column and on a diagonal", async () => {
+      await seedParticipant();
+      const db = asPlayer();
+      await assertSucceeds(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: COL0, bingoWonAt: serverTimestamp() },
+          { merge: true }
+        )
+      );
+      await assertSucceeds(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: DIAG, bingoWonAt: serverTimestamp() },
+          { merge: true }
+        )
+      );
+    });
+
+    // The core exploit: opening the console and declaring victory.
+    it("rejects a win with no completed line", async () => {
+      await seedParticipant();
+      const db = asPlayer();
+      await assertFails(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: NO_LINE, bingoWonAt: serverTimestamp() },
+          { merge: true }
+        )
+      );
+    });
+
+    it("rejects a win on an entirely empty card", async () => {
+      await seedParticipant();
+      const db = asPlayer();
+      await assertFails(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: EMPTY, bingoWonAt: serverTimestamp() },
+          { merge: true }
+        )
+      );
+    });
+
+    // Winners are ordered by bingoWonAt, so a backdated client timestamp
+    // would jump the queue. The win must carry the server's own time.
+    it("rejects a real line with a backdated client timestamp", async () => {
+      await seedParticipant();
+      const db = asPlayer();
+      await assertFails(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: ROW0, bingoWonAt: Timestamp.fromMillis(1000) },
+          { merge: true }
+        )
+      );
+    });
+  });
+
+  describe("play continues after a legitimate win", () => {
+    /** Seeds a participant who has already legitimately won on ROW0. */
+    async function seedWinner() {
+      const env = await getTestEnv();
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), PATH), {
+          uid: UID,
+          alias: "Jugador",
+          joinedAt: 0,
+          bingoCard: Array.from({ length: 16 }, (_, i) => `term-${i}`),
+          bingoMarked: ROW0,
+          bingoWonAt: Timestamp.fromMillis(5000),
+        });
+      });
+    }
+
+    it("allows marking more cells (bingoWonAt unchanged)", async () => {
+      await seedWinner();
+      const db = asPlayer();
+      await assertSucceeds(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: marks(0, 1, 2, 3, 4) },
+          { merge: true }
+        )
+      );
+    });
+
+    it("allows un-marking a cell after winning, keeping the win", async () => {
+      await seedWinner();
+      const db = asPlayer();
+      // Breaks the line, but bingoWonAt is not re-written, so it stands.
+      await assertSucceeds(
+        setDoc(doc(db, PATH), { bingoMarked: marks(1, 2, 3) }, { merge: true })
+      );
+    });
+
+    it("rejects overwriting an existing win with a new backdated time", async () => {
+      await seedWinner();
+      const db = asPlayer();
+      await assertFails(
+        setDoc(
+          doc(db, PATH),
+          { bingoWonAt: Timestamp.fromMillis(1) },
+          { merge: true }
+        )
+      );
+    });
+  });
+
+  describe("a player cannot touch another player's card", () => {
+    it("rejects writing to a different participant's doc", async () => {
+      await seedParticipant();
+      const other = env2.authenticatedContext("player-2").firestore();
+      await assertFails(
+        setDoc(doc(other, PATH), { bingoMarked: ROW0 }, { merge: true })
+      );
+    });
+  });
+});

--- a/tests/rules/minigame-instances.test.ts
+++ b/tests/rules/minigame-instances.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
 import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
-import { deleteDoc, doc, getDoc, setDoc } from "firebase/firestore";
+import {
+  deleteDoc,
+  doc,
+  getDoc,
+  serverTimestamp,
+  setDoc,
+} from "firebase/firestore";
 import { cleanup, clearAll, getTestEnv } from "./setup";
 
 const SLUG = "devfest-2025";
@@ -292,10 +298,13 @@ describe("firestore.rules — PR5 bingo marking", () => {
     );
   });
 
-  it("allows setting bingoWonAt alongside bingoMarked", async () => {
+  it("allows setting bingoWonAt on a completed line with the server time", async () => {
     const env = await getTestEnv();
     await seedBingoState(env);
     const auth = env.authenticatedContext("user-1").firestore();
+    // A completed top row. The win must carry serverTimestamp(): the rule
+    // pins bingoWonAt to request.time so a win cannot be self-reported or
+    // backdated. Deeper coverage of that boundary lives in bingo-win.test.ts.
     const win = Array.from({ length: 16 }, (_, i) => i < 4);
     await assertSucceeds(
       setDoc(
@@ -303,7 +312,7 @@ describe("firestore.rules — PR5 bingo marking", () => {
           auth,
           `events/${SLUG}/minigames/${BINGO_INSTANCE_ID}/participants/user-1`
         ),
-        { bingoMarked: win, bingoWonAt: new Date() },
+        { bingoMarked: win, bingoWonAt: serverTimestamp() },
         { merge: true }
       )
     );


### PR DESCRIPTION
## What changed

Bingo declared the winner from the browser. `BingoCardView` writes `bingoWonAt` straight to Firestore, and the rules only checked that `bingoMarked` was a 16-element list — never that the marks formed a line. **Verified against the emulator with a real anonymous token: anyone could open the console and win with an empty card, or with scattered marks that form no line.**

The participant rule now accepts `bingoWonAt` only when:

- `bingoMarked` contains a real completed row, column or diagonal (`bingoHasLine`, spelling out the ten lines from `src/lib/bingo.ts` since rules cannot loop), and
- `bingoWonAt` equals the server time (`request.time`), so a cheater cannot backdate the win to jump the winners queue, which is ordered by that field.

The gate only applies to the write that actually **sets** `bingoWonAt` (when it is in `affectedKeys`). Marking and un-marking cells after winning do not re-write the field, so ongoing play is untouched. The quiz path, which shares this rule, is unaffected.

## How this was found and verified

This came out of an end-to-end E2E of the whole bingo flow against a live emulator, driving it with a real anonymous auth token through the actual security rules — the same path an attendee's browser takes.

**Confirmed working (honest flow):** join → card is unique per attendee, reproducible on rejoin, drawn from the same term bank → marking persists through the rules → win records → winners endpoint lists it.

**Confirmed blocked (the exploit), before and after the fix:**

| attempt | before | after |
|---|---|---|
| win with a completed line + server time | ✅ allowed | ✅ allowed |
| win with scattered marks, no line | ⚠️ **allowed** | 🚫 denied |
| win with an entirely empty card | ⚠️ **allowed** | 🚫 denied |
| real line but a backdated client timestamp | ⚠️ **allowed** | 🚫 denied |
| mark / un-mark after a legit win | ✅ allowed | ✅ allowed |

## Tests

`tests/rules/bingo-win.test.ts` — 11 new cases covering every row above plus the cross-player boundary. Run: `npm run test:rules` → 77 passed across 5 files.

One pre-existing test in `minigame-instances.test.ts` (`allows setting bingoWonAt alongside bingoMarked`) used a client `new Date()` to win; it now uses `serverTimestamp()`, matching the real client and the new rule. It broke for the right reason.

## Notes

- `serverTimestamp()` resolves to `request.time` during rule evaluation in both the emulator and production, so the time-pin is production-correct.
- The emulator logs a benign "evaluation error" line on the denied-cheat path; it is cosmetic, does not change the outcome, and every legitimate operation is asserted to succeed.
- Not addressed here (out of scope, low value for a friendly event): the marks themselves are still self-reported — nothing proves the speaker actually said the term. That is inherent to buzzword bingo and not a security boundary.