### PR TITLE
feat(bingo): add classic mode with called balls and anti-collision card dealing

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -18,6 +18,24 @@ service cloud.firestore {
     // Rules cannot loop, so the ten lines are spelled out. Only reached
     // when bingoMarked is already asserted to be a 16-element list, so the
     // fixed indexing is safe.
+    // True when this instance is a classic bingo — the mode where an
+    // admin calls the terms out loud. There, a win is not something a
+    // client may assert at all: the Cloud Function recomputes the card
+    // against the balls it actually called and writes bingoWonAt itself
+    // with the Admin SDK, which bypasses these rules. Conference-mode
+    // bingo has nobody calling, so self-reported marks are all there is
+    // and the line check below is the only guard available.
+    // Defaults to false in two ways, both deliberate: an instance written
+    // before classic mode existed has no `classic` key, and a participant
+    // whose parent instance is missing entirely would otherwise make the
+    // get() error out and deny a legitimate conference-mode win. Neither
+    // case is a classic bingo, so neither should block one.
+    function isClassicBingo(eventSlug, instanceId) {
+      return exists(/databases/$(database)/documents/events/$(eventSlug)/minigames/$(instanceId))
+          && get(/databases/$(database)/documents/events/$(eventSlug)/minigames/$(instanceId))
+               .data.get('config', {}).get('classic', false) == true;
+    }
+
     function bingoHasLine(m) {
       return (m[0] && m[1] && m[2] && m[3])
           || (m[4] && m[5] && m[6] && m[7])
@@ -93,8 +111,32 @@ service cloud.firestore {
                                 && bingoHasLine(request.resource.data.bingoMarked)
                                 // Pin to server time so a cheater cannot
                                 // backdate the win to jump the winners queue.
-                                && request.resource.data.bingoWonAt == request.time));
+                                && request.resource.data.bingoWonAt == request.time
+                                // In classic mode the line check is not
+                                // enough: marks are only legitimate for
+                                // balls that were actually called, and
+                                // rules cannot cross-reference the card
+                                // against the called list. So the client
+                                // is shut out entirely and /bingo/claim
+                                // does the verifying.
+                                && !isClassicBingo(eventSlug, instanceId)));
           allow delete: if false;
+        }
+
+        // Classic-bingo bookkeeping, both server-only and both secret by
+        // design rather than by omission:
+        //   secret/draw  — the full calling sequence. Readable would mean
+        //     every attendee knows every ball in advance.
+        //   slots/{uid}  — which ball each card wins on. Participant docs
+        //     are world-readable, so this is the one place that can hold
+        //     the reservation without spoiling the surprise.
+        // The root catch-all already denies both; stated here so a later
+        // refactor cannot widen them by accident.
+        match /secret/{docId} {
+          allow read, write: if false;
+        }
+        match /slots/{participantUid} {
+          allow read, write: if false;
         }
         match /responses/{responseId} {
           allow read: if true;

--- a/functions/src/handlers/minigameBingo.test.ts
+++ b/functions/src/handlers/minigameBingo.test.ts
@@ -1,0 +1,465 @@
+import { Request, Response } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SERVER_TS = "__SERVER_TS__";
+
+const mocks = vi.hoisted(() => ({
+  docMock: vi.fn(),
+  collectionMock: vi.fn(),
+  runTransactionMock: vi.fn(),
+}));
+
+vi.mock("firebase-admin", () => ({
+  firestore: () => ({
+    doc: mocks.docMock,
+    collection: mocks.collectionMock,
+    runTransaction: mocks.runTransactionMock,
+  }),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: () => SERVER_TS },
+}));
+
+import * as handler from "./minigameBingo";
+import type { AuthenticatedRequest } from "../middleware/auth";
+
+const { docMock, collectionMock, runTransactionMock } = mocks;
+
+interface ResMock extends Response {
+  __status: number | undefined;
+  __body: unknown;
+}
+
+function buildRes(): ResMock {
+  const res: Partial<ResMock> = {};
+  res.status = vi.fn(function (this: ResMock, code: number) {
+    this.__status = code;
+    return this;
+  }) as ResMock["status"];
+  res.json = vi.fn(function (this: ResMock, body: unknown) {
+    this.__body = body;
+    return this;
+  }) as ResMock["json"];
+  return res as ResMock;
+}
+
+function buildReq(uid = "player-1"): Request {
+  return {
+    body: {},
+    params: { slug: "devfest-2026", id: "bingo-A" },
+    user: { uid },
+  } as unknown as AuthenticatedRequest as unknown as Request;
+}
+
+const CARD = Array.from({ length: 16 }, (_, i) => `c${i}`);
+// Row 0 completes on the 4th ball; the filler keeps every other line open.
+const ORDER = ["c0", "c1", "c2", "zz", "c3", "c4", "c8", "c12"];
+
+interface Scene {
+  instance?: Record<string, unknown>;
+  sealedOrder?: string[];
+  participant?: Record<string, unknown> | null;
+}
+
+interface Wiring {
+  instanceUpdates: Array<Record<string, unknown>>;
+  participantUpdates: Array<Record<string, unknown>>;
+  sealSets: Array<Record<string, unknown>>;
+  audit: ReturnType<typeof vi.fn>;
+}
+
+// Wires just enough of the Admin SDK for these two handlers: the instance
+// doc, its private secret/draw doc, and one participant doc.
+function wire(scene: Scene): Wiring {
+  const instanceUpdates: Array<Record<string, unknown>> = [];
+  const participantUpdates: Array<Record<string, unknown>> = [];
+  const sealSets: Array<Record<string, unknown>> = [];
+  const audit = vi.fn(async () => undefined);
+
+  const drawRef = { __kind: "draw" };
+  const participantRef = { __kind: "participant" };
+
+  const instanceSnap = () => ({
+    exists: scene.instance !== undefined,
+    data: () => scene.instance,
+  });
+  const drawSnap = () => ({
+    exists: scene.sealedOrder !== undefined,
+    data: () => (scene.sealedOrder ? { order: scene.sealedOrder } : undefined),
+  });
+  const participantSnap = () => ({
+    exists: Boolean(scene.participant),
+    data: () => scene.participant ?? undefined,
+  });
+
+  const runTransaction = vi.fn(async (cb: (tx: unknown) => unknown) => {
+    const tx = {
+      get: vi.fn(async (ref: { __kind?: string }) => {
+        if (ref.__kind === "draw") return drawSnap();
+        if (ref.__kind === "participant") return participantSnap();
+        return instanceSnap();
+      }),
+      set: vi.fn((ref: { __kind?: string }, data: Record<string, unknown>) => {
+        if (ref.__kind === "draw") sealSets.push(data);
+      }),
+      update: vi.fn(
+        (ref: { __kind?: string }, data: Record<string, unknown>) => {
+          if (ref.__kind === "participant") participantUpdates.push(data);
+          else instanceUpdates.push(data);
+        }
+      ),
+    };
+    return cb(tx);
+  });
+
+  const instanceRef = {
+    id: "bingo-A",
+    firestore: { runTransaction },
+    get: vi.fn(async () => instanceSnap()),
+    collection: vi.fn((name: string) => {
+      if (name === "secret") return { doc: vi.fn(() => drawRef) };
+      if (name === "participants") return { doc: vi.fn(() => participantRef) };
+      throw new Error("unexpected collection " + name);
+    }),
+  };
+
+  Object.assign(drawRef, { get: vi.fn(async () => drawSnap()) });
+  Object.assign(participantRef, { get: vi.fn(async () => participantSnap()) });
+
+  docMock.mockImplementation(() => instanceRef);
+  collectionMock.mockImplementation((name: string) => {
+    if (name === "audit_log") return { add: audit };
+    throw new Error("unexpected root collection " + name);
+  });
+  runTransactionMock.mockImplementation(runTransaction);
+
+  return { instanceUpdates, participantUpdates, sealSets, audit };
+}
+
+const LIVE_CLASSIC = {
+  type: "bingo",
+  state: "live",
+  config: { terms: ORDER, classic: true, prizes: 3, maxWinnersPerDraw: 1 },
+  drawCount: 0,
+  drawnTerms: [] as string[],
+  bingoWinnerCount: 0,
+};
+
+describe("minigameBingo handler", () => {
+  beforeEach(() => {
+    docMock.mockReset();
+    collectionMock.mockReset();
+    runTransactionMock.mockReset();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  describe("guards shared by both endpoints", () => {
+    it("404s an instance that does not exist", async () => {
+      wire({});
+      const res = buildRes();
+      await handler.drawBall(buildReq(), res);
+      expect(res.__status).toBe(404);
+    });
+
+    it("rejects a non-bingo instance", async () => {
+      wire({ instance: { type: "roulette", state: "live" } });
+      const res = buildRes();
+      await handler.drawBall(buildReq(), res);
+      expect(res.__status).toBe(400);
+      expect((res.__body as { error: string }).error).toMatch(/no es.*bingo/i);
+    });
+
+    it("rejects a conference-mode bingo — nobody calls balls there", async () => {
+      wire({
+        instance: { type: "bingo", state: "live", config: { terms: ORDER } },
+      });
+      const res = buildRes();
+      await handler.drawBall(buildReq(), res);
+      expect(res.__status).toBe(400);
+      expect((res.__body as { error: string }).error).toMatch(/clásico/i);
+    });
+
+    it("rejects a bingo that is not live", async () => {
+      wire({ instance: { ...LIVE_CLASSIC, state: "scheduled" } });
+      const res = buildRes();
+      await handler.claim(buildReq(), res);
+      expect(res.__status).toBe(400);
+      expect((res.__body as { error: string }).error).toMatch(/en vivo/i);
+    });
+  });
+
+  describe("drawBall", () => {
+    it("calls the next ball from the sealed sequence", async () => {
+      const w = wire({ instance: LIVE_CLASSIC, sealedOrder: ORDER });
+      const res = buildRes();
+      await handler.drawBall(buildReq("admin-1"), res);
+
+      expect(res.__status).toBeUndefined();
+      expect((res.__body as { data: unknown }).data).toEqual({
+        term: "c0",
+        drawCount: 1,
+        remaining: ORDER.length - 1,
+      });
+      expect(w.instanceUpdates[0]).toEqual({
+        drawCount: 1,
+        drawnTerms: ["c0"],
+        lastDrawnTerm: "c0",
+        lastDrawAt: SERVER_TS,
+      });
+    });
+
+    it("advances through the sequence in order, never at random", async () => {
+      const w = wire({
+        instance: {
+          ...LIVE_CLASSIC,
+          drawCount: 3,
+          drawnTerms: ORDER.slice(0, 3),
+        },
+        sealedOrder: ORDER,
+      });
+      const res = buildRes();
+      await handler.drawBall(buildReq("admin-1"), res);
+      expect((res.__body as { data: { term: string } }).data.term).toBe(
+        ORDER[3]
+      );
+      expect(w.instanceUpdates[0].drawnTerms).toEqual(ORDER.slice(0, 4));
+    });
+
+    it("refuses once every ball has been called", async () => {
+      wire({
+        instance: { ...LIVE_CLASSIC, drawCount: ORDER.length },
+        sealedOrder: ORDER,
+      });
+      const res = buildRes();
+      await handler.drawBall(buildReq("admin-1"), res);
+      expect(res.__status).toBe(400);
+      expect((res.__body as { error: string }).error).toMatch(
+        /todas las bolas/i
+      );
+    });
+
+    it("seals a sequence for an instance that has none yet", async () => {
+      const w = wire({ instance: LIVE_CLASSIC });
+      const res = buildRes();
+      await handler.drawBall(buildReq("admin-1"), res);
+      expect(w.sealSets).toHaveLength(1);
+      expect((w.sealSets[0].order as string[]).length).toBe(
+        new Set(ORDER).size
+      );
+      expect(res.__status).toBeUndefined();
+    });
+
+    it("logs the ball it called", async () => {
+      const w = wire({ instance: LIVE_CLASSIC, sealedOrder: ORDER });
+      await handler.drawBall(buildReq("admin-1"), buildRes());
+      expect(w.audit).toHaveBeenCalledTimes(1);
+      expect(w.audit.mock.calls[0][0]).toMatchObject({
+        action: "minigame_instance.bingo.draw",
+        performedBy: "admin-1",
+        details: { term: "c0", drawCount: 1 },
+      });
+    });
+  });
+
+  describe("claim", () => {
+    const joined = { alias: "Ana", bingoCard: CARD };
+
+    it("crowns a genuine line and hands out rank 1", async () => {
+      const w = wire({
+        instance: {
+          ...LIVE_CLASSIC,
+          drawCount: 5,
+          drawnTerms: ORDER.slice(0, 5),
+        },
+        sealedOrder: ORDER,
+        participant: joined,
+      });
+      const res = buildRes();
+      await handler.claim(buildReq(), res);
+
+      expect(res.__status).toBeUndefined();
+      expect(res.__body).toMatchObject({
+        success: true,
+        data: { rank: 1, hasPrize: true, prizes: 3, winDraw: 5 },
+      });
+      expect(w.instanceUpdates[0]).toEqual({ bingoWinnerCount: 1 });
+      expect(w.participantUpdates[0]).toMatchObject({
+        bingoWonAt: SERVER_TS,
+        bingoRank: 1,
+        bingoWinDraw: 5,
+      });
+    });
+
+    it("rebuilds the marks from the called balls, ignoring the client", async () => {
+      const w = wire({
+        instance: {
+          ...LIVE_CLASSIC,
+          drawCount: 5,
+          drawnTerms: ORDER.slice(0, 5),
+        },
+        sealedOrder: ORDER,
+        // The client claims a full card; the server must not believe it.
+        participant: {
+          ...joined,
+          bingoMarked: Array.from({ length: 16 }, () => true),
+        },
+      });
+      await handler.claim(buildReq(), buildRes());
+      const stored = w.participantUpdates[0].bingoMarked as boolean[];
+      // Only c0..c3 were called (c4 is the 6th ball), so only row 0 is on.
+      expect(stored.filter(Boolean)).toHaveLength(4);
+      expect(stored.slice(0, 4)).toEqual([true, true, true, true]);
+    });
+
+    it("rejects a claim with no line among the called balls", async () => {
+      const w = wire({
+        instance: {
+          ...LIVE_CLASSIC,
+          drawCount: 3,
+          drawnTerms: ORDER.slice(0, 3),
+        },
+        sealedOrder: ORDER,
+        participant: joined,
+      });
+      const res = buildRes();
+      await handler.claim(buildReq(), res);
+      expect(res.__status).toBe(400);
+      expect((res.__body as { error: string }).error).toMatch(/línea/i);
+      expect(w.participantUpdates).toHaveLength(0);
+    });
+
+    it("rejects a card whose marks were never called at all", async () => {
+      const w = wire({
+        instance: { ...LIVE_CLASSIC, drawCount: 0, drawnTerms: [] },
+        sealedOrder: ORDER,
+        participant: {
+          ...joined,
+          bingoMarked: Array.from({ length: 16 }, () => true),
+        },
+      });
+      const res = buildRes();
+      await handler.claim(buildReq(), res);
+      expect(res.__status).toBe(400);
+      expect(w.participantUpdates).toHaveLength(0);
+    });
+
+    it("assigns ranks in sequence so two claims never tie", async () => {
+      const w = wire({
+        instance: {
+          ...LIVE_CLASSIC,
+          drawCount: 5,
+          drawnTerms: ORDER.slice(0, 5),
+          bingoWinnerCount: 2,
+        },
+        sealedOrder: ORDER,
+        participant: joined,
+      });
+      const res = buildRes();
+      await handler.claim(buildReq("player-3"), res);
+      expect((res.__body as { data: { rank: number } }).data.rank).toBe(3);
+      expect(w.instanceUpdates[0]).toEqual({ bingoWinnerCount: 3 });
+    });
+
+    it("marks a winner beyond the prize count as having no prize", async () => {
+      wire({
+        instance: {
+          ...LIVE_CLASSIC,
+          drawCount: 5,
+          drawnTerms: ORDER.slice(0, 5),
+          bingoWinnerCount: 3,
+        },
+        sealedOrder: ORDER,
+        participant: joined,
+      });
+      const res = buildRes();
+      await handler.claim(buildReq("player-4"), res);
+      expect(res.__body).toMatchObject({
+        data: { rank: 4, hasPrize: false },
+      });
+    });
+
+    it("is idempotent: a second tap returns the rank already held", async () => {
+      const w = wire({
+        instance: {
+          ...LIVE_CLASSIC,
+          drawCount: 5,
+          drawnTerms: ORDER.slice(0, 5),
+          bingoWinnerCount: 1,
+        },
+        sealedOrder: ORDER,
+        participant: {
+          ...joined,
+          bingoWonAt: { seconds: 1 },
+          bingoRank: 1,
+          bingoWinDraw: 5,
+        },
+      });
+      const res = buildRes();
+      await handler.claim(buildReq(), res);
+      expect(res.__body).toMatchObject({
+        data: { rank: 1, alreadyWon: true },
+      });
+      // No second rank minted, no duplicate audit entry.
+      expect(w.instanceUpdates).toHaveLength(0);
+      expect(w.audit).not.toHaveBeenCalled();
+    });
+
+    it("404s somebody who never joined", async () => {
+      wire({
+        instance: {
+          ...LIVE_CLASSIC,
+          drawCount: 5,
+          drawnTerms: ORDER.slice(0, 5),
+        },
+        sealedOrder: ORDER,
+        participant: null,
+      });
+      const res = buildRes();
+      await handler.claim(buildReq(), res);
+      expect(res.__status).toBe(404);
+    });
+
+    it("rejects a participant with no card", async () => {
+      wire({
+        instance: {
+          ...LIVE_CLASSIC,
+          drawCount: 5,
+          drawnTerms: ORDER.slice(0, 5),
+        },
+        sealedOrder: ORDER,
+        participant: { alias: "Ana", bingoCard: [] },
+      });
+      const res = buildRes();
+      await handler.claim(buildReq(), res);
+      expect(res.__status).toBe(400);
+      expect((res.__body as { error: string }).error).toMatch(/cartón/i);
+    });
+
+    it("falls back to the sealed sequence when drawnTerms is missing", async () => {
+      const w = wire({
+        instance: {
+          type: "bingo",
+          state: "live",
+          config: { terms: ORDER, classic: true, prizes: 3 },
+          drawCount: 5,
+        },
+        sealedOrder: ORDER,
+        participant: joined,
+      });
+      const res = buildRes();
+      await handler.claim(buildReq(), res);
+      expect(res.__status).toBeUndefined();
+      expect(w.participantUpdates[0].bingoRank).toBe(1);
+    });
+
+    it("returns 500 when Firestore unexpectedly throws", async () => {
+      docMock.mockImplementation(() => {
+        throw new Error("kaboom");
+      });
+      const res = buildRes();
+      await handler.claim(buildReq(), res);
+      expect(res.__status).toBe(500);
+    });
+  });
+});

--- a/functions/src/handlers/minigameBingo.ts
+++ b/functions/src/handlers/minigameBingo.ts
@@ -1,0 +1,271 @@
+import { Request, Response } from "express";
+import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
+import { writeAuditLog } from "../utils/audit";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { safeError } from "../middleware/validate";
+import { completedLines, markedFromDrawn } from "../services/bingoClassic";
+import { ensureDrawOrder, readDrawOrder } from "../services/bingoDrawStore";
+
+interface ClassicBingoConfig {
+  terms?: string[];
+  classic?: boolean;
+  prizes?: number;
+  maxWinnersPerDraw?: number;
+}
+
+interface BingoInstanceData {
+  type?: string;
+  state?: string;
+  config?: ClassicBingoConfig;
+  drawCount?: number;
+  drawnTerms?: string[];
+  bingoWinnerCount?: number;
+}
+
+interface ParticipantData {
+  alias?: string;
+  bingoCard?: string[];
+  bingoWonAt?: unknown;
+  bingoRank?: number;
+  bingoWinDraw?: number;
+}
+
+function instanceRefFor(slug: string, id: string) {
+  return admin.firestore().doc(`events/${slug}/minigames/${id}`);
+}
+
+// Shared preamble for both endpoints: the instance must exist, be a bingo
+// in classic mode, and be live. Answers the client itself and returns
+// null when any of that fails.
+async function loadLiveClassicInstance(
+  slug: string,
+  id: string,
+  res: Response
+): Promise<{
+  ref: admin.firestore.DocumentReference;
+  data: BingoInstanceData;
+} | null> {
+  const ref = instanceRefFor(slug, id);
+  const snap = await ref.get();
+  if (!snap.exists) {
+    res.status(404).json({ success: false, error: "Instancia no encontrada" });
+    return null;
+  }
+  const data = snap.data() as BingoInstanceData;
+  if (data.type !== "bingo") {
+    res
+      .status(400)
+      .json({ success: false, error: "No es una instancia de bingo" });
+    return null;
+  }
+  if (data.config?.classic !== true) {
+    res.status(400).json({
+      success: false,
+      error: "Este bingo no está en modo clásico",
+    });
+    return null;
+  }
+  if (data.state !== "live") {
+    res.status(400).json({
+      success: false,
+      error: "El bingo debe estar en vivo",
+    });
+    return null;
+  }
+  return { ref, data };
+}
+
+// POST /api/events/:slug/minigames/:id/bingo/draw
+//
+// Calls the next ball. The sequence was sealed when the instance was
+// attached, so this only ever reveals one more entry of it — the admin
+// has no say in which term comes up, which is what lets us promise that
+// wins are staggered.
+export async function drawBall(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const id = req.params.id as string;
+    const user = (req as AuthenticatedRequest).user;
+
+    const loaded = await loadLiveClassicInstance(slug, id, res);
+    if (!loaded) return;
+    const { ref, data } = loaded;
+
+    // Attach seals the sequence, but a bingo attached before classic
+    // mode existed (or one whose seal write lost a race) would have
+    // none. Sealing here keeps the button working either way.
+    const order = await ensureDrawOrder(ref, data.config?.terms ?? []);
+    if (order.length === 0) {
+      res.status(400).json({
+        success: false,
+        error: "La plantilla no tiene términos para cantar",
+      });
+      return;
+    }
+
+    const drawn = await ref.firestore.runTransaction(async (tx) => {
+      const fresh = await tx.get(ref);
+      const count = (fresh.data() as BingoInstanceData).drawCount ?? 0;
+      if (count >= order.length) return null;
+
+      const term = order[count];
+      tx.update(ref, {
+        drawCount: count + 1,
+        // Rewritten whole rather than appended: arrayUnion would silently
+        // reorder on a repeated term, and the order of this list is what
+        // the projector animates.
+        drawnTerms: order.slice(0, count + 1),
+        lastDrawnTerm: term,
+        lastDrawAt: FieldValue.serverTimestamp(),
+      });
+      return { term, drawCount: count + 1 };
+    });
+
+    if (!drawn) {
+      res.status(400).json({
+        success: false,
+        error: "Ya se cantaron todas las bolas",
+      });
+      return;
+    }
+
+    await writeAuditLog({
+      action: "minigame_instance.bingo.draw",
+      performedBy: user.uid,
+      targetId: id,
+      targetType: "minigame_instance",
+      details: { slug, term: drawn.term, drawCount: drawn.drawCount },
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    res.json({
+      success: true,
+      data: {
+        term: drawn.term,
+        drawCount: drawn.drawCount,
+        remaining: order.length - drawn.drawCount,
+      },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+// POST /api/events/:slug/minigames/:id/bingo/claim
+//
+// A participant pressing "¡Bingo!". Nothing from the client is trusted:
+// the server rebuilds the marked card from its own record of which balls
+// were called, checks the line itself, and assigns the rank atomically so
+// two claims in the same second still come out as 1st and 2nd rather than
+// a tie nobody can settle in front of the room.
+export async function claim(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const id = req.params.id as string;
+    const user = (req as AuthenticatedRequest).user;
+
+    const loaded = await loadLiveClassicInstance(slug, id, res);
+    if (!loaded) return;
+    const { ref, data } = loaded;
+
+    const participantRef = ref.collection("participants").doc(user.uid);
+    const participantSnap = await participantRef.get();
+    if (!participantSnap.exists) {
+      res.status(404).json({
+        success: false,
+        error: "No estás participando en este bingo",
+      });
+      return;
+    }
+    const participant = participantSnap.data() as ParticipantData;
+    const card = participant.bingoCard ?? [];
+    if (card.length === 0) {
+      res
+        .status(400)
+        .json({ success: false, error: "No tienes un cartón asignado" });
+      return;
+    }
+
+    // Prefer the instance's own list of called balls; fall back to the
+    // sealed sequence when an older instance only tracked the count.
+    const drawCount = data.drawCount ?? 0;
+    const drawnTerms =
+      data.drawnTerms ?? (await readDrawOrder(ref)).slice(0, drawCount);
+
+    const marked = markedFromDrawn(card, drawnTerms);
+    const lines = completedLines(marked);
+    if (lines.length === 0) {
+      res.status(400).json({
+        success: false,
+        error: "Todavía no tienes una línea completa con las bolas cantadas",
+      });
+      return;
+    }
+
+    const prizes = data.config?.prizes ?? 3;
+    const result = await ref.firestore.runTransaction(async (tx) => {
+      const [freshInstance, freshParticipant] = await Promise.all([
+        tx.get(ref),
+        tx.get(participantRef),
+      ]);
+      const existing = freshParticipant.data() as ParticipantData | undefined;
+      if (existing?.bingoWonAt) {
+        // Double tap, or a reconnect replaying the claim. Give back the
+        // rank they already hold instead of minting a second one.
+        return {
+          rank: existing.bingoRank ?? 0,
+          winDraw: existing.bingoWinDraw ?? drawCount,
+          alreadyWon: true,
+        };
+      }
+
+      const winnerCount =
+        (freshInstance.data() as BingoInstanceData).bingoWinnerCount ?? 0;
+      const rank = winnerCount + 1;
+
+      tx.update(ref, { bingoWinnerCount: rank });
+      tx.update(participantRef, {
+        // Server-owned: firestore.rules forbids a classic-mode client
+        // from writing bingoWonAt at all.
+        bingoWonAt: FieldValue.serverTimestamp(),
+        bingoRank: rank,
+        bingoWinDraw: drawCount,
+        // Overwrite the self-reported marks with what was actually
+        // called, so the highlighted line matches the verified win.
+        bingoMarked: marked,
+      });
+      return { rank, winDraw: drawCount, alreadyWon: false };
+    });
+
+    if (!result.alreadyWon) {
+      await writeAuditLog({
+        action: "minigame_participant.bingo.claim",
+        performedBy: user.uid,
+        targetId: id,
+        targetType: "minigame_instance",
+        details: {
+          slug,
+          alias: participant.alias ?? "Anónimo",
+          rank: result.rank,
+          winDraw: result.winDraw,
+        },
+        timestamp: FieldValue.serverTimestamp(),
+      });
+    }
+
+    res.json({
+      success: true,
+      data: {
+        rank: result.rank,
+        winDraw: result.winDraw,
+        prizes,
+        hasPrize: result.rank > 0 && result.rank <= prizes,
+        lines,
+        alreadyWon: result.alreadyWon,
+      },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}

--- a/functions/src/handlers/minigameInstances.ts
+++ b/functions/src/handlers/minigameInstances.ts
@@ -4,6 +4,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
+import { ensureDrawOrder } from "../services/bingoDrawStore";
 import type { MinigameTemplate, MinigameTemplateType } from "../schemas";
 
 interface AuditDetails {
@@ -122,8 +123,28 @@ export async function attach(req: Request, res: Response) {
       baseInstance.lastSpinWinnerId = null;
       baseInstance.lastSpinAt = null;
     }
+    // Non-null only for a classic bingo, which needs a sealed calling
+    // sequence before the first participant can be dealt a card.
+    // Optional chaining because `tpl` is raw Firestore data wearing the
+    // schema type, not something zod has parsed.
+    let classicTerms: string[] | null = null;
+    if (tpl.type === "bingo" && tpl.bingo?.classic === true) {
+      classicTerms = tpl.bingo.terms ?? [];
+      baseInstance.drawCount = 0;
+      baseInstance.drawnTerms = [];
+      baseInstance.lastDrawnTerm = null;
+      baseInstance.lastDrawAt = null;
+      baseInstance.bingoWinnerCount = 0;
+    }
 
     const ref = await instancesCol(slug).add(baseInstance);
+
+    if (classicTerms) {
+      // Seal it now, before anyone can join: cards are scored against
+      // this sequence so that no two of them win on the same ball, and
+      // that scoring is impossible until the sequence exists.
+      await ensureDrawOrder(ref, classicTerms);
+    }
 
     await writeAuditLog(
       auditEntry("minigame_instance.attach", user.uid, ref.id, {

--- a/functions/src/handlers/minigameJoin.test.ts
+++ b/functions/src/handlers/minigameJoin.test.ts
@@ -68,33 +68,95 @@ interface InstanceFixture {
   id: string;
   type: string;
   state: string;
-  config?: { terms?: string[] };
+  config?: {
+    terms?: string[];
+    classic?: boolean;
+    maxWinnersPerDraw?: number;
+  };
   existingParticipant?: {
     alias: string;
     bingoCard?: string[];
   };
+  // Classic mode only: the calling sequence already sealed for this
+  // instance, and the winning balls other participants have reserved.
+  sealedOrder?: string[];
+  takenWinIndices?: number[];
 }
 
 interface WiringResult {
   txCalls: Array<Record<string, unknown>>;
   setCalls: Array<{ ref: object; data: Record<string, unknown> }>;
+  slotCalls: Array<{ instanceId: string; data: Record<string, unknown> }>;
+  sealCalls: Array<{ instanceId: string; data: Record<string, unknown> }>;
   auditAdd: ReturnType<typeof vi.fn>;
 }
 
 function wireFirestore(liveInstances: InstanceFixture[]): WiringResult {
   const setCalls: Array<{ ref: object; data: Record<string, unknown> }> = [];
+  const slotCalls: Array<{
+    instanceId: string;
+    data: Record<string, unknown>;
+  }> = [];
+  const sealCalls: Array<{
+    instanceId: string;
+    data: Record<string, unknown>;
+  }> = [];
   const auditAdd = vi.fn(async () => undefined);
 
   const instanceDocs = liveInstances.map((i) => {
     const participantRef = { __participantFor: i.id };
+    const drawRef = { __drawFor: i.id };
+    const slotDocRef = { __slotFor: i.id };
+    // The occupancy query the dealer runs inside the transaction. It
+    // carries the fixture's reserved balls so tx.get can answer it.
+    const slotQuery = {
+      __slotQueryFor: i.id,
+      __taken: i.takenWinIndices ?? [],
+    };
+
+    const sealTransaction = vi.fn(async (cb: (tx: unknown) => unknown) => {
+      const tx = {
+        get: vi.fn(async () => ({
+          data: () => (i.sealedOrder ? { order: i.sealedOrder } : undefined),
+        })),
+        set: vi.fn((_ref: object, data: Record<string, unknown>) => {
+          sealCalls.push({ instanceId: i.id, data });
+          // Later reads in the same test see the sealed sequence.
+          i.sealedOrder = data.order as string[];
+        }),
+      };
+      return cb(tx);
+    });
+
     const ref = {
+      id: i.id,
+      firestore: { runTransaction: sealTransaction },
       collection: vi.fn((name: string) => {
         if (name === "participants") {
           return { doc: vi.fn(() => participantRef) };
         }
+        if (name === "secret") {
+          return {
+            doc: vi.fn(() => ({
+              ...drawRef,
+              get: vi.fn(async () => ({
+                data: () =>
+                  i.sealedOrder ? { order: i.sealedOrder } : undefined,
+              })),
+            })),
+          };
+        }
+        if (name === "slots") {
+          return {
+            doc: vi.fn(() => slotDocRef),
+            where: vi.fn(() => slotQuery),
+          };
+        }
         throw new Error("unexpected nested collection " + name);
       }),
       __participantRef: participantRef,
+      __slotDocRef: slotDocRef,
+      __slotQuery: slotQuery,
     };
     return {
       id: i.id,
@@ -124,9 +186,19 @@ function wireFirestore(liveInstances: InstanceFixture[]): WiringResult {
 
   runTransactionMock.mockImplementation(async (callback) => {
     // Find which instance ref the upcoming tx.set/get refers to. We
-    // expose `tx.get(participantRef)` and `tx.set(participantRef, data)`.
+    // expose `tx.get(participantRef)`, `tx.get(slotQuery)` and
+    // `tx.set(ref, data)`.
     const tx = {
       get: vi.fn(async (ref: object) => {
+        const query = ref as { __slotQueryFor?: string; __taken?: number[] };
+        if (query.__slotQueryFor) {
+          return {
+            docs: (query.__taken ?? []).map((winIndex, n) => ({
+              id: `other-${n}`,
+              data: () => ({ winIndex }),
+            })),
+          };
+        }
         const inst = instanceDocs.find((d) => d.ref.__participantRef === ref);
         if (inst?.__existing) {
           return { exists: true, data: () => inst.__existing };
@@ -134,13 +206,18 @@ function wireFirestore(liveInstances: InstanceFixture[]): WiringResult {
         return { exists: false };
       }),
       set: vi.fn((ref: object, data: Record<string, unknown>) => {
+        const slotOwner = instanceDocs.find((d) => d.ref.__slotDocRef === ref);
+        if (slotOwner) {
+          slotCalls.push({ instanceId: slotOwner.id, data });
+          return;
+        }
         setCalls.push({ ref, data });
       }),
     };
     await callback(tx);
   });
 
-  return { txCalls: [], setCalls, auditAdd };
+  return { txCalls: [], setCalls, slotCalls, sealCalls, auditAdd };
 }
 
 const POLL_INSTANCE: InstanceFixture = {
@@ -320,6 +397,117 @@ describe("minigameJoin handler", () => {
     await handler.join(buildReq({ alias: "Test" }, { slug: "x" }), res);
     // Should not throw / not 500. Card empty in summary.
     expect(res.__status).toBeUndefined();
+  });
+
+  describe("classic bingo — staggered card dealing", () => {
+    const CLASSIC_TERMS = Array.from({ length: 50 }, (_, i) => `t${i + 1}`);
+    const classicInstance = (
+      overrides: Partial<InstanceFixture> = {}
+    ): InstanceFixture => ({
+      id: "i-classic",
+      type: "bingo",
+      state: "live",
+      config: { terms: CLASSIC_TERMS, classic: true, maxWinnersPerDraw: 1 },
+      sealedOrder: [...CLASSIC_TERMS].reverse(),
+      ...overrides,
+    });
+
+    it("deals a card and reserves the ball it wins on", async () => {
+      const wiring = wireFirestore([classicInstance()]);
+      const res = buildRes();
+      await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), res);
+
+      expect(wiring.setCalls).toHaveLength(1);
+      expect(wiring.setCalls[0].data.bingoCard).toHaveLength(16);
+      expect(wiring.slotCalls).toHaveLength(1);
+      const slot = wiring.slotCalls[0].data;
+      expect(slot.uid).toBe("anon-uid-1");
+      expect(typeof slot.winIndex).toBe("number");
+      expect(slot.relaxed).toBe(false);
+    });
+
+    it("keeps the winning ball out of the world-readable participant doc", async () => {
+      const wiring = wireFirestore([classicInstance()]);
+      const res = buildRes();
+      await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), res);
+
+      const stored = wiring.setCalls[0].data;
+      expect(stored.winIndex).toBeUndefined();
+      expect(stored.bingoWinIndex).toBeUndefined();
+      // And nothing in the API response leaks it either.
+      expect(JSON.stringify(res.__body)).not.toContain("winIndex");
+    });
+
+    it("re-deals when the ball it would win on is already taken", async () => {
+      // Deal once with nothing reserved to learn the natural ball...
+      const first = wireFirestore([classicInstance()]);
+      await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), buildRes());
+      const natural = first.slotCalls[0].data.winIndex as number;
+      const naturalCard = first.setCalls[0].data.bingoCard;
+
+      // ...then reserve exactly that ball and join again as the same uid.
+      const second = wireFirestore([
+        classicInstance({ takenWinIndices: [natural] }),
+      ]);
+      await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), buildRes());
+
+      expect(second.slotCalls[0].data.winIndex).not.toBe(natural);
+      expect(second.setCalls[0].data.bingoCard).not.toEqual(naturalCard);
+      expect(second.slotCalls[0].data.relaxed).toBe(false);
+    });
+
+    it("seals the calling sequence when the instance has none yet", async () => {
+      const wiring = wireFirestore([
+        classicInstance({ sealedOrder: undefined }),
+      ]);
+      await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), buildRes());
+      expect(wiring.sealCalls).toHaveLength(1);
+      expect(wiring.sealCalls[0].data.order).toHaveLength(50);
+      expect(wiring.slotCalls).toHaveLength(1);
+    });
+
+    it("still deals when every candidate ball is taken, flagging the squeeze", async () => {
+      // Reserve a wide swathe of balls so no candidate can be free.
+      const wiring = wireFirestore([
+        classicInstance({
+          takenWinIndices: Array.from({ length: 50 }, (_, i) => i + 1),
+        }),
+      ]);
+      const res = buildRes();
+      await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), res);
+      expect(res.__status).toBeUndefined();
+      expect(wiring.setCalls[0].data.bingoCard).toHaveLength(16);
+      expect(wiring.slotCalls[0].data.relaxed).toBe(true);
+    });
+
+    it("does not touch the private collections in conference mode", async () => {
+      const wiring = wireFirestore([
+        {
+          id: "i-conference",
+          type: "bingo",
+          state: "live",
+          config: { terms: CLASSIC_TERMS },
+        },
+      ]);
+      await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), buildRes());
+      expect(wiring.slotCalls).toHaveLength(0);
+      expect(wiring.sealCalls).toHaveLength(0);
+      expect(wiring.setCalls[0].data.bingoCard).toHaveLength(16);
+    });
+
+    it("hands out no card when a classic bank is too small, without failing the join", async () => {
+      const wiring = wireFirestore([
+        classicInstance({
+          config: { terms: ["a", "b", "c"], classic: true },
+          sealedOrder: undefined,
+        }),
+      ]);
+      const res = buildRes();
+      await handler.join(buildReq({ alias: "Ana" }, { slug: "x" }), res);
+      expect(res.__status).toBeUndefined();
+      expect(wiring.setCalls[0].data.bingoCard).toEqual([]);
+      expect(wiring.slotCalls).toHaveLength(0);
+    });
   });
 
   it("returns 500 when Firestore unexpectedly throws", async () => {

--- a/functions/src/handlers/minigameJoin.ts
+++ b/functions/src/handlers/minigameJoin.ts
@@ -1,14 +1,25 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
+import type { DocumentReference } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import { isCleanAlias } from "../services/profanity";
 import { generateBingoCard } from "../services/bingo";
+import {
+  buildCardCandidates,
+  candidateWinIndices,
+  earliestWinFloor,
+  pickStaggeredCard,
+  type CardCandidate,
+} from "../services/bingoClassic";
+import { ensureDrawOrder, winSlotsCol } from "../services/bingoDrawStore";
 
 interface BingoConfig {
   terms?: string[];
+  classic?: boolean;
+  maxWinnersPerDraw?: number;
 }
 
 interface InstanceData {
@@ -22,6 +33,48 @@ interface JoinedInstanceSummary {
   type: string;
   joined: boolean;
   bingoCard?: string[];
+}
+
+// Everything the classic-mode dealer needs that can be computed before
+// the transaction opens: a handful of scored candidate cards and the
+// balls they would win on. The sealed sequence never changes, so this is
+// safe to do outside.
+interface ClassicDealPlan {
+  candidates: CardCandidate[];
+  winIndices: number[];
+  maxWinnersPerDraw: number;
+}
+
+async function prepareClassicDeal(
+  instanceRef: DocumentReference,
+  instanceId: string,
+  config: BingoConfig,
+  uid: string
+): Promise<ClassicDealPlan | null> {
+  const terms = config.terms ?? [];
+  try {
+    const order = await ensureDrawOrder(instanceRef, terms);
+    if (order.length === 0) return null;
+
+    const candidates = buildCardCandidates(
+      terms,
+      order,
+      `${uid}:${instanceId}`,
+      undefined,
+      earliestWinFloor(order.length)
+    );
+    if (candidates.length === 0) return null;
+
+    return {
+      candidates,
+      winIndices: candidateWinIndices(candidates),
+      maxWinnersPerDraw: Math.max(1, config.maxWinnersPerDraw ?? 1),
+    };
+  } catch {
+    // Malformed bank (fewer than 16 usable terms). Same tolerance as
+    // conference mode: hand out no card rather than fail the whole join.
+    return null;
+  }
 }
 
 // POST /api/events/:slug/minigames/join
@@ -77,6 +130,22 @@ export async function join(req: Request, res: Response) {
           joined: false,
         };
 
+        const isClassicBingo =
+          instanceData.type === "bingo" &&
+          instanceData.config?.classic === true;
+
+        // Scoring candidate cards needs the sealed calling sequence, so
+        // it happens before the transaction opens — a transaction may
+        // not read anything after its first write.
+        const deal = isClassicBingo
+          ? await prepareClassicDeal(
+              instanceDoc.ref,
+              instanceId,
+              instanceData.config ?? {},
+              user.uid
+            )
+          : null;
+
         await db.runTransaction(async (tx) => {
           const existing = await tx.get(participantRef);
           if (existing.exists) {
@@ -99,7 +168,46 @@ export async function join(req: Request, res: Response) {
             joinedAt: FieldValue.serverTimestamp(),
           };
 
-          if (instanceData.type === "bingo") {
+          if (deal) {
+            // Classic mode. Which ball each card wins on is already
+            // decided by the sealed sequence, so we look at what is
+            // taken and deal a card that wins on a free ball. That is
+            // what stops five people from claiming at once when there
+            // are three prizes.
+            const slots = winSlotsCol(instanceDoc.ref);
+            const takenSnap = await tx.get(
+              slots.where("winIndex", "in", deal.winIndices)
+            );
+            const occupancy: Record<number, number> = {};
+            for (const doc of takenSnap.docs) {
+              const idx = (doc.data() as { winIndex?: number }).winIndex;
+              if (typeof idx === "number") {
+                occupancy[idx] = (occupancy[idx] ?? 0) + 1;
+              }
+            }
+
+            const pick = pickStaggeredCard(
+              deal.candidates,
+              occupancy,
+              deal.maxWinnersPerDraw
+            );
+            if (pick) {
+              participantDoc.bingoCard = pick.card;
+              summary.bingoCard = pick.card;
+              // The reservation lives in a private collection: the
+              // participant doc is world-readable, and "you win on ball
+              // 31" would spoil the game for everyone who looked.
+              tx.set(slots.doc(user.uid), {
+                uid: user.uid,
+                winIndex: pick.winIndex,
+                deal: pick.attempt,
+                relaxed: pick.relaxed,
+                createdAt: FieldValue.serverTimestamp(),
+              });
+            } else {
+              participantDoc.bingoCard = [];
+            }
+          } else if (instanceData.type === "bingo") {
             const terms = instanceData.config?.terms ?? [];
             // generateBingoCard validates length and dedupes; if the
             // template is somehow short we surface a clean error

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -140,6 +140,30 @@ const joinLimiter = rateLimit({
   },
 });
 
+// Calling bingo balls does not belong on writeLimiter. That limiter caps
+// an organizer at 30 writes/minute to protect the GitHub API quota for
+// the data repo, and a ball touches neither — it is one small update to
+// one Firestore doc. Sharing it meant an admin calling a 48-ball game at
+// any pace faster than one ball every two seconds got "slow down" partway
+// through, with the rest of the bag unreachable (caught in an end-to-end
+// run: it died on ball 25). The real ceiling is the bag itself: once the
+// sequence is exhausted the endpoint 400s, so an instance can never serve
+// more draws than it has terms.
+const ballLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => {
+    const uid = (req as { user?: { uid?: string } }).user?.uid;
+    return uid ? `u:${uid}` : `ip:${ipKeyGenerator(req.ip ?? "unknown")}`;
+  },
+  message: {
+    success: false,
+    error: "Demasiadas bolas seguidas, espera un momento",
+  },
+});
+
 // Classic-bingo claims are public and anon-token-backed like /join, so
 // they are keyed by IP too — but on their own counter. A whole venue
 // usually shares one NAT address, and sharing joinLimiter would let the
@@ -426,7 +450,7 @@ app.post(
   requireRole("admin"),
   slugP,
   vid,
-  writeLimiter,
+  ballLimiter,
   minigameBingo.drawBall
 );
 // ...and participants claim the line themselves. The handler re-derives

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -38,6 +38,7 @@ import * as minigameInstances from "./handlers/minigameInstances";
 import * as minigameJoin from "./handlers/minigameJoin";
 import * as minigameWords from "./handlers/minigameWords";
 import * as minigameRoulette from "./handlers/minigameRoulette";
+import * as minigameBingo from "./handlers/minigameBingo";
 import * as certificates from "./handlers/certificates";
 import * as checkin from "./handlers/checkin";
 
@@ -130,6 +131,25 @@ const writeLimiter = rateLimit({
 const joinLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => `ip:${ipKeyGenerator(req.ip ?? "unknown")}`,
+  message: {
+    success: false,
+    error: "Demasiados intentos, espera un momento",
+  },
+});
+
+// Classic-bingo claims are public and anon-token-backed like /join, so
+// they are keyed by IP too — but on their own counter. A whole venue
+// usually shares one NAT address, and sharing joinLimiter would let the
+// scan-the-QR rush use up the budget and then throttle the first winner
+// at the exact moment they press ¡BINGO!. The cap is comfortable because
+// the staggered card dealing keeps genuine claims minutes apart, and the
+// handler verifies each one against the balls it actually called.
+const claimLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (req) => `ip:${ipKeyGenerator(req.ip ?? "unknown")}`,
@@ -398,6 +418,27 @@ app.post(
   vid,
   writeLimiter,
   minigameRoulette.spin
+);
+
+// Classic bingo: the admin calls one ball at a time...
+app.post(
+  "/api/events/:slug/minigames/:id/bingo/draw",
+  requireRole("admin"),
+  slugP,
+  vid,
+  writeLimiter,
+  minigameBingo.drawBall
+);
+// ...and participants claim the line themselves. The handler re-derives
+// the win from the server's own record of called balls, so a flood of
+// bogus claims cannot manufacture a winner.
+app.post(
+  "/api/events/:slug/minigames/:id/bingo/claim",
+  requireAuth(),
+  slugP,
+  vid,
+  claimLimiter,
+  minigameBingo.claim
 );
 
 // Word cloud moderation + bingo winners (admin-only)

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -216,6 +216,19 @@ export const minigameTemplateSchema = z.discriminatedUnion("type", [
           terms: z.array(shortText(120).min(1)).min(16).max(200),
           cardSize: z.literal(4).default(4),
           freeCenter: z.boolean().default(false),
+          // Classic mode: an admin calls the terms out loud one at a
+          // time and participants may only mark what has been called.
+          // Off means conference mode, where the speakers do the calling
+          // without knowing it and every card marks freely.
+          classic: z.boolean().default(false),
+          // How many prizes are on the table. The projector marks the
+          // first `prizes` winners as prize-winners and the rest as
+          // honourable mentions.
+          prizes: z.number().int().min(1).max(20).default(3),
+          // Cards are dealt so that at most this many of them win on the
+          // same ball. 1 means wins arrive strictly one announcement at
+          // a time — the whole point of the classic mode.
+          maxWinnersPerDraw: z.number().int().min(1).max(10).default(1),
         })
         .strict(),
     })

--- a/functions/src/services/bingo.ts
+++ b/functions/src/services/bingo.ts
@@ -30,11 +30,34 @@ function mulberry32(seed: number): () => number {
   };
 }
 
-export function generateBingoCard(terms: string[], seed: string): string[] {
-  // De-dupe input first — admins can be sloppy. Preserve first-seen order.
-  const unique = Array.from(
-    new Set(terms.map((t) => t.trim())).values()
-  ).filter((t) => t.length > 0);
+// The term bank as the game actually sees it: trimmed, de-duped (admins
+// are sloppy) and stripped of blanks, in first-seen order. Both the card
+// dealer and the classic-mode draw order run through this, which is what
+// guarantees every card term also appears in the draw sequence.
+export function normalizeTerms(terms: readonly string[]): string[] {
+  return Array.from(new Set(terms.map((t) => t.trim())).values()).filter(
+    (t) => t.length > 0
+  );
+}
+
+// Fisher–Yates with a seeded RNG. Same seed → same permutation.
+export function seededShuffle<T>(items: readonly T[], seed: string): T[] {
+  const rand = mulberry32(hashSeed(seed));
+  const arr = items.slice();
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+  }
+  return arr;
+}
+
+export function generateBingoCard(
+  terms: readonly string[],
+  seed: string
+): string[] {
+  const unique = normalizeTerms(terms);
 
   if (unique.length < CARD_SIZE) {
     throw new Error(
@@ -42,14 +65,5 @@ export function generateBingoCard(terms: string[], seed: string): string[] {
     );
   }
 
-  const rand = mulberry32(hashSeed(seed));
-  const arr = unique.slice();
-  // Fisher–Yates with seeded RNG.
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(rand() * (i + 1));
-    const tmp = arr[i];
-    arr[i] = arr[j];
-    arr[j] = tmp;
-  }
-  return arr.slice(0, CARD_SIZE);
+  return seededShuffle(unique, seed).slice(0, CARD_SIZE);
 }

--- a/functions/src/services/bingoClassic.test.ts
+++ b/functions/src/services/bingoClassic.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCardCandidates,
+  buildDrawOrder,
+  candidateWinIndices,
+  classicWinIndex,
+  completedLines,
+  earliestWinFloor,
+  markedFromDrawn,
+  pickStaggeredCard,
+  NEVER_WINS,
+  WIN_LINES,
+} from "./bingoClassic";
+
+const bank = (n: number) => Array.from({ length: n }, (_, i) => `t${i + 1}`);
+const BANK_50 = bank(50);
+
+// A card laid out row-major so the assertions below can talk about
+// specific lines: cells 0..3 are the top row, 0/4/8/12 the left column.
+const CARD = Array.from({ length: 16 }, (_, i) => `c${i}`);
+
+describe("buildDrawOrder", () => {
+  it("covers the whole bank, so every card eventually wins", () => {
+    const order = buildDrawOrder(BANK_50, "seed");
+    expect(order).toHaveLength(50);
+    expect(new Set(order)).toEqual(new Set(BANK_50));
+  });
+
+  it("is deterministic per seed and differs across seeds", () => {
+    expect(buildDrawOrder(BANK_50, "a")).toEqual(buildDrawOrder(BANK_50, "a"));
+    expect(buildDrawOrder(BANK_50, "a")).not.toEqual(
+      buildDrawOrder(BANK_50, "b")
+    );
+  });
+
+  it("normalizes the bank the same way cards are dealt", () => {
+    const sloppy = [...BANK_50, "  t1  ", "", "   ", "t2"];
+    expect(buildDrawOrder(sloppy, "seed")).toHaveLength(50);
+  });
+});
+
+describe("classicWinIndex", () => {
+  it("returns the ball that completes the earliest line, 1-based", () => {
+    // Top row last term lands on ball 4; nothing else can be faster.
+    const order = ["c0", "c1", "c2", "c3", ...CARD.slice(4)];
+    expect(classicWinIndex(CARD, order)).toBe(4);
+  });
+
+  it("counts the LAST ball a line needs, not the first", () => {
+    // Left column (0,4,8,12) completes only when c12 is called 9th.
+    const order = [
+      "c0",
+      "c4",
+      "zz1",
+      "c8",
+      "zz2",
+      "zz3",
+      "zz4",
+      "zz5",
+      "c12",
+      ...CARD,
+    ];
+    expect(classicWinIndex(CARD, order)).toBe(9);
+  });
+
+  it("takes the minimum across all ten lines", () => {
+    const order = buildDrawOrder(BANK_50, "cross-check");
+    const card = order.slice(0, 16); // arbitrary but valid card
+    const perLine = WIN_LINES.map((line) =>
+      Math.max(...line.map((cell) => order.indexOf(card[cell]) + 1))
+    );
+    expect(classicWinIndex(card, order)).toBe(Math.min(...perLine));
+  });
+
+  it("reports NEVER_WINS when a card term is missing from the sequence", () => {
+    expect(classicWinIndex(CARD, ["c0", "c1", "c2"])).toBe(NEVER_WINS);
+  });
+
+  it("never exceeds the sequence length for a card drawn from the bank", () => {
+    const order = buildDrawOrder(BANK_50, "bounded");
+    for (let i = 0; i < 20; i++) {
+      const card = buildCardCandidates(BANK_50, order, `p${i}`, 1)[0];
+      expect(card.winIndex).toBeLessThanOrEqual(order.length);
+      expect(card.winIndex).toBeGreaterThanOrEqual(4);
+    }
+  });
+});
+
+describe("earliestWinFloor", () => {
+  it("keeps a prize from going out in the opening seconds", () => {
+    expect(earliestWinFloor(60)).toBe(6);
+  });
+
+  it("scales down so a small bank still has candidates", () => {
+    expect(earliestWinFloor(16)).toBe(4);
+    expect(earliestWinFloor(20)).toBe(5);
+  });
+});
+
+describe("buildCardCandidates", () => {
+  const order = buildDrawOrder(BANK_50, "candidates");
+
+  it("scores several distinct cards for one participant", () => {
+    const candidates = buildCardCandidates(BANK_50, order, "uid:inst");
+    expect(candidates.length).toBeGreaterThan(1);
+    const fingerprints = new Set(candidates.map((c) => c.card.join(" ")));
+    expect(fingerprints.size).toBe(candidates.length);
+  });
+
+  it("keeps attempt 0 identical to the plain conference-mode deal", () => {
+    const [first] = buildCardCandidates(BANK_50, order, "uid:inst", 1);
+    expect(first.attempt).toBe(0);
+    expect(first.card).toHaveLength(16);
+  });
+
+  it("drops cards that would win before the floor", () => {
+    const candidates = buildCardCandidates(BANK_50, order, "uid:inst", 16, 25);
+    expect(candidates.length).toBeGreaterThan(0);
+    for (const c of candidates) expect(c.winIndex).toBeGreaterThanOrEqual(25);
+  });
+
+  it("ignores an unreachable floor rather than dealing nothing", () => {
+    // No card can win on ball 999 of a 50-ball sequence.
+    const candidates = buildCardCandidates(BANK_50, order, "uid:inst", 16, 999);
+    expect(candidates.length).toBeGreaterThan(0);
+  });
+
+  it("propagates the bank-too-small error from the dealer", () => {
+    expect(() => buildCardCandidates(bank(9), order, "uid")).toThrowError(
+      /at least 16/i
+    );
+  });
+});
+
+describe("pickStaggeredCard", () => {
+  const candidates = [
+    { card: ["a"], winIndex: 10, attempt: 0 },
+    { card: ["b"], winIndex: 22, attempt: 1 },
+    { card: ["c"], winIndex: 31, attempt: 2 },
+  ];
+
+  it("takes the first free ball", () => {
+    const pick = pickStaggeredCard(candidates, {}, 1);
+    expect(pick).toMatchObject({ winIndex: 10, relaxed: false });
+  });
+
+  it("skips a ball that already has its winner", () => {
+    const pick = pickStaggeredCard(candidates, { 10: 1 }, 1);
+    expect(pick).toMatchObject({ winIndex: 22, relaxed: false });
+  });
+
+  it("honours a quota above 1", () => {
+    const pick = pickStaggeredCard(candidates, { 10: 1 }, 2);
+    expect(pick).toMatchObject({ winIndex: 10, relaxed: false });
+  });
+
+  it("sends the overflow to the latest ball, not the emptiest", () => {
+    // Ball 22 is the least crowded, but seating a duplicate there would
+    // create a second winner while prizes are still on the table. Ball 31
+    // is late, where a shared win costs nothing.
+    const pick = pickStaggeredCard(candidates, { 10: 3, 22: 1, 31: 2 }, 1);
+    expect(pick).toMatchObject({ winIndex: 31, relaxed: true });
+  });
+
+  it("never seats overflow on an early ball", () => {
+    const pick = pickStaggeredCard(candidates, { 10: 1, 22: 5, 31: 5 }, 1);
+    expect(pick?.winIndex).not.toBe(10);
+    expect(pick?.relaxed).toBe(true);
+  });
+
+  it("returns null when there is nothing to deal", () => {
+    expect(pickStaggeredCard([], {}, 1)).toBeNull();
+  });
+});
+
+describe("candidateWinIndices", () => {
+  it("de-dupes and stays inside the 30-value `in` filter limit", () => {
+    const many = Array.from({ length: 60 }, (_, i) => ({
+      card: [`c${i}`],
+      winIndex: i,
+      attempt: i,
+    }));
+    expect(candidateWinIndices(many)).toHaveLength(30);
+    expect(
+      candidateWinIndices([
+        { card: ["a"], winIndex: 7, attempt: 0 },
+        { card: ["b"], winIndex: 7, attempt: 1 },
+      ])
+    ).toEqual([7]);
+  });
+});
+
+describe("markedFromDrawn / completedLines", () => {
+  it("marks only the cells whose term was actually called", () => {
+    const marked = markedFromDrawn(CARD, ["c0", "c5", "nope"]);
+    expect(marked[0]).toBe(true);
+    expect(marked[5]).toBe(true);
+    expect(marked[1]).toBe(false);
+    expect(marked.filter(Boolean)).toHaveLength(2);
+  });
+
+  it("finds no line until one is genuinely complete", () => {
+    expect(completedLines(markedFromDrawn(CARD, ["c0", "c1", "c2"]))).toEqual(
+      []
+    );
+    expect(
+      completedLines(markedFromDrawn(CARD, ["c0", "c1", "c2", "c3"]))
+    ).toEqual([[0, 1, 2, 3]]);
+  });
+
+  it("reports every completed line, not just the first", () => {
+    const lines = completedLines(
+      markedFromDrawn(CARD, ["c0", "c1", "c2", "c3", "c4", "c8", "c12"])
+    );
+    expect(lines).toHaveLength(2); // top row + left column
+  });
+});
+
+// The property the whole feature exists for. Deals cards to a room full
+// of participants exactly the way the join handler does, then replays the
+// game and counts how many people would legitimately shout at once.
+function dealRoom(
+  bankSize: number,
+  participants: number,
+  maxWinnersPerDraw = 1
+): number[] {
+  const terms = bank(bankSize);
+  const order = buildDrawOrder(terms, "room-seed");
+  const floor = earliestWinFloor(order.length);
+  const occupancy: Record<number, number> = {};
+  const winBalls: number[] = [];
+
+  for (let i = 0; i < participants; i++) {
+    const candidates = buildCardCandidates(
+      terms,
+      order,
+      `player-${i}:inst`,
+      undefined,
+      floor
+    );
+    const pick = pickStaggeredCard(candidates, occupancy, maxWinnersPerDraw);
+    if (!pick) throw new Error("no card dealt");
+    occupancy[pick.winIndex] = (occupancy[pick.winIndex] ?? 0) + 1;
+    // The card the participant actually holds must win on the ball we
+    // reserved for them — otherwise the reservation is a lie.
+    expect(classicWinIndex(pick.card, order)).toBe(pick.winIndex);
+    winBalls.push(pick.winIndex);
+  }
+  return winBalls;
+}
+
+function tally(values: number[]): Record<number, number> {
+  const counts: Record<number, number> = {};
+  for (const v of values) counts[v] = (counts[v] ?? 0) + 1;
+  return counts;
+}
+
+// The ball on which two people first win together, or null if nobody
+// ever shares. Everything before it is announced one winner at a time.
+function firstSharedBall(balls: number[]): number | null {
+  const shared = Object.entries(tally(balls))
+    .filter(([, count]) => count > 1)
+    .map(([ball]) => Number(ball));
+  return shared.length > 0 ? Math.min(...shared) : null;
+}
+
+describe("simultaneous-bingo staggering", () => {
+  // 12 covers three prizes with a wide margin: even if the organizer
+  // hands out a few extra mentions, they are still called one at a time.
+  const STAGGERED_PREFIX = 12;
+
+  function assertStaggeredOpening(balls: number[]) {
+    const opening = [...balls].sort((a, b) => a - b).slice(0, STAGGERED_PREFIX);
+    expect(new Set(opening).size).toBe(opening.length);
+  }
+
+  it("announces the first winners one ball at a time (40 players, 50 terms)", () => {
+    const balls = dealRoom(50, 40);
+    assertStaggeredOpening(balls);
+  });
+
+  it("still staggers the opening when the room outgrows the bank", () => {
+    // 120 players over a 50-ball sequence cannot all be unique — there
+    // are only so many balls. What must not happen is two of them
+    // claiming at once while prizes are still on the table.
+    const balls = dealRoom(50, 120);
+    assertStaggeredOpening(balls);
+  });
+
+  it("pushes unavoidable shared wins past the prize positions", () => {
+    for (const [bankSize, players] of [
+      [50, 120],
+      [75, 120],
+    ] as const) {
+      const balls = dealRoom(bankSize, players);
+      const shared = firstSharedBall(balls);
+      if (shared === null) continue;
+      const sorted = [...balls].sort((a, b) => a - b);
+      // Every prize is already handed out by the time anyone doubles up.
+      expect(shared).toBeGreaterThan(sorted[STAGGERED_PREFIX - 1]);
+    }
+  });
+
+  it("lets an organizer relax the quota when they have many prizes", () => {
+    const balls = dealRoom(50, 40, 3);
+    const opening = [...balls].sort((a, b) => a - b).slice(0, 12);
+    // Up to three winners may now share a ball, but not more.
+    for (const count of Object.values(tally(opening))) {
+      expect(count).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it("keeps a tiny bank playable even though cards must overlap", () => {
+    // 16 terms means every card holds the entire bank and only the
+    // arrangement differs. Wins bunch up — that is physics, not a bug —
+    // but the dealer must not crash or hand out a card that never wins.
+    const balls = dealRoom(16, 30);
+    expect(balls).toHaveLength(30);
+    for (const b of balls) expect(b).toBeLessThanOrEqual(16);
+  });
+
+  it("is reproducible: the same room deals the same way twice", () => {
+    expect(dealRoom(50, 25)).toEqual(dealRoom(50, 25));
+  });
+});

--- a/functions/src/services/bingoClassic.ts
+++ b/functions/src/services/bingoClassic.ts
@@ -1,0 +1,218 @@
+// Classic bingo: an admin calls one term at a time ("balls") and every
+// card is scored against that single sealed sequence.
+//
+// The whole anti-collision design rests on one property: once the draw
+// order is sealed, a card's winning moment is already decided. It is the
+// smallest number of balls that completes any of the ten lines — no
+// player behaviour affects it. So at join time we can look at a candidate
+// card, notice it would win on ball 31 exactly like somebody else's, and
+// deal a different one before the participant ever sees it.
+//
+// That is what keeps five people from shouting "¡Bingo!" over each other
+// when there are only three prizes: legitimate wins are spread one per
+// ball, so they arrive one announcement at a time.
+
+import { generateBingoCard, normalizeTerms, seededShuffle } from "./bingo";
+
+// Row-major indices of the ten winning lines on a 4x4 card: 4 rows,
+// 4 columns, 2 diagonals. Duplicated in src/lib/bingo.ts (browser) and
+// bingoHasLine() in firestore.rules (write guard) — the three must be
+// changed together.
+export const WIN_LINES: ReadonlyArray<ReadonlyArray<number>> = [
+  [0, 1, 2, 3],
+  [4, 5, 6, 7],
+  [8, 9, 10, 11],
+  [12, 13, 14, 15],
+  [0, 4, 8, 12],
+  [1, 5, 9, 13],
+  [2, 6, 10, 14],
+  [3, 7, 11, 15],
+  [0, 5, 10, 15],
+  [3, 6, 9, 12],
+];
+
+// A card that can never complete a line against the given sequence.
+// Unreachable while cards are dealt from the same bank the sequence is
+// built from, but callers should not have to assume that.
+export const NEVER_WINS = Number.POSITIVE_INFINITY;
+
+// How many cards we deal and score before settling. Each attempt is a
+// 16-of-N shuffle plus ten 4-cell scans, so the whole loop is
+// microseconds; the ceiling exists because the occupancy lookup that
+// consumes these turns into a single Firestore `in` query, and that
+// clause takes at most 30 values.
+export const MAX_DEAL_ATTEMPTS = 16;
+
+// Nobody should win in the opening seconds — the room has not even
+// settled and a prize would be gone. We refuse cards that win before
+// this ball, capped low enough that it never eats the whole candidate
+// pool on a small bank.
+const EARLIEST_WIN_CAP = 6;
+
+export function earliestWinFloor(drawOrderLength: number): number {
+  return Math.min(EARLIEST_WIN_CAP, Math.floor(drawOrderLength / 4));
+}
+
+// The sealed calling sequence: the entire bank in random order, so every
+// card eventually wins if the admin keeps calling. `seed` must be
+// unpredictable (a fresh UUID at seal time) — deriving it from public
+// data like the instance id would let an attendee recompute the sequence
+// and know every ball in advance.
+export function buildDrawOrder(
+  terms: readonly string[],
+  seed: string
+): string[] {
+  return seededShuffle(normalizeTerms(terms), seed);
+}
+
+// The ball number this card wins on: 1-based, so 31 means "after the
+// 31st ball is called". Min over the ten lines of the last ball that
+// line needs.
+export function classicWinIndex(
+  card: readonly string[],
+  drawOrder: readonly string[]
+): number {
+  const position = new Map<string, number>();
+  for (let i = 0; i < drawOrder.length; i++) {
+    if (!position.has(drawOrder[i])) position.set(drawOrder[i], i + 1);
+  }
+
+  let best = NEVER_WINS;
+  for (const line of WIN_LINES) {
+    let lineCost = 0;
+    for (const cell of line) {
+      const pos = position.get(card[cell]);
+      if (pos === undefined) {
+        lineCost = NEVER_WINS;
+        break;
+      }
+      if (pos > lineCost) lineCost = pos;
+    }
+    if (lineCost < best) best = lineCost;
+  }
+  return best;
+}
+
+export interface CardCandidate {
+  card: string[];
+  // Ball this card would win on (1-based).
+  winIndex: number;
+  // Which deal produced it. Kept so the audit trail can show how hard
+  // the dealer had to work to find a free ball.
+  attempt: number;
+}
+
+// Attempt 0 reuses the plain seed, so a classic card matches the
+// conference-mode card for the same (uid, instance) unless a collision
+// forces a re-deal.
+function dealSeed(seedBase: string, attempt: number): string {
+  return attempt === 0 ? seedBase : `${seedBase}#${attempt}`;
+}
+
+// Deals up to `attempts` cards and scores each one. Cards that win
+// before `minWinIndex` are dropped — unless that would leave nothing to
+// choose from, in which case an early card beats no card at all.
+export function buildCardCandidates(
+  terms: readonly string[],
+  drawOrder: readonly string[],
+  seedBase: string,
+  attempts: number = MAX_DEAL_ATTEMPTS,
+  minWinIndex = 0
+): CardCandidate[] {
+  const dealt: CardCandidate[] = [];
+  const seen = new Set<string>();
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const card = generateBingoCard(terms, dealSeed(seedBase, attempt));
+    const winIndex = classicWinIndex(card, drawOrder);
+    if (winIndex === NEVER_WINS) continue;
+    // Two seeds can land on the same 16 terms in the same order when the
+    // bank is barely bigger than a card; scoring it twice would waste an
+    // attempt without widening the choice. Newline is the separator
+    // because terms come from a textarea split on newlines and so can
+    // never contain one — a space could let ["a b", "c"] and ["a", "b c"]
+    // collide.
+    const fingerprint = card.join("\n");
+    if (seen.has(fingerprint)) continue;
+    seen.add(fingerprint);
+    dealt.push({ card, winIndex, attempt });
+  }
+
+  const lateEnough = dealt.filter((c) => c.winIndex >= minWinIndex);
+  return lateEnough.length > 0 ? lateEnough : dealt;
+}
+
+export interface StaggerPick extends CardCandidate {
+  // True when every candidate collided and the participant had to be
+  // seated on an already-taken ball anyway. Worth logging: it means the
+  // bank is too small for the crowd, and simultaneous bingos become
+  // possible again.
+  relaxed: boolean;
+}
+
+// Picks the first candidate whose winning ball still has room.
+//
+// When the bank is too small for the crowd, every candidate ball is
+// already taken and somebody has to double up. The overflow goes to the
+// LATEST ball, never the emptiest: by then the prizes have been handed
+// out and a shared win costs nothing, whereas a second winner on an
+// early ball is precisely the pile-up this function exists to prevent.
+// (Choosing the emptiest ball instead looks fairer and is measurably
+// worse — it seats the overflow on the rare early balls, which are empty
+// exactly because they are early.)
+export function pickStaggeredCard(
+  candidates: readonly CardCandidate[],
+  occupancy: Readonly<Record<number, number>>,
+  maxWinnersPerDraw: number
+): StaggerPick | null {
+  if (candidates.length === 0) return null;
+
+  let fallback = candidates[0];
+  let fallbackLoad = occupancy[fallback.winIndex] ?? 0;
+
+  for (const candidate of candidates) {
+    const load = occupancy[candidate.winIndex] ?? 0;
+    if (load < maxWinnersPerDraw) {
+      return { ...candidate, relaxed: false };
+    }
+    // Latest ball wins; on a tie take the emptier of the two so we don't
+    // stack needlessly when two deals share the same winning ball.
+    if (
+      candidate.winIndex > fallback.winIndex ||
+      (candidate.winIndex === fallback.winIndex && load < fallbackLoad)
+    ) {
+      fallback = candidate;
+      fallbackLoad = load;
+    }
+  }
+
+  return { ...fallback, relaxed: true };
+}
+
+// Distinct winning balls across the candidates, in first-seen order.
+// This is what the occupancy query asks Firestore about, so it is capped
+// at the 30-value ceiling of an `in` filter.
+export function candidateWinIndices(
+  candidates: readonly CardCandidate[]
+): number[] {
+  return Array.from(new Set(candidates.map((c) => c.winIndex))).slice(0, 30);
+}
+
+// Which cells of `card` are covered by the balls called so far. The
+// server derives this itself when verifying a claim, so a participant
+// cannot win by marking cells that were never called.
+export function markedFromDrawn(
+  card: readonly string[],
+  drawnTerms: readonly string[]
+): boolean[] {
+  const called = new Set(drawnTerms);
+  return card.map((term) => called.has(term));
+}
+
+// Completed lines for a marked card. Empty means no bingo yet.
+export function completedLines(marked: readonly boolean[]): number[][] {
+  const lines: number[][] = [];
+  for (const line of WIN_LINES) {
+    if (line.every((cell) => marked[cell] === true)) lines.push([...line]);
+  }
+  return lines;
+}

--- a/functions/src/services/bingoDrawStore.ts
+++ b/functions/src/services/bingoDrawStore.ts
@@ -1,0 +1,78 @@
+// Firestore side of classic bingo: where the sealed calling sequence and
+// the per-participant ball reservations live.
+//
+// Both collections are deliberately absent from firestore.rules, which
+// means the root catch-all denies them. That matters:
+//
+//   secret/draw — the full sequence. Public would let anyone read every
+//     ball before it is called.
+//   slots/{uid} — which ball each participant wins on. Participant docs
+//     ARE publicly readable, so keeping the reservation out of them is
+//     the only way the winning moment stays a surprise.
+//
+// Cloud Functions reach both through the Admin SDK, which bypasses rules.
+
+import { randomUUID } from "node:crypto";
+import { FieldValue } from "firebase-admin/firestore";
+import type {
+  CollectionReference,
+  DocumentReference,
+} from "firebase-admin/firestore";
+import { buildDrawOrder } from "./bingoClassic";
+
+const SECRET_COL = "secret";
+const DRAW_DOC = "draw";
+const SLOTS_COL = "slots";
+
+interface SealedDraw {
+  order?: string[];
+}
+
+export function drawOrderRef(
+  instanceRef: DocumentReference
+): DocumentReference {
+  return instanceRef.collection(SECRET_COL).doc(DRAW_DOC);
+}
+
+export function winSlotsCol(
+  instanceRef: DocumentReference
+): CollectionReference {
+  return instanceRef.collection(SLOTS_COL);
+}
+
+export async function readDrawOrder(
+  instanceRef: DocumentReference
+): Promise<string[]> {
+  const snap = await drawOrderRef(instanceRef).get();
+  return (snap.data() as SealedDraw | undefined)?.order ?? [];
+}
+
+// Seals the calling sequence once and returns it forever after.
+//
+// The seed is a fresh UUID rather than anything derived from the instance
+// id or the term list: those are public, and a seeded shuffle over public
+// inputs is a sequence any attendee could recompute at home.
+export async function ensureDrawOrder(
+  instanceRef: DocumentReference,
+  terms: readonly string[]
+): Promise<string[]> {
+  const existing = await readDrawOrder(instanceRef);
+  if (existing.length > 0) return existing;
+
+  const ref = drawOrderRef(instanceRef);
+  // Transaction so two participants joining in the same instant cannot
+  // seal two different sequences — the first one through wins and the
+  // other reads it back.
+  return instanceRef.firestore.runTransaction(async (tx) => {
+    const fresh = await tx.get(ref);
+    const sealed = (fresh.data() as SealedDraw | undefined)?.order ?? [];
+    if (sealed.length > 0) return sealed;
+
+    const order = buildDrawOrder(terms, randomUUID());
+    tx.set(ref, {
+      order,
+      sealedAt: FieldValue.serverTimestamp(),
+    });
+    return order;
+  });
+}

--- a/src/components/react/admin/event-minigames/BingoWinnersPanel.tsx
+++ b/src/components/react/admin/event-minigames/BingoWinnersPanel.tsx
@@ -5,6 +5,10 @@ interface Winner {
   id: string;
   alias: string;
   bingoWonAt?: { seconds?: number; _seconds?: number } | null;
+  // Classic mode only: the placing and the ball it happened on, both
+  // assigned by the Cloud Function that verified the claim.
+  bingoRank?: number;
+  bingoWinDraw?: number;
 }
 
 interface Props {
@@ -12,6 +16,9 @@ interface Props {
   instanceId: string;
   title: string;
   onClose: () => void;
+  // Classic mode: how many of these winners actually get a prize. Left
+  // undefined in conference mode, which has no prize split.
+  prizes?: number;
 }
 
 function formatWonAt(value: Winner["bingoWonAt"]): string {
@@ -21,7 +28,13 @@ function formatWonAt(value: Winner["bingoWonAt"]): string {
   return new Date(seconds * 1000).toLocaleString("es-PE");
 }
 
-export function BingoWinnersPanel({ slug, instanceId, title, onClose }: Props) {
+export function BingoWinnersPanel({
+  slug,
+  instanceId,
+  title,
+  onClose,
+  prizes,
+}: Props) {
   const [winners, setWinners] = useState<Winner[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -103,9 +116,27 @@ export function BingoWinnersPanel({ slug, instanceId, title, onClose }: Props) {
                     <span className="text-lg" aria-hidden>
                       {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : "🎉"}
                     </span>
-                    <p className="font-medium text-gray-900 dark:text-white">
-                      {w.alias}
-                    </p>
+                    <div>
+                      <p className="font-medium text-gray-900 dark:text-white">
+                        {w.alias}
+                      </p>
+                      {w.bingoWinDraw !== undefined && (
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          Línea en la bola {w.bingoWinDraw}
+                        </p>
+                      )}
+                    </div>
+                    {prizes !== undefined && (
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                          i < prizes
+                            ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+                            : "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300"
+                        }`}
+                      >
+                        {i < prizes ? "Premio" : "Mención"}
+                      </span>
+                    )}
                   </div>
                   <span className="text-xs text-gray-500 dark:text-gray-400">
                     {formatWonAt(w.bingoWonAt)}

--- a/src/components/react/admin/event-minigames/EventMinigameManager.tsx
+++ b/src/components/react/admin/event-minigames/EventMinigameManager.tsx
@@ -126,6 +126,25 @@ export function EventMinigameManager({ initialSlug }: Props) {
     setBusyId(null);
   }
 
+  async function handleDrawBall(id: string) {
+    if (!slug) return;
+    setBusyId(id);
+    const res = await api.drawBingoBall(slug, id);
+    if (res.success && res.data) {
+      setToast({
+        message: `🎱 ${res.data.term} · bola ${res.data.drawCount} (quedan ${res.data.remaining})`,
+        type: "success",
+      });
+      await reload();
+    } else {
+      setToast({
+        message: res.error || "Error al cantar la bola",
+        type: "error",
+      });
+    }
+    setBusyId(null);
+  }
+
   async function handleDelete(id: string) {
     if (!slug) return;
     setBusyId(id);
@@ -233,6 +252,11 @@ export function EventMinigameManager({ initialSlug }: Props) {
               onSpin={
                 inst.type === "roulette" ? () => handleSpin(inst.id) : undefined
               }
+              onDrawBall={
+                inst.type === "bingo" && inst.config?.classic === true
+                  ? () => handleDrawBall(inst.id)
+                  : undefined
+              }
             />
           ))}
         </div>
@@ -252,6 +276,11 @@ export function EventMinigameManager({ initialSlug }: Props) {
           instanceId={moderationFor.id}
           title={moderationFor.title}
           onClose={() => setModerationFor(null)}
+          prizes={
+            moderationFor.config?.classic === true
+              ? ((moderationFor.config?.prizes as number | undefined) ?? 3)
+              : undefined
+          }
         />
       )}
       {moderationFor && moderationFor.type === "roulette" && (

--- a/src/components/react/admin/event-minigames/InstanceCard.tsx
+++ b/src/components/react/admin/event-minigames/InstanceCard.tsx
@@ -19,6 +19,16 @@ interface Props {
   onOpenModeration?: () => void;
   // Roulette-specific: spin the wheel.
   onSpin?: () => Promise<void> | void;
+  // Classic-bingo-specific: call the next ball.
+  onDrawBall?: () => Promise<void> | void;
+}
+
+function isClassicBingo(instance: MinigameInstance): boolean {
+  return instance.type === "bingo" && instance.config?.classic === true;
+}
+
+function bankSize(instance: MinigameInstance): number {
+  return (instance.config?.terms as string[] | undefined)?.length ?? 0;
 }
 
 function questionCount(instance: MinigameInstance): number {
@@ -35,6 +45,7 @@ export function InstanceCard({
   busy,
   onOpenModeration,
   onSpin,
+  onDrawBall,
 }: Props) {
   const moderationLabel =
     instance.type === "wordcloud"
@@ -49,6 +60,10 @@ export function InstanceCard({
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const isQuiz = instance.type === "quiz";
+  const classic = isClassicBingo(instance);
+  const totalBalls = bankSize(instance);
+  const calledBalls = instance.drawCount ?? 0;
+  const allBallsCalled = totalBalls > 0 && calledBalls >= totalBalls;
   const totalQuestions = questionCount(instance);
   const currentQ =
     instance.currentQuestionIndex !== undefined &&
@@ -83,6 +98,19 @@ export function InstanceCard({
           {isQuiz && (
             <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
               Pregunta {currentQ} de {totalQuestions}
+            </p>
+          )}
+          {classic && (
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Bola {calledBalls} de {totalBalls}
+              {instance.lastDrawnTerm && (
+                <>
+                  {" · última: "}
+                  <span className="font-medium text-gray-700 dark:text-gray-200">
+                    {instance.lastDrawnTerm}
+                  </span>
+                </>
+              )}
             </p>
           )}
         </div>
@@ -152,6 +180,16 @@ export function InstanceCard({
                 className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
               >
                 ⏭ Avanzar pregunta
+              </button>
+            )}
+            {classic && onDrawBall && (
+              <button
+                type="button"
+                onClick={() => onDrawBall()}
+                disabled={busy || allBallsCalled}
+                className="bg-google-green rounded-lg px-3 py-1.5 text-sm font-medium text-white hover:brightness-110 disabled:opacity-50"
+              >
+                {allBallsCalled ? "Sin bolas" : "🎱 Cantar bola"}
               </button>
             )}
             {instance.type === "roulette" && onSpin && (

--- a/src/components/react/admin/event-minigames/types.ts
+++ b/src/components/react/admin/event-minigames/types.ts
@@ -15,6 +15,12 @@ export interface MinigameInstance {
   order: number;
   config?: Record<string, unknown>;
   currentQuestionIndex?: number;
+  // Classic-bingo runtime state, written by the Cloud Function on every
+  // called ball.
+  drawCount?: number;
+  drawnTerms?: string[];
+  lastDrawnTerm?: string | null;
+  bingoWinnerCount?: number;
 }
 
 export const STATE_LABELS: Record<InstanceState, string> = {

--- a/src/components/react/admin/minigame-templates/forms/BingoFields.tsx
+++ b/src/components/react/admin/minigame-templates/forms/BingoFields.tsx
@@ -1,11 +1,17 @@
 import { useMemo, useState } from "react";
 import { FormField } from "../../ui/FormField";
 import { inputClass, type BingoConfig } from "../types";
+import { GOOGLE_TECH_TERMS } from "./googleTechTerms";
 
 interface Props {
   value: BingoConfig;
   onChange: (next: BingoConfig) => void;
 }
+
+// A bank this size or larger makes cards diverge enough that wins spread
+// out on their own. Below it the dealer has to work harder to keep the
+// bingos apart, and it says so.
+const COMFORTABLE_BANK = 40;
 
 function termsToText(terms: string[]): string {
   return terms.join("\n");
@@ -31,6 +37,14 @@ export function BingoFields({ value, onChange }: Props) {
     onChange({ ...value, terms: textToTerms(next) });
   }
 
+  function fillWithGoogleTerms() {
+    const merged = Array.from(
+      new Set([...textToTerms(raw), ...GOOGLE_TECH_TERMS])
+    );
+    setRaw(termsToText(merged));
+    onChange({ ...value, terms: merged });
+  }
+
   return (
     <div className="space-y-4">
       <FormField label="Términos del bingo" required>
@@ -42,9 +56,94 @@ export function BingoFields({ value, onChange }: Props) {
           className={`${inputClass} font-mono`}
         />
       </FormField>
-      <p className="text-xs text-gray-500 dark:text-gray-400">
-        {termCount} términos detectados. Mínimo 16 (cada cartón es 4×4).
-      </p>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {termCount} términos detectados. Mínimo 16 (cada cartón es 4×4).
+        </p>
+        <button
+          type="button"
+          onClick={fillWithGoogleTerms}
+          className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+        >
+          + Tecnologías de Google
+        </button>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+        <label className="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-300">
+          <input
+            type="checkbox"
+            checked={value.classic}
+            onChange={(e) => onChange({ ...value, classic: e.target.checked })}
+            className="mt-0.5 h-4 w-4 rounded border-gray-300"
+          />
+          <span>
+            <span className="font-medium text-gray-900 dark:text-white">
+              Bingo clásico
+            </span>
+            <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+              Tú cantas las bolas desde el panel y salen animadas en el
+              proyector. Los asistentes solo pueden marcar lo que ya cantaste, y
+              el ganador se verifica en el servidor.
+            </span>
+            <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+              Sin marcar: modo conferencia — nadie canta, los que “cantan” son
+              los speakers sin saberlo y cada uno marca cuando oye un término.
+            </span>
+          </span>
+        </label>
+
+        {value.classic && (
+          <div className="mt-4 grid gap-4 border-t border-gray-100 pt-4 sm:grid-cols-2 dark:border-gray-700">
+            <FormField label="Premios disponibles">
+              <input
+                type="number"
+                min={1}
+                max={20}
+                value={value.prizes}
+                onChange={(e) =>
+                  onChange({
+                    ...value,
+                    prizes: Number(e.target.value) || 1,
+                  })
+                }
+                className={inputClass}
+              />
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Los primeros {value.prizes} en completar línea salen marcados
+                como premiados; el resto, como menciones.
+              </p>
+            </FormField>
+            <FormField label="Ganadores por bola">
+              <input
+                type="number"
+                min={1}
+                max={10}
+                value={value.maxWinnersPerDraw}
+                onChange={(e) =>
+                  onChange({
+                    ...value,
+                    maxWinnersPerDraw: Number(e.target.value) || 1,
+                  })
+                }
+                className={inputClass}
+              />
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Déjalo en 1 y los cartones se reparten para que nunca canten
+                bingo dos personas en la misma bola.
+              </p>
+            </FormField>
+          </div>
+        )}
+
+        {value.classic && termCount > 0 && termCount < COMFORTABLE_BANK && (
+          <p className="mt-4 rounded-lg border border-yellow-300 bg-yellow-50 p-3 text-xs text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-300">
+            Con {termCount} términos los cartones se parecen mucho entre sí y la
+            partida se acaba pronto. Sube a {COMFORTABLE_BANK}–50 para que haya
+            tensión y los bingos se separen solos.
+          </p>
+        )}
+      </div>
 
       <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
         <input

--- a/src/components/react/admin/minigame-templates/forms/googleTechTerms.ts
+++ b/src/components/react/admin/minigame-templates/forms/googleTechTerms.ts
@@ -1,0 +1,59 @@
+// Starter bank for a classic bingo at a GDG event: Google products and
+// technologies, short enough to fit on a projected ball and to be shouted
+// across a room.
+//
+// Size matters more than content here. Every card holds 16 terms, so with
+// a 24-term bank two attendees share two thirds of their card and the
+// bingos all land at once; nearer 50 the cards diverge and the game has
+// room to build tension. That is why this list is long — it is meant to
+// be trimmed, not padded.
+export const GOOGLE_TECH_TERMS: readonly string[] = [
+  "Android",
+  "Angular",
+  "Apps Script",
+  "BigQuery",
+  "Chrome",
+  "Cloud Functions",
+  "Cloud Run",
+  "Cloud Storage",
+  "Colab",
+  "Dart",
+  "DeepMind",
+  "Dialogflow",
+  "Firebase",
+  "Firestore",
+  "Flutter",
+  "Gemini",
+  "Gemma",
+  "Go",
+  "Google Analytics",
+  "Google Maps Platform",
+  "Google Workspace",
+  "Jetpack Compose",
+  "Kaggle",
+  "Keras",
+  "Kotlin",
+  "Kubernetes",
+  "Lighthouse",
+  "Looker Studio",
+  "Material Design",
+  "NotebookLM",
+  "Play Store",
+  "Pub/Sub",
+  "Spanner",
+  "TensorFlow",
+  "TPU",
+  "Vertex AI",
+  "WebGPU",
+  "Wear OS",
+  "Android Studio",
+  "Cloud SQL",
+  "Dataflow",
+  "Firebase Studio",
+  "Google Cloud",
+  "Google Search",
+  "Google Sheets",
+  "Identity Platform",
+  "Protobuf",
+  "reCAPTCHA",
+];

--- a/src/components/react/admin/minigame-templates/types.ts
+++ b/src/components/react/admin/minigame-templates/types.ts
@@ -33,6 +33,14 @@ export interface BingoConfig {
   terms: string[];
   cardSize: 4;
   freeCenter: boolean;
+  // Classic mode: an admin calls the terms out loud one at a time and
+  // participants may only mark what has been called. Off means
+  // conference mode, where the speakers do the calling without knowing
+  // it and every card marks freely.
+  classic: boolean;
+  prizes: number;
+  // Cards are dealt so that at most this many win on the same ball.
+  maxWinnersPerDraw: number;
 }
 
 export interface RouletteConfig {
@@ -141,6 +149,9 @@ export function emptyForType(type: MinigameType): Template {
           terms: [],
           cardSize: 4,
           freeCenter: false,
+          classic: false,
+          prizes: 3,
+          maxWinnersPerDraw: 1,
         },
       };
     case "roulette":

--- a/src/components/react/event/BingoCardView.tsx
+++ b/src/components/react/event/BingoCardView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import { getFirestore } from "@/lib/firebase";
 import {
@@ -32,18 +32,32 @@ export function BingoCardView({
     instanceId,
     uid
   );
-  const [pendingIndex, setPendingIndex] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [claiming, setClaiming] = useState(false);
+
+  // What the player has tapped but the server has not confirmed yet, and
+  // the writer state that keeps those taps in order. See `toggle` for why
+  // this exists rather than a simple "one write at a time" lock.
+  const [optimistic, setOptimistic] = useState<boolean[] | null>(null);
+  const desiredRef = useRef<boolean[] | null>(null);
+  const writingRef = useRef(false);
 
   const isClassic = instance?.config?.classic === true;
   const prizes = (instance?.config?.prizes as number | undefined) ?? 3;
 
   const card = participant?.bingoCard ?? [];
-  const marked = useMemo(
-    () => participant?.bingoMarked ?? emptyMarked(),
-    [participant?.bingoMarked]
-  );
+  const serverMarked = useMemo(() => {
+    const stored = participant?.bingoMarked ?? emptyMarked();
+    if (stored.length === CELL_COUNT) return stored;
+    // Pad a short array rather than throwing in detectBingoWin below.
+    const padded = [...stored];
+    while (padded.length < CELL_COUNT) padded.push(false);
+    return padded.slice(0, CELL_COUNT);
+  }, [participant?.bingoMarked]);
+
+  // Render the player's own taps immediately; fall back to the server's
+  // record once there is nothing in flight.
+  const marked = optimistic ?? serverMarked;
 
   // Balls already called out loud. Only these may be marked in classic
   // mode — the server enforces the same rule when verifying a claim, so a
@@ -75,20 +89,39 @@ export function BingoCardView({
     );
   }, [isClassic, hasWonBefore, winningLines, called, card]);
 
-  async function toggle(index: number) {
-    if (pendingIndex !== null) return;
+  // Records a tap and schedules the write.
+  //
+  // Taps must never be dropped. The card lights up the moment the local
+  // Firestore cache echoes a write — before setDoc resolves against the
+  // server — so a player who taps a cell, sees it turn blue and moves on
+  // to the next one is tapping while the previous write is still in
+  // flight. A plain "one write at a time, ignore the rest" lock silently
+  // swallowed every other tap in that rhythm (measured in a browser: 51ms,
+  // stuck, 51ms, stuck) and gave no hint that half the marks were gone.
+  // Somebody joining a classic game late has a handful of already-called
+  // cells to catch up on and taps them in exactly that rhythm.
+  //
+  // So the intended card lives in a ref, every tap updates it, and a
+  // single writer drains it — coalescing a burst into one write. Writing
+  // the array wholesale is also why parallel writes are not the answer:
+  // two of them racing would each clobber the other's cell.
+  function toggle(index: number) {
     if (card.length !== CELL_COUNT) return;
     // Classic mode: a cell opens up only once its term has been called.
     if (isClassic && !called.has(card[index]) && marked[index] !== true) return;
 
-    const nextMarked = [...marked];
-    if (nextMarked.length !== CELL_COUNT) {
-      while (nextMarked.length < CELL_COUNT) nextMarked.push(false);
-    }
-    nextMarked[index] = !nextMarked[index];
-
-    setPendingIndex(index);
+    const base = desiredRef.current ?? marked;
+    const next = [...base];
+    next[index] = !next[index];
+    desiredRef.current = next;
+    setOptimistic(next);
     setError(null);
+    void flush();
+  }
+
+  async function flush() {
+    if (writingRef.current) return; // the running writer will pick this up
+    writingRef.current = true;
     try {
       const db = await getFirestore();
       const { doc, setDoc, serverTimestamp } =
@@ -97,19 +130,32 @@ export function BingoCardView({
         db,
         `events/${slug}/minigames/${instanceId}/participants/${uid}`
       );
-      // Conference mode has nobody calling terms, so completing a line is
-      // the win and the client records it (firestore.rules re-checks the
-      // line). Classic mode routes the win through /bingo/claim instead —
-      // the rules there reject a client-written bingoWonAt outright.
-      const justWon =
-        !isClassic && !hasWonBefore && detectBingoWin(nextMarked).length > 0;
-      const payload: Record<string, unknown> = { bingoMarked: nextMarked };
-      if (justWon) payload.bingoWonAt = serverTimestamp();
-      await setDoc(ref, payload, { merge: true });
+      while (desiredRef.current) {
+        const nextMarked = desiredRef.current;
+        // Conference mode has nobody calling terms, so completing a line is
+        // the win and the client records it (firestore.rules re-checks the
+        // line). Classic mode routes the win through /bingo/claim instead —
+        // the rules there reject a client-written bingoWonAt outright.
+        const justWon =
+          !isClassic && !hasWonBefore && detectBingoWin(nextMarked).length > 0;
+        const payload: Record<string, unknown> = { bingoMarked: nextMarked };
+        if (justWon) payload.bingoWonAt = serverTimestamp();
+        // Cleared before awaiting, so a tap that lands mid-write queues
+        // the next pass instead of being lost.
+        desiredRef.current = null;
+        await setDoc(ref, payload, { merge: true });
+      }
+      // Nothing queued any more: hand the card back to the server's own
+      // record so the two cannot drift apart.
+      setOptimistic(null);
     } catch (err) {
+      // Drop the optimistic view as well — the marks did not land, and
+      // showing them as though they had would be a lie.
+      desiredRef.current = null;
+      setOptimistic(null);
       setError(err instanceof Error ? err.message : "No pudimos guardar");
     } finally {
-      setPendingIndex(null);
+      writingRef.current = false;
     }
   }
 
@@ -196,7 +242,11 @@ export function BingoCardView({
               key={index}
               type="button"
               onClick={() => toggle(index)}
-              disabled={pendingIndex === index || isLocked}
+              // Only a cell whose ball has not been called is unusable.
+              // A write in flight no longer disables anything: the tap is
+              // queued, so blocking the cell would just make the player
+              // think the app missed them.
+              disabled={isLocked}
               aria-pressed={isMarked}
               aria-label={isLocked ? `${term} (aún no cantado)` : term}
               className={`flex aspect-square items-center justify-center rounded-lg border p-2 text-center text-xs font-medium transition disabled:opacity-50 sm:text-sm ${

--- a/src/components/react/event/BingoCardView.tsx
+++ b/src/components/react/event/BingoCardView.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { api } from "@/lib/api";
 import { getFirestore } from "@/lib/firebase";
 import {
   CARD_SIZE,
@@ -7,15 +8,25 @@ import {
   emptyMarked,
 } from "@/lib/bingo";
 import { useParticipantDoc } from "./useParticipantDoc";
+import type { LiveInstance } from "./types";
 
 interface Props {
   slug: string;
   instanceId: string;
   uid: string;
   title: string;
+  // Live instance doc. Classic mode reads the called balls from it; in
+  // conference mode there is nothing to read, so it stays optional.
+  instance?: LiveInstance;
 }
 
-export function BingoCardView({ slug, instanceId, uid, title }: Props) {
+export function BingoCardView({
+  slug,
+  instanceId,
+  uid,
+  title,
+  instance,
+}: Props) {
   const { doc: participant, loading } = useParticipantDoc(
     slug,
     instanceId,
@@ -23,6 +34,10 @@ export function BingoCardView({ slug, instanceId, uid, title }: Props) {
   );
   const [pendingIndex, setPendingIndex] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [claiming, setClaiming] = useState(false);
+
+  const isClassic = instance?.config?.classic === true;
+  const prizes = (instance?.config?.prizes as number | undefined) ?? 3;
 
   const card = participant?.bingoCard ?? [];
   const marked = useMemo(
@@ -30,7 +45,16 @@ export function BingoCardView({ slug, instanceId, uid, title }: Props) {
     [participant?.bingoMarked]
   );
 
+  // Balls already called out loud. Only these may be marked in classic
+  // mode — the server enforces the same rule when verifying a claim, so a
+  // hand-crafted write buys nothing.
+  const called = useMemo(
+    () => new Set(instance?.drawnTerms ?? []),
+    [instance?.drawnTerms]
+  );
+
   const hasWonBefore = Boolean(participant?.bingoWonAt);
+  const rank = participant?.bingoRank ?? 0;
   const winningLines = useMemo(
     () => (marked.length === CELL_COUNT ? detectBingoWin(marked) : []),
     [marked]
@@ -41,9 +65,22 @@ export function BingoCardView({ slug, instanceId, uid, title }: Props) {
     return set;
   }, [winningLines]);
 
+  // In classic mode a line only counts if every cell in it was actually
+  // called, so the claim button never invites a request the server will
+  // refuse.
+  const claimableLine = useMemo(() => {
+    if (!isClassic || hasWonBefore) return false;
+    return winningLines.some((line) =>
+      line.every((cell) => called.has(card[cell]))
+    );
+  }, [isClassic, hasWonBefore, winningLines, called, card]);
+
   async function toggle(index: number) {
     if (pendingIndex !== null) return;
     if (card.length !== CELL_COUNT) return;
+    // Classic mode: a cell opens up only once its term has been called.
+    if (isClassic && !called.has(card[index]) && marked[index] !== true) return;
+
     const nextMarked = [...marked];
     if (nextMarked.length !== CELL_COUNT) {
       while (nextMarked.length < CELL_COUNT) nextMarked.push(false);
@@ -54,14 +91,18 @@ export function BingoCardView({ slug, instanceId, uid, title }: Props) {
     setError(null);
     try {
       const db = await getFirestore();
-      const { doc, setDoc, serverTimestamp } = await import(
-        "firebase/firestore"
-      );
+      const { doc, setDoc, serverTimestamp } =
+        await import("firebase/firestore");
       const ref = doc(
         db,
         `events/${slug}/minigames/${instanceId}/participants/${uid}`
       );
-      const justWon = !hasWonBefore && detectBingoWin(nextMarked).length > 0;
+      // Conference mode has nobody calling terms, so completing a line is
+      // the win and the client records it (firestore.rules re-checks the
+      // line). Classic mode routes the win through /bingo/claim instead —
+      // the rules there reject a client-written bingoWonAt outright.
+      const justWon =
+        !isClassic && !hasWonBefore && detectBingoWin(nextMarked).length > 0;
       const payload: Record<string, unknown> = { bingoMarked: nextMarked };
       if (justWon) payload.bingoWonAt = serverTimestamp();
       await setDoc(ref, payload, { merge: true });
@@ -70,6 +111,17 @@ export function BingoCardView({ slug, instanceId, uid, title }: Props) {
     } finally {
       setPendingIndex(null);
     }
+  }
+
+  async function claim() {
+    if (claiming) return;
+    setClaiming(true);
+    setError(null);
+    const res = await api.claimBingo(slug, instanceId);
+    if (!res.success) {
+      setError(res.error || "No pudimos registrar tu bingo");
+    }
+    setClaiming(false);
   }
 
   if (loading) {
@@ -91,19 +143,41 @@ export function BingoCardView({ slug, instanceId, uid, title }: Props) {
 
   return (
     <div>
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-4 flex items-center justify-between gap-3">
         <h2 className="text-primary text-2xl font-semibold">{title}</h2>
         {hasWonBefore && (
           <span className="rounded-full bg-yellow-100 px-3 py-1 text-sm font-semibold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
-            🎉 ¡Bingo!
+            {rank > 0
+              ? `🎉 ¡Bingo! Puesto ${rank}${rank <= prizes ? " · premio" : ""}`
+              : "🎉 ¡Bingo!"}
           </span>
         )}
       </div>
+
+      {isClassic && (
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/60">
+          <div>
+            <p className="text-xs tracking-widest text-gray-500 uppercase dark:text-gray-400">
+              Última bola
+            </p>
+            <p className="text-primary text-xl font-bold">
+              {instance?.lastDrawnTerm ?? "—"}
+            </p>
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {instance?.drawCount ?? 0} bola
+            {(instance?.drawCount ?? 0) !== 1 && "s"} cantada
+            {(instance?.drawCount ?? 0) !== 1 && "s"}
+          </p>
+        </div>
+      )}
+
       {error && (
         <p className="mb-3 text-sm text-red-600 dark:text-red-400" role="alert">
           {error}
         </p>
       )}
+
       <div
         className="grid gap-2"
         style={{ gridTemplateColumns: `repeat(${CARD_SIZE}, minmax(0, 1fr))` }}
@@ -113,19 +187,26 @@ export function BingoCardView({ slug, instanceId, uid, title }: Props) {
         {card.map((term, index) => {
           const isMarked = marked[index] === true;
           const isWinning = winningIndices.has(index);
+          // Called but not yet ticked: nudge without marking it for them,
+          // because noticing the ball is the game.
+          const isPending = isClassic && !isMarked && called.has(term);
+          const isLocked = isClassic && !isMarked && !called.has(term);
           return (
             <button
               key={index}
               type="button"
               onClick={() => toggle(index)}
-              disabled={pendingIndex === index}
+              disabled={pendingIndex === index || isLocked}
               aria-pressed={isMarked}
+              aria-label={isLocked ? `${term} (aún no cantado)` : term}
               className={`flex aspect-square items-center justify-center rounded-lg border p-2 text-center text-xs font-medium transition disabled:opacity-50 sm:text-sm ${
                 isMarked
                   ? isWinning
                     ? "border-yellow-400 bg-yellow-200 text-yellow-900 dark:bg-yellow-500/30 dark:text-yellow-100"
                     : "border-blue-400 bg-blue-100 text-blue-900 dark:bg-blue-500/30 dark:text-blue-100"
-                  : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                  : isPending
+                    ? "border-green-500 bg-green-50 text-green-900 ring-2 ring-green-400/60 dark:bg-green-900/20 dark:text-green-200"
+                    : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
               }`}
             >
               <span className="line-clamp-3 break-words">{term}</span>
@@ -133,8 +214,22 @@ export function BingoCardView({ slug, instanceId, uid, title }: Props) {
           );
         })}
       </div>
+
+      {claimableLine && (
+        <button
+          type="button"
+          onClick={claim}
+          disabled={claiming}
+          className="bg-google-green mt-4 w-full rounded-xl px-6 py-4 text-lg font-bold text-white shadow-lg transition hover:brightness-110 disabled:opacity-60"
+        >
+          {claiming ? "Cantando..." : "🎉 ¡BINGO!"}
+        </button>
+      )}
+
       <p className="mt-3 text-center text-xs text-gray-500 dark:text-gray-400">
-        Toca una celda cuando el speaker mencione el término.
+        {isClassic
+          ? "Marca las casillas que vayan cantando. Cuando completes una línea, pulsa ¡BINGO!"
+          : "Toca una celda cuando el speaker mencione el término."}
       </p>
     </div>
   );

--- a/src/components/react/event/MiniGamesRoot.tsx
+++ b/src/components/react/event/MiniGamesRoot.tsx
@@ -237,6 +237,7 @@ export function MiniGamesRoot({ slug }: Props) {
                     instanceId={inst.id}
                     uid={uid}
                     title={inst.title}
+                    instance={inst}
                   />
                 )}
                 {inst.type === "roulette" && (

--- a/src/components/react/event/ProjectorView.tsx
+++ b/src/components/react/event/ProjectorView.tsx
@@ -5,7 +5,7 @@ import type {
   WordCloudConfig,
 } from "../admin/minigame-templates/types";
 import { useAggregates } from "./useAggregates";
-import { useBingoWinners } from "./useBingoWinners";
+import { useBingoWinners, type BingoWinner } from "./useBingoWinners";
 import { useLiveMinigames } from "./useLiveMinigames";
 import { useRouletteParticipants } from "./useRouletteParticipants";
 import { useWordCloud } from "./useWordCloud";
@@ -400,7 +400,142 @@ function formatWinTime(value: { seconds?: number } | null | undefined): string {
   });
 }
 
+// Google brand colours, cycled per ball so the history strip reads as a
+// row of distinct balls rather than a wall of one colour. The faded
+// variants are spelled out rather than built as `${color}/70`, because
+// Tailwind only generates classes it can find literally in the source —
+// an interpolated opacity modifier would come out unstyled.
+const BALL_COLORS = [
+  "bg-google-blue",
+  "bg-google-red",
+  "bg-google-yellow",
+  "bg-google-green",
+];
+
+const BALL_COLORS_SOFT = [
+  "bg-google-blue/70",
+  "bg-google-red/70",
+  "bg-google-yellow/70",
+  "bg-google-green/70",
+];
+
+function ballColor(index: number, soft = false): string {
+  const palette = soft ? BALL_COLORS_SOFT : BALL_COLORS;
+  // Guard the negative case (index -1 before the first ball) so a bad
+  // index yields a colour rather than the literal class "undefined".
+  const n = palette.length;
+  return palette[((index % n) + n) % n];
+}
+
 function ProjectorBingo({
+  slug,
+  instance,
+}: {
+  slug: string;
+  instance: LiveInstance;
+}) {
+  if (instance.config?.classic === true) {
+    return <ProjectorBingoClassic slug={slug} instance={instance} />;
+  }
+  return <ProjectorBingoConference slug={slug} instance={instance} />;
+}
+
+// Classic mode: the admin calls a ball, it drops onto the screen, and the
+// ones already called line up behind it.
+function ProjectorBingoClassic({
+  slug,
+  instance,
+}: {
+  slug: string;
+  instance: LiveInstance;
+}) {
+  const { winners } = useBingoWinners(slug, instance.id);
+  const prizes = (instance.config?.prizes as number | undefined) ?? 3;
+  const bankSize =
+    (instance.config?.terms as string[] | undefined)?.length ?? 0;
+
+  const drawn = instance.drawnTerms ?? [];
+  const drawCount = instance.drawCount ?? drawn.length;
+  const current = instance.lastDrawnTerm ?? null;
+
+  // Re-key the ball on every new call so React remounts it and the drop
+  // animation replays. The count is part of the key because two balls
+  // called inside the same second would otherwise share a timestamp and
+  // the second one would appear without animating.
+  const drawKey = `${instance.lastDrawAt?.seconds ?? 0}-${drawCount}`;
+  const previous = useMemo(() => drawn.slice(0, -1).reverse(), [drawn]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-4">
+        <Badge color="green">Bingo clásico</Badge>
+        <span className="text-lg text-white/70 tabular-nums">
+          {drawCount}
+          {bankSize > 0 && ` / ${bankSize}`} bolas
+        </span>
+      </div>
+      <h2 className="mt-3 text-3xl font-bold">{instance.title}</h2>
+
+      <div className="mt-6 flex min-h-[15rem] flex-col items-center justify-center rounded-2xl border border-white/10 bg-black/40 p-6">
+        {current ? (
+          <div
+            key={drawKey}
+            className={`animate-bingo-ball-drop flex h-44 w-44 items-center justify-center rounded-full ${ballColor(
+              drawCount - 1
+            )} p-4 text-center shadow-2xl`}
+          >
+            <span className="text-2xl leading-tight font-extrabold break-words text-white drop-shadow">
+              {current}
+            </span>
+          </div>
+        ) : (
+          <>
+            {/* Nothing called yet. Idling balls beat a blank rectangle. */}
+            <div className="flex items-end gap-4" aria-hidden>
+              {BALL_COLORS.map((color, i) => (
+                <span
+                  key={color}
+                  className={`animate-bingo-tumble h-12 w-12 rounded-full ${color}`}
+                  style={{ animationDelay: `${i * 180}ms` }}
+                />
+              ))}
+            </div>
+            <p className="mt-6 text-xl text-white/70">
+              Esperando la primera bola...
+            </p>
+          </>
+        )}
+      </div>
+
+      {previous.length > 0 && (
+        <div className="mt-6">
+          <p className="text-xs tracking-widest text-white/50 uppercase">
+            Ya cantadas
+          </p>
+          <ul className="mt-3 flex flex-wrap gap-2">
+            {previous.map((term, i) => (
+              <li
+                key={`${term}-${i}`}
+                className={`flex h-20 w-20 items-center justify-center rounded-full ${ballColor(
+                  previous.length - 1 - i,
+                  true
+                )} p-2 text-center`}
+              >
+                <span className="text-[0.7rem] leading-tight font-bold break-words text-white">
+                  {term}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <BingoWinnerList winners={winners} prizes={prizes} />
+    </div>
+  );
+}
+
+function ProjectorBingoConference({
   slug,
   instance,
 }: {
@@ -415,33 +550,55 @@ function ProjectorBingo({
       <p className="mt-2 text-xl text-white/80">
         Marca tu cartón cuando el speaker mencione un término.
       </p>
-      <div className="mt-6 rounded-xl border border-white/10 bg-black/40 p-6">
-        <p className="text-xs tracking-widest text-white/50 uppercase">
-          Ganadores
-        </p>
-        {winners.length === 0 ? (
-          <p className="mt-3 text-white/60">Aún no hay ganadores.</p>
-        ) : (
-          <ol className="mt-3 space-y-2 text-lg">
-            {winners.map((w, i) => (
-              <li
-                key={w.uid}
-                className="flex items-center justify-between gap-4"
-              >
-                <span>
-                  <span aria-hidden className="mr-2">
-                    {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : "🎉"}
+      <BingoWinnerList winners={winners} />
+    </div>
+  );
+}
+
+// Shared by both bingo modes. `prizes` is classic-only: conference mode
+// has no ball count to rank against, so it just lists who got there first.
+function BingoWinnerList({
+  winners,
+  prizes,
+}: {
+  winners: BingoWinner[];
+  prizes?: number;
+}) {
+  return (
+    <div className="mt-6 rounded-xl border border-white/10 bg-black/40 p-6">
+      <p className="text-xs tracking-widest text-white/50 uppercase">
+        Ganadores
+      </p>
+      {winners.length === 0 ? (
+        <p className="mt-3 text-white/60">Aún no hay ganadores.</p>
+      ) : (
+        <ol className="mt-3 space-y-2 text-lg">
+          {winners.map((w, i) => (
+            <li key={w.uid} className="flex items-center justify-between gap-4">
+              <span>
+                <span aria-hidden className="mr-2">
+                  {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : "🎉"}
+                </span>
+                {w.alias}
+                {prizes !== undefined && (
+                  <span
+                    className={`ml-3 rounded-full px-2 py-0.5 text-xs font-semibold tracking-wide uppercase ${
+                      i < prizes
+                        ? "bg-google-green/25 text-green-200"
+                        : "bg-white/10 text-white/60"
+                    }`}
+                  >
+                    {i < prizes ? "Premio" : "Mención"}
                   </span>
-                  {w.alias}
-                </span>
-                <span className="text-sm text-white/60 tabular-nums">
-                  {formatWinTime(w.bingoWonAt)}
-                </span>
-              </li>
-            ))}
-          </ol>
-        )}
-      </div>
+                )}
+              </span>
+              <span className="text-sm text-white/60 tabular-nums">
+                {formatWinTime(w.bingoWonAt)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
     </div>
   );
 }

--- a/src/components/react/event/__tests__/BingoCardView.test.tsx
+++ b/src/components/react/event/__tests__/BingoCardView.test.tsx
@@ -8,6 +8,11 @@ const mocks = vi.hoisted(() => ({
   getFirestore: vi.fn(),
   doc: vi.fn(() => ({ __ref: true })),
   useParticipantDoc: vi.fn(),
+  claimBingo: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: { claimBingo: mocks.claimBingo },
 }));
 
 vi.mock("@/lib/firebase", () => ({
@@ -43,6 +48,7 @@ beforeEach(() => {
   mocks.getFirestore.mockResolvedValue({});
   mocks.doc.mockImplementation(() => ({ __ref: true }));
   mocks.setDoc.mockResolvedValue(undefined);
+  mocks.claimBingo.mockResolvedValue({ success: true, data: { rank: 1 } });
 });
 
 afterEach(() => cleanup());
@@ -155,5 +161,220 @@ describe("BingoCardView", () => {
     });
     render(<BingoCardView slug="x" instanceId="i" uid="u1" title="B" />);
     expect(screen.getByText(/¡Bingo!/i)).toBeInTheDocument();
+  });
+
+  // Classic mode: an admin calls the balls, so a cell only opens once its
+  // term has been called and the win goes through /bingo/claim rather
+  // than a direct Firestore write.
+  describe("classic mode", () => {
+    const classicInstance = (drawnTerms: string[]) =>
+      ({
+        id: "i",
+        type: "bingo",
+        mode: "global",
+        state: "live",
+        title: "B",
+        order: 0,
+        config: { classic: true, prizes: 3 },
+        drawnTerms,
+        drawCount: drawnTerms.length,
+        lastDrawnTerm: drawnTerms[drawnTerms.length - 1] ?? null,
+      }) as never;
+
+    function joined(marked: boolean[] = Array(16).fill(false), extra = {}) {
+      mocks.useParticipantDoc.mockReturnValue({
+        doc: {
+          uid: "u1",
+          alias: "Ana",
+          bingoCard: card(),
+          bingoMarked: marked,
+          ...extra,
+        },
+        loading: false,
+        error: null,
+      });
+    }
+
+    it("shows the last ball called", () => {
+      joined();
+      render(
+        <BingoCardView
+          slug="x"
+          instanceId="i"
+          uid="u1"
+          title="B"
+          // "Firebase" is in the bank but not on this card, which is the
+          // normal case and keeps the assertion unambiguous.
+          instance={classicInstance(["term-1", "Firebase"])}
+        />
+      );
+      expect(screen.getByText("Última bola")).toBeInTheDocument();
+      expect(screen.getByText("Firebase")).toBeInTheDocument();
+      expect(screen.getByText(/2 bolas cantadas/i)).toBeInTheDocument();
+    });
+
+    it("locks cells whose term has not been called", async () => {
+      joined();
+      const user = userEvent.setup();
+      render(
+        <BingoCardView
+          slug="x"
+          instanceId="i"
+          uid="u1"
+          title="B"
+          instance={classicInstance(["term-1"])}
+        />
+      );
+      const locked = screen.getByRole("button", {
+        name: /term-5 \(aún no cantado\)/i,
+      });
+      expect(locked).toBeDisabled();
+      await user.click(locked);
+      expect(mocks.setDoc).not.toHaveBeenCalled();
+    });
+
+    it("lets a called cell be marked", async () => {
+      joined();
+      const user = userEvent.setup();
+      render(
+        <BingoCardView
+          slug="x"
+          instanceId="i"
+          uid="u1"
+          title="B"
+          instance={classicInstance(["term-1"])}
+        />
+      );
+      await user.click(screen.getByRole("button", { name: "term-1" }));
+      await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(1));
+      const payload = mocks.setDoc.mock.calls[0][1] as Record<string, unknown>;
+      expect((payload.bingoMarked as boolean[])[0]).toBe(true);
+      // The win is the server's call here, never the client's.
+      expect(payload.bingoWonAt).toBeUndefined();
+    });
+
+    it("never writes bingoWonAt itself, even on a completed line", async () => {
+      const marked = Array(16).fill(false);
+      marked[1] = marked[2] = marked[3] = true;
+      joined(marked);
+      const user = userEvent.setup();
+      render(
+        <BingoCardView
+          slug="x"
+          instanceId="i"
+          uid="u1"
+          title="B"
+          instance={classicInstance(["term-1", "term-2", "term-3", "term-4"])}
+        />
+      );
+      await user.click(screen.getByRole("button", { name: "term-1" }));
+      await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(1));
+      const payload = mocks.setDoc.mock.calls[0][1] as Record<string, unknown>;
+      expect(payload.bingoWonAt).toBeUndefined();
+    });
+
+    it("offers the BINGO button once a called line is complete", async () => {
+      joined(Array.from({ length: 16 }, (_, i) => i < 4));
+      const user = userEvent.setup();
+      render(
+        <BingoCardView
+          slug="x"
+          instanceId="i"
+          uid="u1"
+          title="B"
+          instance={classicInstance(["term-1", "term-2", "term-3", "term-4"])}
+        />
+      );
+      const claim = screen.getByRole("button", { name: /¡BINGO!/i });
+      await user.click(claim);
+      await waitFor(() =>
+        expect(mocks.claimBingo).toHaveBeenCalledWith("x", "i")
+      );
+    });
+
+    it("hides the BINGO button when the line rests on uncalled cells", () => {
+      // The card says row 0 is marked, but only two of those balls were
+      // called — a leftover from an earlier state, or a tampered doc.
+      joined(Array.from({ length: 16 }, (_, i) => i < 4));
+      render(
+        <BingoCardView
+          slug="x"
+          instanceId="i"
+          uid="u1"
+          title="B"
+          instance={classicInstance(["term-1", "term-2"])}
+        />
+      );
+      expect(
+        screen.queryByRole("button", { name: /¡BINGO!/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("surfaces a rejected claim to the player", async () => {
+      mocks.claimBingo.mockResolvedValue({
+        success: false,
+        error: "Todavía no tienes una línea completa",
+      });
+      joined(Array.from({ length: 16 }, (_, i) => i < 4));
+      const user = userEvent.setup();
+      render(
+        <BingoCardView
+          slug="x"
+          instanceId="i"
+          uid="u1"
+          title="B"
+          instance={classicInstance(["term-1", "term-2", "term-3", "term-4"])}
+        />
+      );
+      await user.click(screen.getByRole("button", { name: /¡BINGO!/i }));
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toHaveTextContent(/línea completa/i)
+      );
+    });
+
+    it("shows the placing and prize status once crowned", () => {
+      joined(
+        Array.from({ length: 16 }, (_, i) => i < 4),
+        {
+          bingoWonAt: { seconds: 9 },
+          bingoRank: 2,
+        }
+      );
+      render(
+        <BingoCardView
+          slug="x"
+          instanceId="i"
+          uid="u1"
+          title="B"
+          instance={classicInstance(["term-1", "term-2", "term-3", "term-4"])}
+        />
+      );
+      expect(screen.getByText(/Puesto 2 · premio/i)).toBeInTheDocument();
+      // Already won — no second claim to make.
+      expect(
+        screen.queryByRole("button", { name: /¡BINGO!/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("labels a winner past the prize count as a mention", () => {
+      joined(
+        Array.from({ length: 16 }, (_, i) => i < 4),
+        {
+          bingoWonAt: { seconds: 9 },
+          bingoRank: 5,
+        }
+      );
+      render(
+        <BingoCardView
+          slug="x"
+          instanceId="i"
+          uid="u1"
+          title="B"
+          instance={classicInstance(["term-1", "term-2", "term-3", "term-4"])}
+        />
+      );
+      expect(screen.getByText(/Puesto 5/i)).toBeInTheDocument();
+      expect(screen.queryByText(/premio/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/react/event/__tests__/BingoCardView.test.tsx
+++ b/src/components/react/event/__tests__/BingoCardView.test.tsx
@@ -163,6 +163,84 @@ describe("BingoCardView", () => {
     expect(screen.getByText(/¡Bingo!/i)).toBeInTheDocument();
   });
 
+  // Regression cover for taps vanishing while a write was in flight. The
+  // card lights up from the local cache echo, well before setDoc resolves
+  // against the server, so a player who taps, sees blue and moves on was
+  // tapping into a lock that silently dropped them.
+  describe("rapid tapping", () => {
+    function deferredSetDoc() {
+      const resolvers: Array<() => void> = [];
+      mocks.setDoc.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolvers.push(() => resolve());
+          })
+      );
+      return resolvers;
+    }
+
+    beforeEach(() => {
+      mocks.useParticipantDoc.mockReturnValue({
+        doc: {
+          uid: "u1",
+          alias: "Ana",
+          bingoCard: card(),
+          bingoMarked: Array.from({ length: 16 }, () => false),
+        },
+        loading: false,
+        error: null,
+      });
+    });
+
+    it("keeps a second tap that lands while the first write is pending", async () => {
+      const resolvers = deferredSetDoc();
+      const user = userEvent.setup();
+      render(<BingoCardView slug="x" instanceId="i" uid="u1" title="B" />);
+      const buttons = screen.getAllByRole("button");
+
+      await user.click(buttons[0]);
+      await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(1));
+      // Still unresolved — exactly when taps used to disappear.
+      await user.click(buttons[1]);
+      await user.click(buttons[2]);
+
+      // Both later taps are visible right away rather than waiting on the
+      // server, and none of them is lost.
+      expect(buttons[1]).toHaveAttribute("aria-pressed", "true");
+      expect(buttons[2]).toHaveAttribute("aria-pressed", "true");
+
+      resolvers[0]();
+      await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(2));
+      // The queued taps are coalesced into one follow-up write carrying
+      // every mark, so nothing clobbers anything.
+      const second = mocks.setDoc.mock.calls[1][1] as { bingoMarked: boolean[] };
+      expect(second.bingoMarked.slice(0, 3)).toEqual([true, true, true]);
+    });
+
+    it("never disables a cell just because a write is in flight", async () => {
+      deferredSetDoc();
+      const user = userEvent.setup();
+      render(<BingoCardView slug="x" instanceId="i" uid="u1" title="B" />);
+      const buttons = screen.getAllByRole("button");
+      await user.click(buttons[0]);
+      await waitFor(() => expect(mocks.setDoc).toHaveBeenCalledTimes(1));
+      for (const b of buttons) expect(b).toBeEnabled();
+    });
+
+    it("rolls the card back and reports it when the write fails", async () => {
+      mocks.setDoc.mockRejectedValue(new Error("sin conexión"));
+      const user = userEvent.setup();
+      render(<BingoCardView slug="x" instanceId="i" uid="u1" title="B" />);
+      const buttons = screen.getAllByRole("button");
+      await user.click(buttons[0]);
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toHaveTextContent(/sin conexión/i)
+      );
+      // The mark is not left showing as if it had been saved.
+      expect(buttons[0]).toHaveAttribute("aria-pressed", "false");
+    });
+  });
+
   // Classic mode: an admin calls the balls, so a cell only opens once its
   // term has been called and the win goes through /bingo/claim rather
   // than a direct Firestore write.

--- a/src/components/react/event/__tests__/ProjectorView.test.tsx
+++ b/src/components/react/event/__tests__/ProjectorView.test.tsx
@@ -232,6 +232,104 @@ describe("ProjectorView", () => {
     expect(screen.getByText("Bingo!")).toBeInTheDocument();
     expect(screen.getByText("Ana")).toBeInTheDocument();
     expect(screen.getByText("Bea")).toBeInTheDocument();
+    // Conference mode has no ball count, so no prize/mention split.
+    expect(screen.queryByText(/Premio/i)).not.toBeInTheDocument();
+  });
+
+  describe("classic bingo", () => {
+    function liveClassic(overrides: Record<string, unknown> = {}) {
+      mocks.useLiveMinigames.mockReturnValue({
+        loading: false,
+        liveInstances: [
+          {
+            id: "i-bingo",
+            type: "bingo",
+            mode: "global",
+            state: "live",
+            title: "Bingo de tecnologías",
+            order: 0,
+            config: {
+              classic: true,
+              prizes: 2,
+              terms: Array.from({ length: 40 }, (_, i) => `t${i}`),
+            },
+            drawnTerms: [],
+            drawCount: 0,
+            lastDrawnTerm: null,
+            ...overrides,
+          },
+        ],
+        error: null,
+      });
+    }
+
+    it("idles with tumbling balls before the first is called", () => {
+      liveClassic();
+      renderProjector();
+      expect(screen.getByText("Bingo de tecnologías")).toBeInTheDocument();
+      // The badge names the mode, separately from the instance title.
+      expect(screen.getByText("Bingo clásico")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Esperando la primera bola/i)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/0 \/ 40 bolas/)).toBeInTheDocument();
+    });
+
+    it("shows the ball just called, and the earlier ones behind it", () => {
+      liveClassic({
+        drawnTerms: ["Firebase", "Flutter", "Gemini"],
+        drawCount: 3,
+        lastDrawnTerm: "Gemini",
+        lastDrawAt: { seconds: 1700000200 },
+      });
+      renderProjector();
+      expect(screen.getByText("Gemini")).toBeInTheDocument();
+      expect(screen.getByText("Firebase")).toBeInTheDocument();
+      expect(screen.getByText("Flutter")).toBeInTheDocument();
+      expect(screen.getByText(/Ya cantadas/i)).toBeInTheDocument();
+      expect(screen.getByText(/3 \/ 40 bolas/)).toBeInTheDocument();
+    });
+
+    it("replays the drop animation on the newly called ball", () => {
+      liveClassic({
+        drawnTerms: ["Firebase"],
+        drawCount: 1,
+        lastDrawnTerm: "Firebase",
+        lastDrawAt: { seconds: 1700000100 },
+      });
+      renderProjector();
+      const ball = screen.getByText("Firebase").parentElement;
+      expect(ball?.className).toContain("animate-bingo-ball-drop");
+    });
+
+    it("splits winners into prizes and mentions", () => {
+      liveClassic({ drawnTerms: ["a"], drawCount: 1, lastDrawnTerm: "a" });
+      mocks.useBingoWinners.mockReturnValue({
+        loading: false,
+        error: null,
+        winners: [
+          { uid: "u1", alias: "Ana", bingoWonAt: { seconds: 1700000000 } },
+          { uid: "u2", alias: "Bea", bingoWonAt: { seconds: 1700000060 } },
+          { uid: "u3", alias: "Cid", bingoWonAt: { seconds: 1700000120 } },
+        ],
+      });
+      renderProjector();
+      // prizes: 2 → first two are prizes, the third a mention.
+      expect(screen.getAllByText("Premio")).toHaveLength(2);
+      expect(screen.getAllByText("Mención")).toHaveLength(1);
+    });
+
+    it("stays read-only — the presenter's QR toggle is the only button", () => {
+      liveClassic({
+        drawnTerms: ["Firebase", "Flutter"],
+        drawCount: 2,
+        lastDrawnTerm: "Flutter",
+      });
+      renderProjector();
+      const buttons = screen.queryAllByRole("button");
+      expect(buttons).toHaveLength(1);
+      expect(buttons[0]).toHaveAttribute("aria-label", "Agrandar QR");
+    });
   });
 
   it("shows a small QR + URL footer when there are live games", () => {

--- a/src/components/react/event/types.ts
+++ b/src/components/react/event/types.ts
@@ -23,6 +23,14 @@ export interface LiveInstance {
   spinCount?: number;
   lastSpinWinnerId?: string | null;
   lastSpinAt?: { seconds: number; nanoseconds?: number } | null;
+  // Classic-bingo runtime fields (written by Cloud Function on each ball).
+  // `drawnTerms` is only what has already been called out loud — the rest
+  // of the sequence stays server-side so nobody can read ahead.
+  drawCount?: number;
+  drawnTerms?: string[];
+  lastDrawnTerm?: string | null;
+  lastDrawAt?: { seconds: number; nanoseconds?: number } | null;
+  bingoWinnerCount?: number;
 }
 
 export const LOCAL_STORAGE_ALIAS_KEY = (slug: string) =>

--- a/src/components/react/event/useParticipantDoc.ts
+++ b/src/components/react/event/useParticipantDoc.ts
@@ -7,6 +7,10 @@ export interface ParticipantDoc {
   bingoCard?: string[];
   bingoMarked?: boolean[];
   bingoWonAt?: { seconds: number } | null;
+  // Classic mode only: the placing the Cloud Function assigned when it
+  // verified the claim, and which ball it happened on.
+  bingoRank?: number;
+  bingoWinDraw?: number;
   quizScore?: number;
   quizAnsweredQuestions?: string[];
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -182,6 +182,27 @@ const realApi = {
       `/events/${encodeURIComponent(slug)}/minigames/${id}/roulette/spin`
     ),
 
+  // Classic bingo: the admin calls a ball (admin-only)...
+  drawBingoBall: (slug: string, id: string) =>
+    request<{ term: string; drawCount: number; remaining: number }>(
+      "POST",
+      `/events/${encodeURIComponent(slug)}/minigames/${id}/bingo/draw`
+    ),
+  // ...and the participant claims the line. Verified server-side against
+  // the balls actually called, so nothing here is taken on trust.
+  claimBingo: (slug: string, id: string) =>
+    request<{
+      rank: number;
+      winDraw: number;
+      prizes: number;
+      hasPrize: boolean;
+      lines: number[][];
+      alreadyWon: boolean;
+    }>(
+      "POST",
+      `/events/${encodeURIComponent(slug)}/minigames/${id}/bingo/claim`
+    ),
+
   // Certificates (generated on the fly + emailed; nothing is stored)
   sendCertificates: (data: unknown) =>
     request<{

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -81,6 +81,19 @@ export const mockApi = {
   ) => ok({ id: wordId, hidden }),
   listMinigameBingoWinners: () => ok([]),
 
+  spinRoulette: () =>
+    ok({ winnerId: "mock-uid", alias: "Alias", spinNumber: 1 }),
+  drawBingoBall: () => ok({ term: "Firebase", drawCount: 1, remaining: 47 }),
+  claimBingo: () =>
+    ok({
+      rank: 1,
+      winDraw: 1,
+      prizes: 3,
+      hasPrize: true,
+      lines: [[0, 1, 2, 3]],
+      alreadyWon: false,
+    }),
+
   sendCertificates: (data: unknown) => {
     const recipients =
       (data as { recipients?: { name: string; email: string }[] })

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,3 +27,65 @@ body {
 .container {
   @apply mx-auto max-w-[1400px] px-4;
 }
+
+/* Classic-bingo projector. A ball is called every minute or two, so the
+   reveal has to read from the back of the room: it drops in, overshoots,
+   settles. The tumbler balls idle underneath while nothing is happening
+   so the screen never looks frozen. */
+@keyframes bingo-ball-drop {
+  0% {
+    transform: translateY(-140%) scale(0.4) rotate(-25deg);
+    opacity: 0;
+  }
+  55% {
+    transform: translateY(8%) scale(1.12) rotate(6deg);
+    opacity: 1;
+  }
+  75% {
+    transform: translateY(-4%) scale(0.97) rotate(-2deg);
+  }
+  100% {
+    transform: translateY(0) scale(1) rotate(0deg);
+    opacity: 1;
+  }
+}
+
+@keyframes bingo-ball-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgb(255 255 255 / 0.35);
+  }
+  50% {
+    box-shadow: 0 0 0 1.5rem rgb(255 255 255 / 0);
+  }
+}
+
+@keyframes bingo-tumble {
+  0%,
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-38%) rotate(180deg);
+  }
+}
+
+.animate-bingo-ball-drop {
+  animation: bingo-ball-drop 900ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.animate-bingo-ball-pulse {
+  animation: bingo-ball-pulse 2s ease-out infinite;
+}
+
+.animate-bingo-tumble {
+  animation: bingo-tumble 1.8s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-bingo-ball-drop,
+  .animate-bingo-ball-pulse,
+  .animate-bingo-tumble {
+    animation: none;
+  }
+}

--- a/tests/rules/bingo-win.test.ts
+++ b/tests/rules/bingo-win.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
 import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
-import { doc, serverTimestamp, setDoc, Timestamp } from "firebase/firestore";
+import {
+  doc,
+  getDoc,
+  serverTimestamp,
+  setDoc,
+  Timestamp,
+} from "firebase/firestore";
 import { cleanup, clearAll, getTestEnv } from "./setup";
 
 const SLUG = "devfest-2025";
@@ -23,11 +29,20 @@ const DIAG = marks(0, 5, 10, 15);
 const NO_LINE = marks(0, 1, 6, 11); // scattered, no full line
 const EMPTY = marks();
 
+const INSTANCE_PATH = `events/${SLUG}/minigames/${INSTANCE_ID}`;
+
 /** Seeds the participant doc exactly as the join Cloud Function leaves it:
- *  identity + card, and NO check-in / win fields. */
-async function seedParticipant() {
+ *  identity + card, and NO check-in / win fields. The parent instance doc
+ *  is seeded too, because the win rule reads its config to tell classic
+ *  mode from conference mode. */
+async function seedParticipant(classic = false) {
   const env = await getTestEnv();
   await env.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), INSTANCE_PATH), {
+      type: "bingo",
+      state: "live",
+      config: { terms: ["a", "b"], classic },
+    });
     await setDoc(doc(ctx.firestore(), PATH), {
       uid: UID,
       alias: "Jugador",
@@ -202,6 +217,125 @@ describe("firestore.rules — bingo win verification", () => {
       await assertFails(
         setDoc(doc(other, PATH), { bingoMarked: ROW0 }, { merge: true })
       );
+    });
+  });
+
+  // Classic mode has an admin calling balls, so "I completed a line" is
+  // only true for balls that were actually called — something rules
+  // cannot check, since it means cross-referencing the card against the
+  // called list. So the client is shut out of bingoWonAt entirely and
+  // /bingo/claim (Admin SDK, bypasses rules) does the verifying.
+  describe("classic mode — the client may not declare its own win", () => {
+    it("still allows marking cells", async () => {
+      await seedParticipant(true);
+      const db = asPlayer();
+      await assertSucceeds(
+        setDoc(doc(db, PATH), { bingoMarked: ROW0 }, { merge: true })
+      );
+    });
+
+    it("rejects a self-reported win even on a genuine, server-timed line", async () => {
+      await seedParticipant(true);
+      const db = asPlayer();
+      await assertFails(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: ROW0, bingoWonAt: serverTimestamp() },
+          { merge: true }
+        )
+      );
+    });
+
+    it("rejects a self-reported win on a diagonal too", async () => {
+      await seedParticipant(true);
+      const db = asPlayer();
+      await assertFails(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: DIAG, bingoWonAt: serverTimestamp() },
+          { merge: true }
+        )
+      );
+    });
+
+    it("lets the player keep marking after the server crowned them", async () => {
+      await seedParticipant(true);
+      const env = await getTestEnv();
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        // What /bingo/claim leaves behind.
+        await setDoc(
+          doc(ctx.firestore(), PATH),
+          {
+            bingoMarked: ROW0,
+            bingoWonAt: Timestamp.fromMillis(5000),
+            bingoRank: 1,
+            bingoWinDraw: 12,
+          },
+          { merge: true }
+        );
+      });
+      const db = asPlayer();
+      await assertSucceeds(
+        setDoc(
+          doc(db, PATH),
+          { bingoMarked: marks(0, 1, 2, 3, 7) },
+          { merge: true }
+        )
+      );
+    });
+
+    it("rejects a client rewriting the rank the server assigned", async () => {
+      await seedParticipant(true);
+      const db = asPlayer();
+      await assertFails(
+        setDoc(doc(db, PATH), { bingoRank: 1 }, { merge: true })
+      );
+      await assertFails(
+        setDoc(doc(db, PATH), { bingoWinDraw: 1 }, { merge: true })
+      );
+    });
+  });
+
+  // The sealed calling sequence and the per-participant ball reservations.
+  // Reading either would spoil the game: one reveals every future ball,
+  // the other reveals when each person is going to win.
+  describe("classic-mode secrets are unreadable", () => {
+    const SECRET_PATH = `${INSTANCE_PATH}/secret/draw`;
+    const SLOT_PATH = `${INSTANCE_PATH}/slots/${UID}`;
+
+    async function seedSecrets() {
+      const env = await getTestEnv();
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), SECRET_PATH), {
+          order: ["a", "b", "c"],
+        });
+        await setDoc(doc(ctx.firestore(), SLOT_PATH), {
+          uid: UID,
+          winIndex: 31,
+        });
+      });
+    }
+
+    it("denies reading the draw order, authenticated or not", async () => {
+      await seedParticipant(true);
+      await seedSecrets();
+      await assertFails(getDoc(doc(asPlayer(), SECRET_PATH)));
+      await assertFails(
+        getDoc(doc(env2.unauthenticatedContext().firestore(), SECRET_PATH))
+      );
+    });
+
+    it("denies reading which ball anyone wins on", async () => {
+      await seedParticipant(true);
+      await seedSecrets();
+      await assertFails(getDoc(doc(asPlayer(), SLOT_PATH)));
+    });
+
+    it("denies writing to either", async () => {
+      await seedParticipant(true);
+      const db = asPlayer();
+      await assertFails(setDoc(doc(db, SECRET_PATH), { order: ["x"] }));
+      await assertFails(setDoc(doc(db, SLOT_PATH), { winIndex: 1 }));
     });
   });
 });


### PR DESCRIPTION
## What changed

Adds a **classic bingo** mode alongside the existing conference one, picked with a checkbox on the template. Conference mode is unchanged: nobody calls terms, the speakers do it without knowing, and every card marks freely.

In classic mode:

- **The admin calls the balls** from the event panel (`🎱 Cantar bola`), showing `Bola 12 de 48 · última: Firebase`. The order is sealed when the instance is attached — the admin does not pick which term comes up.
- **The projector animates each ball** dropping in with a bounce in Google brand colours, with the already-called ones lined up behind it and four balls idling in the tumbler before the first call. Honours `prefers-reduced-motion`.
- **Participants may only mark what was called.** Uncalled cells are locked and dimmed; called-but-unticked ones get a green ring so nobody misses one. Completing a line reveals a `🎉 ¡BINGO!` button.
- A `+ Tecnologías de Google` button seeds the term bank with 48 Google products, and the form warns when the bank is too small for the crowd.

### The anti-collision dealing

Five people claiming at once when there are three prizes cannot be resolved after the fact, so the cards are dealt to prevent it.

Because the calling sequence is sealed before the first ball, **each card's winning moment is already decided** and computable: the smallest number of balls that completes one of its ten lines. No player behaviour changes it. So on join the server deals 16 candidate cards, scores when each would win, and hands over the first one whose ball is still free.

Measured in simulation (`bingoClassic.test.ts`):

| Bank | Players | Result |
|---|---|---|
| 50 | 40 | first 10 winners on 10 distinct balls |
| 50 | 120 | first shared win at ball 29, prizes long gone |
| 75 | 120 | first shared win at ball 50 |

When the room outgrows the bank and every candidate ball is taken, the overflow goes to the **latest** ball, not the emptiest. The first version did the opposite and the numbers caught it: empty balls are empty precisely because they are early, so "fairest" seating produced `8,8,9,9,10,10` — two simultaneous wins while prizes were still on the table. A shared win at the end costs nothing.

### What the client cannot reach

- `minigames/{id}/secret/draw` — the full sequence. Readable would mean knowing every ball in advance.
- `minigames/{id}/slots/{uid}` — which ball each card wins on. Participant docs *are* world-readable, so this is the only place the reservation can live without spoiling the surprise.

Both are denied by rules and reached only through the Admin SDK. `firestore.rules` now also forbids a classic-mode client from writing `bingoWonAt` at all: rules cannot cross-reference a card against the called list, so `/bingo/claim` re-derives the win server-side and assigns the placing in a transaction — two claims in the same second come out 1st and 2nd rather than tied. Conference mode keeps the existing rule-level line check, which is all there is when nobody is calling.

Claims run on their own IP-keyed limiter instead of sharing `/join`'s: a venue usually shares one NAT address, and the scan-the-QR rush could exhaust the budget and throttle the first winner at the moment they press the button.

## Why

The existing bingo needs no admin attention during a talk, which is its charm, but it also cannot be run as a traditional game with a caller and prizes. This adds that mode without touching the passive one, and solves the problem that makes prize-giving unworkable at scale: simultaneous wins.

## How to test

```bash
pnpm test           # 264 pass
pnpm test:functions # 196 pass
pnpm test:rules     # 85 pass (needs the emulator + Java)
pnpm build
```

End to end:

1. Create a bingo template, tick **Bingo clásico**, press `+ Tecnologías de Google`, save.
2. Attach it to an event and press ▶ Iniciar.
3. Open `/events/<slug>/projector` — four balls idle in the tumbler.
4. Join from a phone via the QR. Cells are locked until called.
5. Press `🎱 Cantar bola` a few times: the ball drops on the projector, the matching cell unlocks on the phone.
6. Complete a line, press `🎉 ¡BINGO!` — the placing and prize/mention tag appear on the phone, in the projector's winners list, and under **Ver ganadores**.
7. Try to claim without a called line, or to write `bingoWonAt` from the console: both refused.

Worth checking with a second device that two winners never land on the same ball.

## Checklist

- [x] Código probado localmente
- [ ] Documentación actualizada (si aplica)
- [ ] Issue enlazada correctamente