### PR TITLE
feat(functions): add credential data model and utilities

### DIFF
--- a/functions/src/schemas/credentials.test.ts
+++ b/functions/src/schemas/credentials.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import {
+  credentialBevyStatusSchema,
+  credentialCreateSchema,
+  credentialPhotoModerationSchema,
+  MAX_PHOTO_DATAURL_CHARS,
+} from "./credentials";
+
+const JPEG = "data:image/jpeg;base64,/9j/4AAQSkZJRg==";
+
+const VALID = {
+  firstName: "Alvaro",
+  lastName: "Pena",
+  dni: "12345678",
+  email: "Alvaro@Example.com",
+  company: "Shinkansen",
+  githubUsername: "aalvaropc",
+  heardAbout: "redes_sociales",
+  heardAboutOther: "",
+  yearsExperience: "3_5",
+  googleToolsLevel: "intermedia",
+  consentGdgTerms: true,
+  consentGooglePrivacy: true,
+  consentCodeOfConduct: true,
+  consentDataProcessing: true,
+  consentAgeAttested: true,
+  consentPolicyVersion: "2026-08-01",
+  avatarKind: "mascot",
+  mascotId: "gdg-blue-1",
+  photoDataUrl: null,
+  credentialImageDataUrl: JPEG,
+};
+
+/** Returns the dotted path of the first issue, for path assertions. */
+function firstIssuePath(input: unknown): string {
+  const r = credentialCreateSchema.safeParse(input);
+  if (r.success) throw new Error("expected a validation failure");
+  return r.error.issues[0].path.join(".");
+}
+
+describe("credentialCreateSchema", () => {
+  it("accepts a valid mascot submission", () => {
+    expect(credentialCreateSchema.safeParse(VALID).success).toBe(true);
+  });
+
+  it("lowercases the email so it can key reconciliation", () => {
+    const r = credentialCreateSchema.safeParse(VALID);
+    expect(r.success && r.data.email).toBe("alvaro@example.com");
+  });
+
+  it("rejects an unknown key", () => {
+    const r = credentialCreateSchema.safeParse({ ...VALID, nickname: "al" });
+    expect(r.success).toBe(false);
+  });
+
+  describe("consent", () => {
+    const CONSENTS = [
+      "consentGdgTerms",
+      "consentGooglePrivacy",
+      "consentCodeOfConduct",
+      "consentDataProcessing",
+      "consentAgeAttested",
+    ] as const;
+
+    it.each(CONSENTS)("rejects %s when explicitly false", (key) => {
+      const r = credentialCreateSchema.safeParse({ ...VALID, [key]: false });
+      expect(r.success).toBe(false);
+    });
+
+    it.each(CONSENTS)("rejects %s when absent", (key) => {
+      const input: Record<string, unknown> = { ...VALID };
+      delete input[key];
+      expect(credentialCreateSchema.safeParse(input).success).toBe(false);
+    });
+
+    it.each(CONSENTS)(
+      "reports %s on its own path so the UI can map it",
+      (key) => {
+        // A z.literal(true) failure the client cannot trace back to a
+        // specific checkbox is a dead end for the user.
+        expect(firstIssuePath({ ...VALID, [key]: false })).toBe(key);
+      }
+    );
+
+    it("rejects an unknown policy version", () => {
+      const r = credentialCreateSchema.safeParse({
+        ...VALID,
+        consentPolicyVersion: "2020-01-01",
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe("dni", () => {
+    it("accepts exactly eight digits", () => {
+      expect(
+        credentialCreateSchema.safeParse({ ...VALID, dni: "00000001" }).success
+      ).toBe(true);
+    });
+
+    it.each(["1234567", "123456789", "1234567a", "", "12 345678"])(
+      "rejects %j",
+      (dni) => {
+        expect(
+          credentialCreateSchema.safeParse({ ...VALID, dni }).success
+        ).toBe(false);
+      }
+    );
+
+    it("accepts an implausible but well-formed dni", () => {
+      // Flagging implausible numbers is an admin-panel policy; blocking
+      // them here would reject real people over a validation guess.
+      expect(
+        credentialCreateSchema.safeParse({ ...VALID, dni: "00000000" }).success
+      ).toBe(true);
+    });
+  });
+
+  describe("githubUsername", () => {
+    it.each(["a", "a-b", "aalvaropc", "a1-b2"])("accepts %j", (u) => {
+      expect(
+        credentialCreateSchema.safeParse({ ...VALID, githubUsername: u })
+          .success
+      ).toBe(true);
+    });
+
+    it.each(["-a", "a-", "a--b", "a".repeat(40), "al varo", "a@b"])(
+      "rejects %j",
+      (u) => {
+        expect(
+          credentialCreateSchema.safeParse({ ...VALID, githubUsername: u })
+            .success
+        ).toBe(false);
+      }
+    );
+
+    it("accepts null", () => {
+      expect(
+        credentialCreateSchema.safeParse({ ...VALID, githubUsername: null })
+          .success
+      ).toBe(true);
+    });
+  });
+
+  describe("images", () => {
+    it("accepts a jpeg data url", () => {
+      const r = credentialCreateSchema.safeParse({
+        ...VALID,
+        avatarKind: "photo",
+        photoDataUrl: JPEG,
+      });
+      expect(r.success).toBe(true);
+    });
+
+    it.each([
+      "data:text/html;base64,PHNjcmlwdD4=",
+      "data:image/svg+xml;base64,PHN2Zz4=",
+      "data:image/png;base64,iVBORw0KGgo=",
+      "https://example.com/photo.jpg",
+      "/9j/4AAQSkZJRg==",
+    ])("rejects %j", (photoDataUrl) => {
+      const r = credentialCreateSchema.safeParse({
+        ...VALID,
+        avatarKind: "photo",
+        photoDataUrl,
+      });
+      expect(r.success).toBe(false);
+    });
+
+    it("rejects a photo over the payload budget", () => {
+      const oversized = `data:image/jpeg;base64,${"A".repeat(
+        MAX_PHOTO_DATAURL_CHARS
+      )}`;
+      const r = credentialCreateSchema.safeParse({
+        ...VALID,
+        avatarKind: "photo",
+        photoDataUrl: oversized,
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe("cross-field rules", () => {
+    it("requires a photo when avatarKind is photo", () => {
+      expect(
+        firstIssuePath({ ...VALID, avatarKind: "photo", photoDataUrl: null })
+      ).toBe("avatarKind");
+    });
+
+    it("requires a mascot when avatarKind is mascot", () => {
+      expect(firstIssuePath({ ...VALID, mascotId: null })).toBe("avatarKind");
+    });
+
+    it("requires a free-text answer when heardAbout is otro", () => {
+      expect(
+        firstIssuePath({ ...VALID, heardAbout: "otro", heardAboutOther: "" })
+      ).toBe("heardAboutOther");
+    });
+
+    it("accepts otro with a free-text answer", () => {
+      const r = credentialCreateSchema.safeParse({
+        ...VALID,
+        heardAbout: "otro",
+        heardAboutOther: "Me lo dijo un profesor",
+      });
+      expect(r.success).toBe(true);
+    });
+  });
+});
+
+describe("credentialBevyStatusSchema", () => {
+  it("accepts a load confirmation", () => {
+    const r = credentialBevyStatusSchema.safeParse({
+      status: "loaded",
+      ticketNumber: "GOOGA263171317",
+    });
+    expect(r.success).toBe(true);
+    expect(r.success && r.data.note).toBeNull();
+  });
+
+  it("rejects an unknown status", () => {
+    expect(
+      credentialBevyStatusSchema.safeParse({ status: "uploaded" }).success
+    ).toBe(false);
+  });
+
+  it("rejects an over-long note", () => {
+    expect(
+      credentialBevyStatusSchema.safeParse({
+        status: "not_found",
+        note: "x".repeat(301),
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("credentialPhotoModerationSchema", () => {
+  it("defaults the reason to an empty string on approve", () => {
+    const r = credentialPhotoModerationSchema.safeParse({ action: "approve" });
+    expect(r.success).toBe(true);
+    expect(r.success && r.data.reason).toBe("");
+  });
+
+  it("rejects an unknown action", () => {
+    expect(
+      credentialPhotoModerationSchema.safeParse({ action: "delete" }).success
+    ).toBe(false);
+  });
+});

--- a/functions/src/schemas/credentials.ts
+++ b/functions/src/schemas/credentials.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+
+// Attendee credential submissions.
+//
+// Modelled on checkinImportSchema: .strict(), explicit bounds on every
+// string, and validated through validateBody() so req.body is replaced by
+// the parsed value. Do NOT model anything here on handlers/forms.ts — it
+// is the only write path in the API without a Zod schema and it spreads
+// req.body blindly over stored state.
+
+const DNI_RE = /^\d{8}$/;
+
+// GitHub's own rule: alphanumeric plus single internal hyphens, 1-39
+// chars. The lookahead is what rejects a trailing or doubled hyphen.
+const GITHUB_RE = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+
+// Only JPEG. The client re-encodes both images through a canvas before
+// sending, so the format is ours to dictate, and pinning it lets the
+// handler verify magic bytes without sniffing.
+const JPEG_DATAURL_RE = /^data:image\/jpeg;base64,[A-Za-z0-9+/]+={0,2}$/;
+
+// Payload budget against express.json({ limit: "1mb" }) in index.ts.
+// Base64 inflates by 4/3, so these char caps bound the decoded bytes at
+// roughly 220 KB and 465 KB respectively. Typical real values land near
+// 60 KB and 240 KB; the caps exist so a crafted request cannot walk the
+// body up to the Express limit and have the request rejected by the
+// middleware with an unhelpful error instead of a mapped 400.
+//   photo            <= 300_000 chars  (~220 KB)
+//   credential image <= 620_000 chars  (~465 KB)
+//   everything else  <=   4_000 chars
+//   worst case ~924 KB, comfortably under 1 MB.
+export const MAX_PHOTO_DATAURL_CHARS = 300_000;
+export const MAX_CREDENTIAL_DATAURL_CHARS = 620_000;
+
+/**
+ * Policy versions this deployment will accept a consent against.
+ *
+ * An enum rather than a free string: the stored consent is a legal
+ * artifact, and it is only meaningful if the version it names is one we
+ * can still produce the text of. A client submitting an unknown version
+ * is either stale or forged, and both deserve a 400.
+ */
+export const KNOWN_POLICY_VERSIONS = ["2026-08-01"] as const;
+
+export const credentialCreateSchema = z
+  .object({
+    firstName: z.string().trim().min(1).max(60),
+    lastName: z.string().trim().min(1).max(60),
+    dni: z.string().trim().regex(DNI_RE),
+    email: z.string().trim().toLowerCase().email().max(254),
+    company: z.string().trim().max(120).default(""),
+    githubUsername: z
+      .string()
+      .trim()
+      .regex(GITHUB_RE)
+      .max(39)
+      .nullable()
+      .default(null),
+
+    // Mirrors of the questions the Google/Bevy panel asks, so a human can
+    // transcribe the record without going back to the attendee.
+    heardAbout: z.enum([
+      "redes_sociales",
+      "amigo_colega",
+      "universidad",
+      "meetup",
+      "otro",
+    ]),
+    heardAboutOther: z.string().trim().max(120).default(""),
+    yearsExperience: z.enum(["menos_1", "1_2", "3_5", "6_10", "mas_10"]),
+    googleToolsLevel: z.enum(["ninguna", "basica", "intermedia", "avanzada"]),
+
+    // z.literal(true), not z.boolean(). There is no valid record without
+    // consent, so an unchecked box must be a 400 the client can map back
+    // to the specific checkbox — never a stored `false` that looks like a
+    // deliberate refusal we accepted anyway.
+    consentGdgTerms: z.literal(true),
+    consentGooglePrivacy: z.literal(true),
+    consentCodeOfConduct: z.literal(true),
+    consentDataProcessing: z.literal(true),
+    consentAgeAttested: z.literal(true),
+    consentPolicyVersion: z.enum(KNOWN_POLICY_VERSIONS),
+
+    avatarKind: z.enum(["photo", "mascot"]),
+    mascotId: z
+      .string()
+      .regex(/^[a-z0-9-]{1,40}$/)
+      .nullable()
+      .default(null),
+    photoDataUrl: z
+      .string()
+      .regex(JPEG_DATAURL_RE)
+      .max(MAX_PHOTO_DATAURL_CHARS)
+      .nullable()
+      .default(null),
+    credentialImageDataUrl: z
+      .string()
+      .regex(JPEG_DATAURL_RE)
+      .max(MAX_CREDENTIAL_DATAURL_CHARS)
+      .nullable()
+      .default(null),
+  })
+  .strict()
+  .refine((v) => (v.avatarKind === "photo" ? !!v.photoDataUrl : !!v.mascotId), {
+    path: ["avatarKind"],
+    message: "Falta la foto o la mascota para el tipo de avatar elegido",
+  })
+  .refine((v) => v.heardAbout !== "otro" || v.heardAboutOther.length > 0, {
+    path: ["heardAboutOther"],
+    message: "Cuentanos como te enteraste",
+  });
+
+export const credentialBevyStatusSchema = z
+  .object({
+    status: z.enum(["pending", "loaded", "not_found", "discarded"]),
+    ticketNumber: z.string().trim().max(100).nullable().default(null),
+    note: z.string().trim().max(300).nullable().default(null),
+  })
+  .strict();
+
+export const credentialPhotoModerationSchema = z
+  .object({
+    action: z.enum(["approve", "remove"]),
+    reason: z.string().trim().max(200).default(""),
+  })
+  .strict();
+
+export type CredentialCreateInput = z.infer<typeof credentialCreateSchema>;

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -324,3 +324,7 @@ export const checkinImportSchema = z
   .strict();
 
 export type CheckinImportBody = z.infer<typeof checkinImportSchema>;
+
+// Attendee credentials live in their own file — this one is already long,
+// and minigameTemplate.test.ts established per-topic modules here.
+export * from "./credentials";

--- a/functions/src/services/credentialSearch.test.ts
+++ b/functions/src/services/credentialSearch.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCredentialSearchTokens,
+  maskDni,
+  normalizeDni,
+} from "./credentialSearch";
+import { buildSearchTokens } from "./nameMatch";
+
+describe("normalizeDni", () => {
+  it("keeps only digits", () => {
+    expect(normalizeDni("1234 5678")).toBe("12345678");
+    expect(normalizeDni("12.345.678")).toBe("12345678");
+    expect(normalizeDni("  12345678 ")).toBe("12345678");
+  });
+
+  it("groups formatting variants of the same number", () => {
+    // The whole point of the key: a conflict must not hide behind a space.
+    expect(normalizeDni("1234 5678")).toBe(normalizeDni("12345678"));
+  });
+});
+
+describe("maskDni", () => {
+  it("reveals only the last four digits", () => {
+    expect(maskDni("12345678")).toBe("****5678");
+  });
+
+  it("masks based on normalized digits, not raw length", () => {
+    expect(maskDni("1234 5678")).toBe("****5678");
+  });
+
+  it("does not over-mask a short value", () => {
+    expect(maskDni("5678")).toBe("5678");
+    expect(maskDni("")).toBe("");
+  });
+});
+
+describe("buildCredentialSearchTokens", () => {
+  const BASE = {
+    firstName: "José",
+    lastName: "Ñañez Quintanilla",
+    email: "jose.nanez@example.com",
+    dni: "12345678",
+  };
+
+  it("matches names typed without diacritics", () => {
+    const tokens = buildCredentialSearchTokens(BASE);
+    expect(tokens).toContain("jose");
+    expect(tokens).toContain("nanez");
+  });
+
+  it("indexes the DNI so it can be typed into the same search box", () => {
+    expect(buildCredentialSearchTokens(BASE)).toContain("12345678");
+  });
+
+  it("indexes a formatted DNI under its normalized form", () => {
+    const tokens = buildCredentialSearchTokens({ ...BASE, dni: "1234 5678" });
+    expect(tokens).toContain("12345678");
+  });
+
+  it("indexes the email address and its local part", () => {
+    const tokens = buildCredentialSearchTokens(BASE);
+    expect(tokens).toContain("jose.nanez@example.com");
+    expect(tokens).toContain("jose");
+  });
+
+  it("indexes the GitHub username when present", () => {
+    const tokens = buildCredentialSearchTokens({
+      ...BASE,
+      githubUsername: "aalvaropc",
+    });
+    expect(tokens).toContain("aalvaropc");
+  });
+
+  it("tolerates a missing GitHub username", () => {
+    expect(() =>
+      buildCredentialSearchTokens({ ...BASE, githubUsername: null })
+    ).not.toThrow();
+    expect(
+      buildCredentialSearchTokens({ ...BASE, githubUsername: "" })
+    ).toEqual(buildCredentialSearchTokens(BASE));
+  });
+
+  it("returns no duplicates", () => {
+    const tokens = buildCredentialSearchTokens({
+      ...BASE,
+      githubUsername: "jose",
+    });
+    expect(tokens.length).toBe(new Set(tokens).size);
+  });
+
+  it("stays a superset of the roster tokenizer for the same person", () => {
+    // Reconciliation between credentials and the Bevy roster relies on both
+    // sides running through buildSearchTokens. If this diverges, a
+    // credential stops being findable by a query that finds its roster row.
+    const rosterTokens = buildSearchTokens({
+      firstName: BASE.firstName,
+      lastName: BASE.lastName,
+      email: BASE.email,
+      ticketNumber: BASE.dni,
+    });
+    const credentialTokens = buildCredentialSearchTokens(BASE);
+    for (const token of rosterTokens) {
+      expect(credentialTokens).toContain(token);
+    }
+  });
+});

--- a/functions/src/services/credentialSearch.ts
+++ b/functions/src/services/credentialSearch.ts
@@ -1,0 +1,63 @@
+import { buildSearchTokens, tokenize } from "./nameMatch";
+
+/**
+ * Digits only. Used as the grouping key for duplicate detection.
+ *
+ * Duplicate DNIs are never blocked — that would let anyone lock a real
+ * person out of registering by claiming their number first — so this key
+ * exists to make conflicts VISIBLE in the admin panel, not to reject
+ * writes. Normalizing means "1234 5678" and "12345678" group together
+ * instead of hiding the conflict behind a formatting difference.
+ */
+export function normalizeDni(dni: string): string {
+  return dni.replace(/\D/g, "");
+}
+
+/**
+ * Hides all but the last four digits for list views.
+ *
+ * The DNI is the most sensitive field this codebase stores, and
+ * persistentLocalCache (enabled app-wide in src/lib/firebase.ts) writes
+ * whatever a page subscribes to onto every organizer's disk. Masking by
+ * default limits what a screenshot or a glance over a shoulder leaks; the
+ * panel reveals a single row on demand.
+ */
+export function maskDni(dni: string): string {
+  const digits = normalizeDni(dni);
+  if (digits.length <= 4) return digits;
+  return `${"*".repeat(digits.length - 4)}${digits.slice(-4)}`;
+}
+
+/**
+ * Prefix-matchable tokens for the credentials panel search box.
+ *
+ * Delegates to nameMatch.buildSearchTokens with the DNI in the
+ * ticketNumber slot — same role, an identifier someone types into a search
+ * box — so a credential and its eventual roster row tokenize through the
+ * exact same code path. That shared path is what makes reconciliation
+ * between the two collections work, and its contract is already pinned
+ * against the browser-side copy in CheckinPanel.tsx by
+ * src/components/react/admin/checkin/__tests__/search.test.ts.
+ */
+export function buildCredentialSearchTokens(input: {
+  firstName: string;
+  lastName: string;
+  email: string;
+  dni: string;
+  githubUsername?: string | null;
+}): string[] {
+  const tokens = new Set(
+    buildSearchTokens({
+      firstName: input.firstName,
+      lastName: input.lastName,
+      email: input.email,
+      ticketNumber: normalizeDni(input.dni),
+    })
+  );
+
+  if (input.githubUsername) {
+    for (const t of tokenize(input.githubUsername)) tokens.add(t);
+  }
+
+  return [...tokens];
+}

--- a/functions/src/services/credentialSequence.test.ts
+++ b/functions/src/services/credentialSequence.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { letterForSequence, mascotForCredentialId } from "./credentialSequence";
+
+const LETTERS = ["A", "Q", "I", "C"];
+
+describe("letterForSequence", () => {
+  it("assigns round-robin starting at the first letter", () => {
+    const assigned = [1, 2, 3, 4, 5, 6, 7, 8].map((n) =>
+      letterForSequence(n, LETTERS)
+    );
+    expect(assigned).toEqual(["A", "Q", "I", "C", "A", "Q", "I", "C"]);
+  });
+
+  it("keeps groups balanced at every prefix, not just at the end", () => {
+    // This is the property that motivated round-robin over random: with
+    // ~300 registrations and only some fraction showing up, the groups
+    // have to be even for any prefix of the sequence.
+    for (const total of [7, 13, 50, 137, 300]) {
+      const counts = new Map<string, number>();
+      for (let n = 1; n <= total; n++) {
+        const letter = letterForSequence(n, LETTERS);
+        counts.set(letter, (counts.get(letter) ?? 0) + 1);
+      }
+      const sizes = [...counts.values()];
+      expect(Math.max(...sizes) - Math.min(...sizes)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("is stable for the same input", () => {
+    expect(letterForSequence(42, LETTERS)).toBe(letterForSequence(42, LETTERS));
+  });
+
+  it("returns A instead of throwing on an empty letter set", () => {
+    // A misconfigured event must not be able to reject a registration.
+    expect(letterForSequence(1, [])).toBe("A");
+    expect(letterForSequence(99, [])).toBe("A");
+  });
+
+  it("handles a single-letter set", () => {
+    expect(letterForSequence(1, ["Z"])).toBe("Z");
+    expect(letterForSequence(500, ["Z"])).toBe("Z");
+  });
+
+  it("never indexes off the front for a non-positive sequence", () => {
+    // Should be unreachable, but a negative modulus in JS is negative and
+    // would return undefined rather than a letter.
+    expect(LETTERS).toContain(letterForSequence(0, LETTERS));
+    expect(LETTERS).toContain(letterForSequence(-3, LETTERS));
+  });
+});
+
+describe("mascotForCredentialId", () => {
+  const MASCOTS = ["gdg-blue-1", "gdg-red-1", "gdg-yellow-1", "gdg-green-1"];
+
+  it("is deterministic for the same id", () => {
+    expect(mascotForCredentialId("abc123", MASCOTS)).toBe(
+      mascotForCredentialId("abc123", MASCOTS)
+    );
+  });
+
+  it("always returns a member of the set", () => {
+    for (const id of ["a", "zzzzz", "Xk29fLp0", "0000000000000000000"]) {
+      expect(MASCOTS).toContain(mascotForCredentialId(id, MASCOTS));
+    }
+  });
+
+  it("spreads across the set rather than collapsing to one", () => {
+    const ids = Array.from({ length: 200 }, (_, i) => `cred${i}`);
+    const used = new Set(ids.map((id) => mascotForCredentialId(id, MASCOTS)));
+    expect(used.size).toBe(MASCOTS.length);
+  });
+
+  it("returns null when there are no mascots", () => {
+    expect(mascotForCredentialId("abc", [])).toBeNull();
+  });
+});

--- a/functions/src/services/credentialSequence.ts
+++ b/functions/src/services/credentialSequence.ts
@@ -1,0 +1,51 @@
+// Group-letter assignment for attendee credentials.
+//
+// Every credential gets a gapless 1-based sequence number, assigned inside
+// the same Firestore transaction that creates it, and a group letter
+// derived from that number. The letter drives an on-site dynamic: everyone
+// holding the same letter forms a group.
+
+/**
+ * Round-robin, deliberately not random.
+ *
+ * With ~300 attendees and 4 letters, random assignment produces visibly
+ * uneven groups; round-robin is exactly balanced at every prefix of the
+ * sequence, so the groups stay even even if only a third of registrants
+ * show up.
+ *
+ * An empty letter set returns "A" rather than throwing. This runs inside
+ * the credential-creation transaction, and a misconfigured event JSON must
+ * not be able to reject a registration — the loader already substitutes
+ * defaults, so reaching here with an empty array means something upstream
+ * is broken and a degraded letter beats a lost attendee.
+ */
+export function letterForSequence(
+  sequenceNumber: number,
+  letters: readonly string[]
+): string {
+  if (letters.length === 0) return "A";
+  // Sequence numbers are 1-based, so shift before taking the modulus.
+  const index = (Math.trunc(sequenceNumber) - 1) % letters.length;
+  // A negative or zero sequence should never reach here, but modulus on a
+  // negative operand is negative in JS and would index off the front.
+  return letters[index < 0 ? index + letters.length : index];
+}
+
+/**
+ * Distributes credentials whose photo was taken down across the mascot
+ * set without another round trip. Deterministic so re-running moderation
+ * on the same record cannot shuffle the avatar the attendee already saw.
+ */
+export function mascotForCredentialId(
+  credentialId: string,
+  mascotIds: readonly string[]
+): string | null {
+  if (mascotIds.length === 0) return null;
+  let hash = 0;
+  for (let i = 0; i < credentialId.length; i++) {
+    // Same cheap FNV-ish rolling hash used for bingo card seeding; we need
+    // spread, not cryptographic strength.
+    hash = (hash * 31 + credentialId.charCodeAt(i)) >>> 0;
+  }
+  return mascotIds[hash % mascotIds.length];
+}


### PR DESCRIPTION
## What changed

Pure, tested building blocks for the credential endpoint. **No routes added and none touched — zero production behaviour change.**

- `functions/src/schemas/credentials.ts` — `.strict()` schemas for creation, Bevy load status and photo moderation.
- `functions/src/services/credentialSequence.ts` — group-letter assignment and a deterministic mascot picker.
- `functions/src/services/credentialSearch.ts` — DNI normalisation and masking, plus the panel's search tokens.

## Why

Three decisions worth reviewing:

**The five consent flags are `z.literal(true)`, not `z.boolean()`.** There is no valid record without consent, so an unchecked box has to be a 400 the client can map back to the specific checkbox — never a stored `false` that reads like a refusal we accepted anyway. Tests pin that each failure reports on its own `path`, because a `z.literal(true)` rejection the client cannot trace back to a checkbox is a dead end for the user.

**Group letters are assigned round-robin, not randomly.** With ~300 attendees and 4 letters, random assignment produces visibly uneven groups; round-robin is exactly balanced at every prefix of the sequence, so groups stay even even if only a third of registrants show up. An empty letter set returns `"A"` rather than throwing — this runs inside the credential-creation transaction, and a misconfigured event must not be able to reject a registration.

**`buildCredentialSearchTokens` delegates to `nameMatch.buildSearchTokens`** with the DNI in the `ticketNumber` slot — same role, an identifier someone types into a search box. That makes a credential and its eventual roster row tokenize through the exact same code path, which is what will make reconciliation between the two collections work.

`normalizeDni` exists to **group** duplicate DNIs, never to reject them: blocking duplicates would let anyone lock a real person out of registering by claiming their number first.

The image fields are restricted to JPEG data URLs with length caps computed against `express.json({ limit: "1mb" })` — worst case ~924 KB.

## How to test

```bash
pnpm test:functions
```

76 new tests across the three files. Notable cases: each consent rejects both `false` and absence; `.strict()` rejects extra keys; DNI accepts 8 digits and rejects 7, but deliberately **accepts** `00000000` (flagging implausible numbers is admin-panel policy, blocking them here would reject real people over a validation guess); round-robin stays balanced for totals of 7, 13, 50, 137 and 300; and credential tokens are a superset of the roster tokenizer's output for the same person.

## Note for reviewers

The schemas are modelled on `checkinImportSchema` / `handlers/checkin.ts`. **Not** on `handlers/forms.ts`, which is the only write path in the API without a Zod schema and spreads `req.body` blindly over stored state.