### PR TITLE
fix(minigames): drop the event-status gate on the participant island

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -557,13 +557,26 @@ const whatsappQrSvg = whatsappGroupLink
   </section>
 
   {
-    (event.data.status?.type === "in-progress" ||
-      event.data.status?.type === "upcoming") && (
-      <MiniGamesRoot
-        client:idle
-        slug={event.id}
-        eventStatus={event.data.status?.type}
-      />
-    )
+    /*
+     * Deliberately NOT gated on event.data.status. The only switch that
+     * decides whether anything renders is `state == "live"` on the Firestore
+     * instance, which the organizer flips from the admin panel and which
+     * takes effect instantly.
+     *
+     * Gating on the event status added a second, invisible condition that
+     * lives in the gdg-ica-data repo and needs a full site rebuild to
+     * change. Two consequences, both bad: a game could not be run on a
+     * `completed` event at all (so nothing could be rehearsed or replayed),
+     * and an event flipped to completed mid-session would rip the game off
+     * every attendee's phone with no way to put it back quickly.
+     *
+     * MiniGamesRoot renders null while no instance is live, so mounting it
+     * unconditionally is inert on events that have no games.
+     */
   }
+  <MiniGamesRoot
+    client:idle
+    slug={event.id}
+    eventStatus={event.data.status?.type}
+  />
 </Layout>


### PR DESCRIPTION
## What changed

Removed the `event.data.status?.type === "in-progress" || … === "upcoming"` condition wrapping `<MiniGamesRoot />` in `src/pages/events/[slug].astro`. The island now mounts on every event page, with a comment explaining why the gate is gone so nobody re-adds it.

Single file, 1 condition removed. No component or API changes.

## Why

A bingo attached to a `completed` event never rendered. The projector page has no such gate, so it happily showed the join QR — but that QR led to a participant page with no island at all: no anonymous sign-in, no Firestore listener, no join modal. Nothing on screen explained why, and the API logs showed the instance correctly `live` with no `POST /minigames/join` ever arriving.

The gate was a second, invisible condition stacked on the real one:

| | Controlled by | Lives in | Time to apply |
|---|---|---|---|
| Event status | `gdg-ica-data` repo | Static HTML | Full site rebuild |
| Instance state | Organizer, admin panel | Firestore | Instant |

`state == "live"` is the switch that is actually designed for this — it is the one an organizer flips mid-session. Event status cannot serve as a runtime switch: changing it means a push to the data repo plus a rebuild. Two concrete failures came out of coupling them:

- A game could not be run on a finished event at all, so nothing could be rehearsed or replayed after the fact.
- An event flipped to `completed` while a game was still open would have pulled it off every attendee's phone, with no quick way to bring it back.

`MiniGamesRoot` already returns `null` while no instance is live, so mounting it unconditionally is inert on events without games.

## How to test

1. `pnpm build`, then confirm the island now ships on finished events:
   ```
   grep -c MiniGamesRoot dist/events/devfest-2025/index.html
   ```
   Expect a match. On `main` this file contains no island at all.
2. End to end against a `completed` event: attach a bingo template in `/admin/events/minigames?slug=<slug>`, press **▶ Iniciar**, open `/events/<slug>/projector`, scan the QR. The alias modal should appear and a `POST /api/events/<slug>/minigames/join` should show up in the Cloud Run logs.
3. Regression — an event with no live instance must render nothing: open any event page and confirm no join modal and no "Participación en vivo" section.

`pnpm test` passes (250 tests, 23 files); `pnpm build` completes; eslint and prettier are clean.

## Follow-up, deliberately not in this PR

With the gate gone the island mounts on every event page, and `MiniGamesRoot` currently calls `signInAnonymouslyIfNeeded()` on mount — so every visitor to any event page now mints a throwaway Firebase anonymous account, including on pages that will never host a game. Reads on `minigames` are public in the rules, so the listener can run unauthenticated and sign-in can be deferred until `liveInstances.length > 0`. Happy to send that as a separate PR.