### PR TITLE
feat(api): cap credentials per event

### DIFF
--- a/functions/src/handlers/credentials.test.ts
+++ b/functions/src/handlers/credentials.test.ts
@@ -127,6 +127,7 @@ interface Harness {
 function setupFirestore(
   options: {
     groupLetters?: string[] | undefined;
+    maxCredentials?: number;
     counterValues?: (number | undefined)[];
     attempts?: number;
   } = {}
@@ -156,7 +157,11 @@ function setupFirestore(
           credential:
             options.groupLetters === undefined
               ? undefined
-              : { enabled: true, group_letters: options.groupLetters },
+              : {
+                  enabled: true,
+                  group_letters: options.groupLetters,
+                  max_credentials: options.maxCredentials,
+                },
         }),
       })
     ),
@@ -567,5 +572,104 @@ describe("attachCredentialImage", () => {
 
     expect(res.__status).toBe(500);
     expect(h.updates).toHaveLength(0);
+  });
+});
+
+describe("createCredential — per-event cap", () => {
+  it("issues normally while below the cap", async () => {
+    const h = setupFirestore({
+      groupLetters: ["A", "Q"],
+      maxCredentials: 5,
+      counterValues: [3],
+    });
+    const res = buildRes();
+    await createCredential(buildReq(VALID_BODY), res);
+
+    expect(res.__body).toMatchObject({ success: true });
+    expect(h.created[0].sequenceNumber).toBe(4);
+  });
+
+  it("issues the very last credential allowed", async () => {
+    // Boundary: with a cap of 5 and 4 already issued, the next one is
+    // number 5 and must go through.
+    const h = setupFirestore({
+      groupLetters: ["A"],
+      maxCredentials: 5,
+      counterValues: [4],
+    });
+    const res = buildRes();
+    await createCredential(buildReq(VALID_BODY), res);
+
+    expect(res.__body).toMatchObject({ success: true });
+    expect(h.created[0].sequenceNumber).toBe(5);
+  });
+
+  it("refuses with 409 once the cap is full", async () => {
+    const h = setupFirestore({
+      groupLetters: ["A"],
+      maxCredentials: 5,
+      counterValues: [5],
+    });
+    const res = buildRes();
+    await createCredential(buildReq(VALID_BODY), res);
+
+    expect(res.__status).toBe(409);
+    expect(h.created).toHaveLength(0);
+    expect(h.counterWrites).toHaveLength(0);
+  });
+
+  it("explains the refusal in Spanish rather than leaking an error", async () => {
+    // 409 is a state the attendee can act on, so it must not be dressed
+    // up as the generic 500 message.
+    setupFirestore({
+      groupLetters: ["A"],
+      maxCredentials: 1,
+      counterValues: [1],
+    });
+    const res = buildRes();
+    await createCredential(buildReq(VALID_BODY), res);
+
+    const body = res.__body as { error: string };
+    expect(body.error).toMatch(/credenciales disponibles/i);
+    expect(body.error).not.toMatch(/internal error/i);
+  });
+
+  it("does not write the counter when refusing", async () => {
+    // A refused attempt must not consume a sequence number, or the cap
+    // would shrink every time someone hits a full event.
+    const h = setupFirestore({
+      groupLetters: ["A"],
+      maxCredentials: 2,
+      counterValues: [2],
+    });
+    await createCredential(buildReq(VALID_BODY), buildRes());
+    expect(h.counterWrites).toHaveLength(0);
+  });
+
+  it("treats an absent cap as unlimited", async () => {
+    const h = setupFirestore({
+      groupLetters: ["A"],
+      counterValues: [99999],
+    });
+    const res = buildRes();
+    await createCredential(buildReq(VALID_BODY), res);
+
+    expect(res.__body).toMatchObject({ success: true });
+    expect(h.created[0].sequenceNumber).toBe(100000);
+  });
+
+  it("treats a zero cap as unlimited, not as closed", async () => {
+    // A missing field and a zero must not mean opposite things; zero
+    // reading as "issue nothing" would silently close registration.
+    const h = setupFirestore({
+      groupLetters: ["A"],
+      maxCredentials: 0,
+      counterValues: [10],
+    });
+    const res = buildRes();
+    await createCredential(buildReq(VALID_BODY), res);
+
+    expect(res.__body).toMatchObject({ success: true });
+    expect(h.created).toHaveLength(1);
   });
 });

--- a/functions/src/handlers/credentials.ts
+++ b/functions/src/handlers/credentials.ts
@@ -32,6 +32,20 @@ const DEFAULT_GROUP_LETTERS = ["A", "B", "C", "D"];
 interface EventCredentialConfig {
   enabled?: boolean;
   group_letters?: string[];
+  max_credentials?: number;
+}
+
+/**
+ * Thrown inside the credential transaction when the event's cap is full.
+ *
+ * A sentinel rather than a plain Error so the catch below can tell "we are
+ * full" (a 409 the attendee can act on) apart from a genuine failure (a
+ * 500 they cannot).
+ */
+class CredentialCapReached extends Error {
+  constructor(readonly cap: number) {
+    super("credential cap reached");
+  }
 }
 
 /**
@@ -57,7 +71,7 @@ export async function createCredential(req: Request, res: Response) {
     const db = admin.firestore();
     const eventRef = db.collection("events").doc(slug);
 
-    const letters = await readGroupLetters(eventRef);
+    const { letters, maxCredentials } = await readCredentialConfig(eventRef);
 
     // Decode before the transaction so a malformed image is rejected
     // without burning a sequence number. We only verify the container's
@@ -92,6 +106,14 @@ export async function createCredential(req: Request, res: Response) {
       const counterSnap = await tx.get(counterRef);
       const next =
         ((counterSnap.data()?.nextSequence as number | undefined) ?? 0) + 1;
+
+      // Checked HERE rather than before the transaction because the
+      // counter is already being read under the same lock. A pre-flight
+      // read would let two concurrent requests both pass the check and
+      // overshoot the cap.
+      if (maxCredentials !== undefined && next > maxCredentials) {
+        throw new CredentialCapReached(maxCredentials);
+      }
 
       sequenceNumber = next;
       groupLetter = letterForSequence(next, letters);
@@ -208,24 +230,41 @@ export async function createCredential(req: Request, res: Response) {
       },
     });
   } catch (err) {
+    if (err instanceof CredentialCapReached) {
+      res.status(409).json({
+        success: false,
+        error:
+          "Ya se emitieron todas las credenciales disponibles para este " +
+          "evento. Escríbenos si crees que es un error.",
+      });
+      return;
+    }
     res.status(500).json({ success: false, error: safeError(err) });
   }
 }
 
 /**
- * Group letters configured on the event document in the data repo.
+ * Credential settings configured on the event document in the data repo.
  *
  * A missing event or a missing block is not an error here: the route only
  * exists for events whose page was built with the feature enabled, and
  * falling back keeps a misconfiguration from rejecting registrations.
  */
-async function readGroupLetters(
+async function readCredentialConfig(
   eventRef: admin.firestore.DocumentReference
-): Promise<string[]> {
+): Promise<{ letters: string[]; maxCredentials: number | undefined }> {
   const snap = await eventRef.get();
   const config = snap.data()?.credential as EventCredentialConfig | undefined;
   const letters = config?.group_letters;
-  return letters && letters.length > 0 ? letters : DEFAULT_GROUP_LETTERS;
+
+  // An absent or non-positive cap means unlimited. A zero would otherwise
+  // read as "issue nothing", which is never what a missing field means and
+  // would silently close registration.
+  const cap = config?.max_credentials;
+  return {
+    letters: letters && letters.length > 0 ? letters : DEFAULT_GROUP_LETTERS,
+    maxCredentials: typeof cap === "number" && cap > 0 ? cap : undefined,
+  };
 }
 
 /**

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -74,6 +74,10 @@ export const credentialConfigSchema = z
     enabled: z.boolean().default(false),
     headline: shortText(200).default(""),
     group_letters: z.array(shortText(2).min(1)).max(26).default([]),
+    // Hard ceiling on how many credentials this event will issue.
+    // Optional: absent means no cap, so events published before this
+    // existed keep their current behaviour.
+    max_credentials: z.number().int().min(1).max(100_000).optional(),
   })
   .strict();
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -116,6 +116,9 @@ const events = defineCollection({
         // Cycled round-robin over the registration sequence to split
         // attendees into on-site groups.
         groupLetters: z.array(z.string().min(1).max(2)).min(1).max(26),
+        // Absent means unlimited. Only the API enforces it; the page does
+        // not render differently when the cap is reached.
+        maxCredentials: z.number().int().positive().optional(),
       })
       .optional(),
   }),

--- a/src/loaders/transform-events.ts
+++ b/src/loaders/transform-events.ts
@@ -68,6 +68,7 @@ interface ExternalEvent {
     enabled?: boolean;
     headline?: string;
     group_letters?: string[];
+    max_credentials?: number;
   };
 }
 
@@ -183,6 +184,7 @@ function buildCredential(event: ExternalEvent) {
     groupLetters: event.credential.group_letters?.length
       ? event.credential.group_letters
       : ["A", "B", "C", "D"],
+    maxCredentials: event.credential.max_credentials,
   };
 }
 


### PR DESCRIPTION
## What changed

Adds an optional `max_credentials` field to the event's `credential` block and enforces it inside the transaction that assigns the sequence number.

- `functions/src/schemas/index.ts` — the field on `credentialConfigSchema`.
- `src/content.config.ts` and `src/loaders/transform-events.ts` — the camelCase mirror.
- `functions/src/handlers/credentials.ts` — the check plus a 409 response.

## Why

`POST /api/events/:slug/credentials` is public and runs on anonymous Firebase tokens, which any client mints for free. The per-IP limit of 8/hour stops casual abuse, but a distributed caller could still create tens of thousands of records a day, each one storing a composed card. Until App Check lands there was **no ceiling at all** — this stops the damage at a number the organisers choose.

Three decisions worth reviewing:

**The check runs inside the transaction, not before it.** The counter is already read there under the same lock. A pre-flight read would let two concurrent requests both pass the check and overshoot the cap — which is exactly the case a cap exists to prevent.

**Refusal is a 409 with a Spanish message, not the generic 500.** Running out of credentials is a state the attendee can act on, so it must not be dressed up as an internal error. A refused attempt writes nothing, so it does not consume a sequence number — otherwise the effective cap would shrink every time someone hit a full event.

**Absent and zero both mean unlimited.** Absent keeps every event published before this unchanged. Zero is the interesting one: reading it as "issue nothing" would let a stray `0` in the data repo silently close registration, and a missing field and a zero must not mean opposite things.

## How to test

```bash
pnpm test:functions
```

7 new tests: issuing below the cap; issuing the very last credential allowed (the boundary); refusing with 409 once full; the refusal message being actionable Spanish rather than the internal-error string; the counter not being written on refusal; and both unlimited cases.

To exercise it manually, add `"max_credentials": 2` to an event's `credential` block in `gdg-ica-data`, then submit three credentials — the third returns 409.

## Note

This is the interim ceiling. **App Check is still the real answer** to a public unauthenticated endpoint, and it needs a reCAPTCHA Enterprise site key plus a CSP amendment, so it is not a last-minute action.