### PR TITLE
fix(minigames): auto-scroll to live participation section on join

### DIFF
--- a/src/components/react/event/MiniGamesRoot.tsx
+++ b/src/components/react/event/MiniGamesRoot.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import { signInAnonymouslyIfNeeded } from "@/lib/firebase";
 import type { PollConfig, QuizConfig } from "../admin/minigame-templates/types";
@@ -173,6 +173,22 @@ export function MiniGamesRoot({ slug }: Props) {
     [liveInstances]
   );
 
+  // The live-games section renders inline, wherever it falls in the page
+  // (after speakers, schedule, sponsors, etc.), so on first join we scroll
+  // it into view rather than making participants hunt for it.
+  const globalGamesRef = useRef<HTMLElement | null>(null);
+  const hasScrolledToGames = useRef(false);
+
+  useEffect(() => {
+    if (step !== "joined" || globalLive.length === 0) return;
+    if (hasScrolledToGames.current) return;
+    hasScrolledToGames.current = true;
+    globalGamesRef.current?.scrollIntoView?.({
+      behavior: "smooth",
+      block: "start",
+    });
+  }, [step, globalLive.length]);
+
   if (!authReady || loading || step === "init") return null;
   if (step === "no_live") return null;
 
@@ -202,6 +218,7 @@ export function MiniGamesRoot({ slug }: Props) {
 
       {step === "joined" && uid && globalLive.length > 0 && (
         <section
+          ref={globalGamesRef}
           className={`container my-8 ${
             realtimeLive.length > 0 ? "pb-[70vh]" : ""
           }`}


### PR DESCRIPTION
## What changed
When a participant joins the live minigames on an event page, the inline "Participación en vivo" section (word cloud, bingo, roulette) now scrolls smoothly into view once — right after `step` becomes `joined`.

## Why
That section renders at the very bottom of the event page, after speakers, schedule, and sponsors. After entering their name in the join modal, participants had to manually scroll all the way down to find the actual game input (e.g. the word cloud text field). This affects every "global" game type (wordcloud, bingo, roulette); realtime games (poll, quiz) were unaffected since they already render as a fixed bottom overlay.

## How to test
1. Open an event with a live wordcloud/bingo/roulette minigame using `?play=1`.
2. Submit your alias in the join modal.
3. Confirm the page auto-scrolls to the "Participación en vivo" section without manual scrolling.
4. Run `pnpm test` — `MiniGamesRoot.test.tsx` and other event component tests pass.