### PR TITLE
feat(content): add credential block to the events schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Pre-commit hooks run automatically via Husky + lint-staged (ESLint + Prettier on
 
 ## Architecture
 
-**Astro 5 static site** for the GDG ICA community (Spanish-language content). TailwindCSS 4 for styling, React 19 only for interactive islands.
+**Astro 7 static site** (default `output: "static"` — no adapter, so there are no SSR routes) for the GDG ICA community (Spanish-language content). TailwindCSS 4 for styling, React 19 only for interactive islands.
 
 ### Routing & Pages
 

--- a/functions/src/schemas/eventCredential.test.ts
+++ b/functions/src/schemas/eventCredential.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { eventSchema } from "./index";
+
+// The credential block is written by hand in the gdg-ica-data repo and
+// round-trips through /admin/events untouched (EventForm spreads the
+// loaded event into form state and back into the payload). eventSchema
+// is .strict(), so without an entry for it every save of a credential
+// -carrying event would 400. These tests pin that contract.
+
+const MINIMAL_EVENT = { id: "devfest-2026", title: "DevFest ICA 2026" };
+
+describe("eventSchema — credential block", () => {
+  it("accepts an event with no credential block at all", () => {
+    const r = eventSchema.safeParse({ ...MINIMAL_EVENT });
+    expect(r.success).toBe(true);
+    // Absent, not defaulted: every event published before this feature
+    // lacks the key, and materializing one would rewrite their JSON.
+    expect(r.success && r.data.credential).toBeUndefined();
+  });
+
+  it("accepts a fully specified credential block and preserves it", () => {
+    const r = eventSchema.safeParse({
+      ...MINIMAL_EVENT,
+      credential: {
+        enabled: true,
+        headline: "Soy parte del DevFest ICA 2026",
+        group_letters: ["A", "Q", "I", "C"],
+      },
+    });
+    expect(r.success).toBe(true);
+    expect(r.success && r.data.credential).toEqual({
+      enabled: true,
+      headline: "Soy parte del DevFest ICA 2026",
+      group_letters: ["A", "Q", "I", "C"],
+    });
+  });
+
+  it("fills credential defaults when the block is present but partial", () => {
+    const r = eventSchema.safeParse({
+      ...MINIMAL_EVENT,
+      credential: { headline: "Soy parte" },
+    });
+    expect(r.success).toBe(true);
+    expect(r.success && r.data.credential).toEqual({
+      enabled: false,
+      headline: "Soy parte",
+      group_letters: [],
+    });
+  });
+
+  it("rejects an unknown key inside credential", () => {
+    const r = eventSchema.safeParse({
+      ...MINIMAL_EVENT,
+      credential: { enabled: true, mascots: ["gopher"] },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a non-boolean enabled", () => {
+    const r = eventSchema.safeParse({
+      ...MINIMAL_EVENT,
+      credential: { enabled: "true" },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects group letters longer than two characters", () => {
+    const r = eventSchema.safeParse({
+      ...MINIMAL_EVENT,
+      credential: { enabled: true, group_letters: ["AAA"] },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects an empty group letter", () => {
+    const r = eventSchema.safeParse({
+      ...MINIMAL_EVENT,
+      credential: { enabled: true, group_letters: [""] },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("still rejects unknown top-level keys", () => {
+    const r = eventSchema.safeParse({ ...MINIMAL_EVENT, credencial: {} });
+    expect(r.success).toBe(false);
+  });
+});

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -51,6 +51,14 @@ export const trackSessionSchema = z
   })
   .strict();
 
+export const credentialConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    headline: shortText(200).default(""),
+    group_letters: z.array(shortText(2).min(1)).max(26).default([]),
+  })
+  .strict();
+
 export const eventSchema = z
   .object({
     id: safeId,
@@ -85,6 +93,16 @@ export const eventSchema = z
     track_sessions: z
       .record(shortText(100), z.array(trackSessionSchema).max(200))
       .default({}),
+    // Opt-in for the shareable attendee credential page. This schema is
+    // .strict() and updateEvent writes { ...req.body } straight to the
+    // data repo, while EventForm loads with { ...EMPTY_EVENT, ...data }
+    // and submits { ...form } — a runtime spread, so an unknown key read
+    // from the JSON survives into form state and back out on save.
+    // Without this entry the first event whose JSON carries `credential`
+    // becomes uneditable in /admin/events with a 400. Optional, not
+    // defaulted: a default would write the key into every event the
+    // admin panel touches.
+    credential: credentialConfigSchema.optional(),
   })
   .strict();
 

--- a/src/components/react/admin/events/EventForm.tsx
+++ b/src/components/react/admin/events/EventForm.tsx
@@ -110,6 +110,16 @@ interface EventData {
   agenda: AgendaItem[];
   tracks: TrackDef[];
   track_sessions: Record<string, TrackSession[]>;
+  // Configured in the data repo, not editable here. Declared so the
+  // load/save round-trip preserves it deliberately rather than by
+  // accident of the `{ ...data }` / `{ ...form }` spreads — dropping it
+  // on save would silently disable the credential page for that event.
+  // Deliberately absent from EMPTY_EVENT so new events omit the key.
+  credential?: {
+    enabled: boolean;
+    headline: string;
+    group_letters: string[];
+  };
 }
 
 const EMPTY_EVENT: EventData = {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -103,6 +103,21 @@ const events = defineCollection({
         alt: z.string(),
       })
     ),
+    // Opt-in per event for the shareable attendee credential page at
+    // /events/{slug}/credencial. Optional rather than defaulted: every
+    // event published before this feature lacks the key entirely, and a
+    // default would claim the feature exists where it does not — the
+    // page's getStaticPaths reads `enabled` to decide the route exists
+    // at all.
+    credential: z
+      .object({
+        enabled: z.boolean(),
+        headline: z.string(),
+        // Cycled round-robin over the registration sequence to split
+        // attendees into on-site groups.
+        groupLetters: z.array(z.string().min(1).max(2)).min(1).max(26),
+      })
+      .optional(),
   }),
 });
 

--- a/src/loaders/__tests__/transform-events.test.ts
+++ b/src/loaders/__tests__/transform-events.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Only fetchGdgData is stubbed; the real stripDomain / formatSpanishDate /
+// expandCategory / expandStatus keep running, so this exercises the actual
+// transform rather than a hollowed-out copy of it.
+const mocks = vi.hoisted(() => ({ fetchGdgData: vi.fn() }));
+
+vi.mock("../fetch-gdg-data", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../fetch-gdg-data")>();
+  return { ...actual, fetchGdgData: mocks.fetchGdgData };
+});
+
+import { loadEvents } from "../transform-events";
+
+const BASE_EVENT = {
+  id: "devfest-2026",
+  title: "DevFest ICA 2026",
+  description: "",
+  short_description: "",
+  date: "2026-11-21T09:00:00",
+  end_time: "2026-11-21T18:00:00",
+  venue: "",
+  venue_address: "",
+  venue_map_url: "",
+  image_url: "",
+  topics: [],
+  speaker_names: [],
+  speaker_ids: [],
+  registration_url: null,
+  is_virtual: false,
+  is_highlight: false,
+  participants: 0,
+  max_participants: 350,
+  category: "devfest",
+  status: "upcoming",
+  materials: {},
+  requirements: [],
+  includes: [],
+  agenda: [],
+};
+
+/** Wires the two index fetches plus one event detail fetch. */
+function stubDataRepo(event: Record<string, unknown>) {
+  mocks.fetchGdgData.mockImplementation((path: string) => {
+    if (path === "events/index.json")
+      return Promise.resolve([{ id: event.id }]);
+    if (path === "speakers/index.json") return Promise.resolve([]);
+    return Promise.resolve(event);
+  });
+}
+
+describe("loadEvents — credential block", () => {
+  beforeEach(() => {
+    mocks.fetchGdgData.mockReset();
+  });
+
+  it("leaves credential undefined when the event JSON omits it", async () => {
+    stubDataRepo(BASE_EVENT);
+    const [event] = await loadEvents();
+    // Undefined rather than a disabled stub: the content schema marks it
+    // .optional(), and getStaticPaths treats absence as "no such route".
+    expect(event.credential).toBeUndefined();
+  });
+
+  it("maps group_letters to groupLetters and passes the rest through", async () => {
+    stubDataRepo({
+      ...BASE_EVENT,
+      credential: {
+        enabled: true,
+        headline: "Soy parte del DevFest ICA 2026",
+        group_letters: ["A", "Q", "I", "C"],
+      },
+    });
+    const [event] = await loadEvents();
+    expect(event.credential).toEqual({
+      enabled: true,
+      headline: "Soy parte del DevFest ICA 2026",
+      groupLetters: ["A", "Q", "I", "C"],
+    });
+  });
+
+  it("defaults enabled to false when the block omits it", async () => {
+    stubDataRepo({ ...BASE_EVENT, credential: { headline: "Hola" } });
+    const [event] = await loadEvents();
+    expect(event.credential?.enabled).toBe(false);
+  });
+
+  it("derives a headline from the event title when none is given", async () => {
+    stubDataRepo({ ...BASE_EVENT, credential: { enabled: true } });
+    const [event] = await loadEvents();
+    expect(event.credential?.headline).toBe("Soy parte de DevFest ICA 2026");
+  });
+
+  it("falls back to default letters when group_letters is empty", async () => {
+    stubDataRepo({
+      ...BASE_EVENT,
+      credential: { enabled: true, group_letters: [] },
+    });
+    const [event] = await loadEvents();
+    // An empty array would make letterForSequence divide by zero, so the
+    // loader never lets one reach the schema.
+    expect(event.credential?.groupLetters).toEqual(["A", "B", "C", "D"]);
+  });
+});

--- a/src/loaders/transform-events.ts
+++ b/src/loaders/transform-events.ts
@@ -64,6 +64,11 @@ interface ExternalEvent {
     }[]
   >;
   sponsors?: { id: string; image_url: string; alt: string }[];
+  credential?: {
+    enabled?: boolean;
+    headline?: string;
+    group_letters?: string[];
+  };
 }
 
 interface ExternalSpeaker {
@@ -162,6 +167,22 @@ function transformEvent(
     schedule,
     speakers,
     sponsors,
+    credential: buildCredential(event),
+  };
+}
+
+// Undefined — not a disabled stub — when the event carries no credential
+// block, so the schema's `.optional()` is what distinguishes "this event
+// has no credential feature" from "it has one and it is off".
+function buildCredential(event: ExternalEvent) {
+  if (!event.credential) return undefined;
+
+  return {
+    enabled: event.credential.enabled ?? false,
+    headline: event.credential.headline || `Soy parte de ${event.title}`,
+    groupLetters: event.credential.group_letters?.length
+      ? event.credential.group_letters
+      : ["A", "B", "C", "D"],
   };
 }
 


### PR DESCRIPTION
## What changed

Adds an optional `credential` block to the events schema across the three places an event passes through:

- `src/loaders/transform-events.ts` — maps `group_letters` (snake_case, matching its neighbours in the data repo) to `groupLetters`, with defaults for `enabled` and `headline`.
- `src/content.config.ts` — declares it `.optional()`, not `.default()`.
- `functions/src/schemas/index.ts` — new `credentialConfigSchema` plus the matching entry in `eventSchema`.

Also declares `credential` on the `EventData` interface (optional, deliberately absent from `EMPTY_EVENT`) and corrects `CLAUDE.md`, which said Astro 5 while the repo runs 7.1.1.

## Why

The functions schema entry is the load-bearing part. `eventSchema` is `.strict()`, `updateEvent` writes `{ ...req.body, id }` straight to the data repo, and `EventForm` loads with `{ ...EMPTY_EVENT, ...data }` and saves with `{ ...form }`. Those are runtime spreads, so an unknown key read from the JSON **survives into form state and back out into the payload**.

Without this entry, the first event whose JSON carries `credential` becomes **uneditable in `/admin/events` with a 400**. That is a hard break, not a silent drop — which is why this must be deployed before the block lands in `gdg-ica-data`.

Optional rather than defaulted because every event published before this feature lacks the key, and materialising a default would rewrite their JSON and claim the feature exists where it does not.

## How to test

```bash
pnpm test            # includes src/loaders/__tests__/transform-events.test.ts
pnpm test:functions  # includes functions/src/schemas/eventCredential.test.ts
pnpm build
```

The loader tests stub only `fetchGdgData`, so the real `stripDomain` / `formatSpanishDate` / `expandCategory` keep running. They cover: `undefined` when the JSON omits the block, snake_case to camelCase mapping, and all three defaults.

The schema tests cover: accepting and preserving a full block, filling partial defaults, rejecting an unknown key inside `credential`, rejecting group letters longer than two characters, and still rejecting unknown top-level keys.