### PR TITLE
feat(admin): reconcile credentials against the Bevy roster

### DIFF
--- a/functions/src/handlers/credentials.ts
+++ b/functions/src/handlers/credentials.ts
@@ -13,6 +13,11 @@ import {
   normalizeDni,
 } from "../services/credentialSearch";
 import {
+  reconcile,
+  type ReconcileAttendee,
+  type ReconcileCredential,
+} from "../services/credentialReconcile";
+import {
   decodeJpegDataUrl,
   deleteCredentialImages,
   saveCredentialImages,
@@ -635,6 +640,127 @@ export async function sendReminders(req: Request, res: Response) {
     res.json({
       success: true,
       data: { queued, skipped: ids.length - queued },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+/**
+ * POST /api/events/:slug/credentials/reconcile
+ *
+ * Cross-references the self-declared credentials with the Bevy roster and
+ * writes the result to both sides.
+ *
+ * Two things depend on this:
+ *
+ * The DNI reaches the door. A matched roster row gets `dni` and
+ * `credentialId` stamped on it, so at check-in a volunteer compares the
+ * number on the document against the number on screen instead of eyeing a
+ * name. That is the entire reason the DNI is collected.
+ *
+ * `pending` starts meaning what it says. Until now `bevyStatus` only moved
+ * when a human clicked, so someone who registered on the official panel
+ * themselves still looked pending — which made the panel's headline metric,
+ * and any reminder built on it, wrong.
+ *
+ * Run it after each roster import. It is idempotent: rows already `loaded`
+ * are left alone.
+ */
+export async function reconcileCredentials(req: Request, res: Response) {
+  try {
+    const slug = req.params.slug as string;
+    const user = (req as AuthenticatedRequest).user;
+
+    const db = admin.firestore();
+    const eventRef = db.collection("events").doc(slug);
+
+    const [credentialSnap, rosterSnap] = await Promise.all([
+      eventRef.collection("credentials").get(),
+      eventRef.collection("roster").get(),
+    ]);
+
+    const credentials: ReconcileCredential[] = credentialSnap.docs.map((d) => {
+      const data = d.data();
+      return {
+        id: d.id,
+        email: (data.email as string) ?? "",
+        dni: (data.dni as string) ?? "",
+        dniNormalized: (data.dniNormalized as string) ?? "",
+        bevyStatus: (data.bevyStatus as string) ?? "pending",
+      };
+    });
+
+    const attendees: ReconcileAttendee[] = rosterSnap.docs.map((d) => {
+      const data = d.data();
+      return {
+        id: d.id,
+        email: (data.email as string) ?? "",
+        ticketNumber: (data.ticketNumber as string) ?? "",
+      };
+    });
+
+    const result = reconcile(credentials, attendees);
+
+    // Two writes per match, so the batch ceiling is halved. Firestore caps
+    // a WriteBatch at 500 operations.
+    const MATCHES_PER_BATCH = 200;
+    for (let i = 0; i < result.matches.length; i += MATCHES_PER_BATCH) {
+      const batch = db.batch();
+      for (const match of result.matches.slice(i, i + MATCHES_PER_BATCH)) {
+        batch.update(
+          eventRef.collection("credentials").doc(match.credentialId),
+          {
+            bevyStatus: "loaded",
+            bevyTicketNumber: match.ticketNumber,
+            bevyLoadedAt: FieldValue.serverTimestamp(),
+            // Attributed to the person who ran the reconciliation, not left
+            // blank: someone has to own the claim that this record is in the
+            // official panel.
+            bevyLoadedBy: user.uid,
+            updatedAt: FieldValue.serverTimestamp(),
+          }
+        );
+
+        // Stamped through the Admin SDK, which bypasses the rules. The
+        // client-side `allow update` on roster is pinned to the check-in
+        // fields by an affectedKeys() diff, so a volunteer still cannot
+        // write these from the browser.
+        batch.update(eventRef.collection("roster").doc(match.attendeeId), {
+          dni: match.dni,
+          dniNormalized: match.dniNormalized,
+          credentialId: match.credentialId,
+        });
+      }
+      await batch.commit();
+    }
+
+    await writeAuditLog({
+      action: "credential.reconcile",
+      performedBy: user.uid,
+      targetId: slug,
+      targetType: "event",
+      details: {
+        credentials: credentials.length,
+        roster: attendees.length,
+        matched: result.matches.length,
+        unmatchedCredentials: result.unmatchedCredentialIds.length,
+        unmatchedRoster: result.unmatchedAttendeeIds.length,
+        ambiguous: result.ambiguousEmails.length,
+      },
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    res.json({
+      success: true,
+      data: {
+        matched: result.matches.length,
+        unmatchedCredentials: result.unmatchedCredentialIds.length,
+        unmatchedRoster: result.unmatchedAttendeeIds.length,
+        // Counted, not listed: the addresses themselves are PII and the
+        // panel already holds the rows they belong to.
+        ambiguous: result.ambiguousEmails.length,
+      },
     });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -714,6 +714,13 @@ app.post(
   validateBody(credentialReminderSchema),
   credentials.sendReminders
 );
+app.post(
+  "/api/events/:slug/credentials/reconcile",
+  requirePermission("credentials:operate", { scopeParam: "slug" }),
+  slugP,
+  writeLimiter,
+  credentials.reconcileCredentials
+);
 
 // Roulette spin
 app.post(

--- a/functions/src/services/credentialReconcile.test.ts
+++ b/functions/src/services/credentialReconcile.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeEmail,
+  reconcile,
+  type ReconcileAttendee,
+  type ReconcileCredential,
+} from "./credentialReconcile";
+
+function credential(
+  over: Partial<ReconcileCredential> = {}
+): ReconcileCredential {
+  return {
+    id: "c1",
+    email: "alvaro@example.com",
+    dni: "12345678",
+    dniNormalized: "12345678",
+    bevyStatus: "pending",
+    ...over,
+  };
+}
+
+function attendee(over: Partial<ReconcileAttendee> = {}): ReconcileAttendee {
+  return {
+    id: "t_GOOGA1",
+    email: "alvaro@example.com",
+    ticketNumber: "GOOGA1",
+    ...over,
+  };
+}
+
+describe("normalizeEmail", () => {
+  it("lowercases and trims", () => {
+    expect(normalizeEmail("  Alvaro@Example.COM ")).toBe("alvaro@example.com");
+  });
+});
+
+describe("reconcile", () => {
+  it("pairs a credential with its roster row", () => {
+    const r = reconcile([credential()], [attendee()]);
+    expect(r.matches).toEqual([
+      {
+        credentialId: "c1",
+        attendeeId: "t_GOOGA1",
+        ticketNumber: "GOOGA1",
+        dni: "12345678",
+        dniNormalized: "12345678",
+      },
+    ]);
+    expect(r.unmatchedCredentialIds).toHaveLength(0);
+    expect(r.unmatchedAttendeeIds).toHaveLength(0);
+  });
+
+  it("matches regardless of case and surrounding spaces", () => {
+    // Bevy exports and hand-typed forms disagree on both constantly.
+    const r = reconcile(
+      [credential({ email: "Alvaro@Example.com" })],
+      [attendee({ email: "  alvaro@EXAMPLE.com " })]
+    );
+    expect(r.matches).toHaveLength(1);
+  });
+
+  it("reports a credential with no roster row as unmatched", () => {
+    // This is the population the reminder targets: they filled our form
+    // and never finished on the official panel.
+    const r = reconcile([credential()], []);
+    expect(r.unmatchedCredentialIds).toEqual(["c1"]);
+    expect(r.matches).toHaveLength(0);
+  });
+
+  it("reports a roster row with no credential as unmatched", () => {
+    // Registered on Bevy without using our form. Nothing to fix, but the
+    // panel should not claim we have their DNI.
+    const r = reconcile([], [attendee()]);
+    expect(r.unmatchedAttendeeIds).toEqual(["t_GOOGA1"]);
+  });
+
+  it("is idempotent: an already loaded credential is not rewritten", () => {
+    // Re-running after a fresh Bevy import must only touch what is new.
+    const r = reconcile([credential({ bevyStatus: "loaded" })], [attendee()]);
+    expect(r.matches).toHaveLength(0);
+    expect(r.unmatchedCredentialIds).toHaveLength(0);
+    expect(r.unmatchedAttendeeIds).toHaveLength(0);
+  });
+
+  it("refuses to guess when two credentials share an email", () => {
+    // Usually someone registering a relative from their own inbox.
+    // Picking one would stamp an identity document onto the wrong person.
+    const r = reconcile(
+      [
+        credential({ id: "c1", dni: "11111111" }),
+        credential({ id: "c2", dni: "22222222" }),
+      ],
+      [attendee()]
+    );
+    expect(r.matches).toHaveLength(0);
+    expect(r.ambiguousEmails).toEqual(["alvaro@example.com"]);
+  });
+
+  it("leaves an ambiguous email out of the unmatched list too", () => {
+    // It is not "missing from Bevy" — it needs a human, which is a
+    // different action, so mixing it in would mislead the panel.
+    const r = reconcile(
+      [credential({ id: "c1" }), credential({ id: "c2" })],
+      [attendee()]
+    );
+    expect(r.unmatchedCredentialIds).toHaveLength(0);
+  });
+
+  it("still matches everyone else when one email is ambiguous", () => {
+    const r = reconcile(
+      [
+        credential({ id: "c1" }),
+        credential({ id: "c2" }),
+        credential({ id: "c3", email: "otra@example.com", dni: "33333333" }),
+      ],
+      [
+        attendee(),
+        attendee({
+          id: "t_GOOGA2",
+          email: "otra@example.com",
+          ticketNumber: "GOOGA2",
+        }),
+      ]
+    );
+    expect(r.matches.map((m) => m.credentialId)).toEqual(["c3"]);
+    expect(r.ambiguousEmails).toEqual(["alvaro@example.com"]);
+  });
+
+  it("ignores rows with a blank email on either side", () => {
+    const r = reconcile(
+      [credential({ email: "   " })],
+      [attendee({ email: "" })]
+    );
+    expect(r.matches).toHaveLength(0);
+    expect(r.ambiguousEmails).toHaveLength(0);
+  });
+
+  it("handles both collections being empty", () => {
+    const r = reconcile([], []);
+    expect(r.matches).toHaveLength(0);
+    expect(r.unmatchedCredentialIds).toHaveLength(0);
+    expect(r.unmatchedAttendeeIds).toHaveLength(0);
+  });
+});

--- a/functions/src/services/credentialReconcile.ts
+++ b/functions/src/services/credentialReconcile.ts
@@ -1,0 +1,129 @@
+// Matching between self-declared credentials and the Bevy roster.
+//
+// Kept pure and separate from the handler so the rules that decide who is
+// the same person can be tested without an emulator. Nothing here touches
+// Firestore.
+//
+// The two collections describe different things and must not be merged:
+// `roster` is imported from Bevy and authoritative about who is
+// registered; `credentials` is self-declared and pre-registration. This
+// module only says which rows refer to the same human.
+
+/** Lowercased and trimmed. The only key we match on. */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export interface ReconcileCredential {
+  id: string;
+  email: string;
+  dni: string;
+  dniNormalized: string;
+  bevyStatus: string;
+}
+
+export interface ReconcileAttendee {
+  id: string;
+  email: string;
+  ticketNumber: string;
+}
+
+export interface ReconcileMatch {
+  credentialId: string;
+  attendeeId: string;
+  ticketNumber: string;
+  dni: string;
+  dniNormalized: string;
+}
+
+export interface ReconcileResult {
+  matches: ReconcileMatch[];
+  /** Credentials with no roster row: not registered on the official panel. */
+  unmatchedCredentialIds: string[];
+  /** Roster rows with no credential: registered without using our form. */
+  unmatchedAttendeeIds: string[];
+  /**
+   * Emails appearing on more than one credential.
+   *
+   * Left unmatched on purpose. Two credentials sharing an address usually
+   * means someone registered a relative from their own inbox, and guessing
+   * which of the two DNIs belongs on the roster row would stamp an
+   * identity document onto the wrong person — a worse outcome than leaving
+   * it for a human.
+   */
+  ambiguousEmails: string[];
+}
+
+/**
+ * Pairs credentials with roster rows by email.
+ *
+ * Email is the only key both sides carry: Bevy never sees the DNI, and the
+ * credential has no ticket number until this runs. Matching on names was
+ * considered and rejected — `nameMatch` exists for a search box, where a
+ * near miss costs a retry, not for deciding whose identity document goes
+ * on which row.
+ *
+ * Idempotent: a credential already `loaded` is skipped, so re-running
+ * after a fresh Bevy import only touches what is genuinely new.
+ */
+export function reconcile(
+  credentials: readonly ReconcileCredential[],
+  attendees: readonly ReconcileAttendee[]
+): ReconcileResult {
+  const byEmail = new Map<string, ReconcileCredential[]>();
+  for (const credential of credentials) {
+    const key = normalizeEmail(credential.email);
+    if (!key) continue;
+    const bucket = byEmail.get(key);
+    if (bucket) bucket.push(credential);
+    else byEmail.set(key, [credential]);
+  }
+
+  const ambiguousEmails = [...byEmail.entries()]
+    .filter(([, list]) => list.length > 1)
+    .map(([email]) => email);
+  const ambiguous = new Set(ambiguousEmails);
+
+  const matches: ReconcileMatch[] = [];
+  const matchedCredentialIds = new Set<string>();
+  const matchedAttendeeIds = new Set<string>();
+
+  for (const attendee of attendees) {
+    const key = normalizeEmail(attendee.email);
+    if (!key || ambiguous.has(key)) continue;
+
+    const credential = byEmail.get(key)?.[0];
+    if (!credential) continue;
+
+    matchedAttendeeIds.add(attendee.id);
+
+    // Already reconciled on a previous run. Counted as matched so it does
+    // not show up as "missing from Bevy", but not rewritten.
+    if (credential.bevyStatus === "loaded") continue;
+
+    matchedCredentialIds.add(credential.id);
+    matches.push({
+      credentialId: credential.id,
+      attendeeId: attendee.id,
+      ticketNumber: attendee.ticketNumber,
+      dni: credential.dni,
+      dniNormalized: credential.dniNormalized,
+    });
+  }
+
+  return {
+    matches,
+    unmatchedCredentialIds: credentials
+      .filter(
+        (c) =>
+          c.bevyStatus !== "loaded" &&
+          !matchedCredentialIds.has(c.id) &&
+          !ambiguous.has(normalizeEmail(c.email))
+      )
+      .map((c) => c.id),
+    unmatchedAttendeeIds: attendees
+      .filter((a) => !matchedAttendeeIds.has(a.id))
+      .map((a) => a.id),
+    ambiguousEmails,
+  };
+}

--- a/src/components/react/admin/checkin/AttendeeRow.tsx
+++ b/src/components/react/admin/checkin/AttendeeRow.tsx
@@ -43,6 +43,15 @@ export function AttendeeRow({ attendee, stale, onToggle }: Props) {
               ya no está en el CSV
             </span>
           )}
+          {/* The whole reason the DNI is collected: the volunteer compares
+              the number on the document against this one instead of
+              eyeing a name. Shown in full, not masked — at the door the
+              point is to read it. */}
+          {attendee.dni && (
+            <span className="rounded bg-gray-900 px-1.5 py-0.5 font-mono text-xs text-white dark:bg-gray-100 dark:text-gray-900">
+              DNI {attendee.dni}
+            </span>
+          )}
           {attendee.bevyCheckinAt && (
             <span className="rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
               ya marcado en Bevy

--- a/src/components/react/admin/checkin/__tests__/AttendeeRow.test.tsx
+++ b/src/components/react/admin/checkin/__tests__/AttendeeRow.test.tsx
@@ -25,6 +25,7 @@ const attendee = (over: Partial<Attendee> = {}): Attendee => ({
   checkedInByName: null,
   note: null,
   dniVerified: false,
+  dni: null,
   pending: false,
   ...over,
 });
@@ -40,7 +41,9 @@ describe("AttendeeRow", () => {
 
   it("offers to mark someone who is not checked in", async () => {
     const onToggle = vi.fn();
-    render(<AttendeeRow attendee={attendee()} stale={false} onToggle={onToggle} />);
+    render(
+      <AttendeeRow attendee={attendee()} stale={false} onToggle={onToggle} />
+    );
     const button = screen.getByRole("button", { name: "Marcar" });
     expect(button).toHaveAttribute("aria-pressed", "false");
     await userEvent.click(button);
@@ -96,6 +99,29 @@ describe("AttendeeRow", () => {
       />
     );
     expect(screen.getByText("ya marcado en Bevy")).toBeVisible();
+  });
+
+  it("shows the DNI once reconciliation has stamped it", () => {
+    // The point of collecting the DNI: at the door the volunteer reads it
+    // off the screen and compares it against the document, instead of
+    // eyeing a name.
+    render(
+      <AttendeeRow
+        attendee={attendee({ dni: "12345678" })}
+        stale={false}
+        onToggle={vi.fn()}
+      />
+    );
+    expect(screen.getByText("DNI 12345678")).toBeVisible();
+  });
+
+  it("shows no DNI badge before reconciliation has run", () => {
+    // Null for every row until the roster is imported and matched, which
+    // is most of the event's lifetime.
+    render(
+      <AttendeeRow attendee={attendee()} stale={false} onToggle={vi.fn()} />
+    );
+    expect(screen.queryByText(/^DNI /)).not.toBeInTheDocument();
   });
 
   it("does not flag a normal attendee", () => {

--- a/src/components/react/admin/checkin/__tests__/CheckinPanel.test.tsx
+++ b/src/components/react/admin/checkin/__tests__/CheckinPanel.test.tsx
@@ -38,7 +38,13 @@ const attendee = (over: Partial<Attendee> = {}): Attendee => ({
   company: "",
   title: "",
   ticketTitle: "General Admission",
-  searchTokens: ["alex", "alberto", "quintanilla", "garcia", "wcandry@gmail.com"],
+  searchTokens: [
+    "alex",
+    "alberto",
+    "quintanilla",
+    "garcia",
+    "wcandry@gmail.com",
+  ],
   bevyCheckinAt: null,
   lastImportId: "imp_1",
   checkedIn: false,
@@ -47,6 +53,7 @@ const attendee = (over: Partial<Attendee> = {}): Attendee => ({
   checkedInByName: null,
   note: null,
   dniVerified: false,
+  dni: null,
   pending: false,
   ...over,
 });
@@ -55,7 +62,12 @@ const attendee = (over: Partial<Attendee> = {}): Attendee => ({
 function rosterState(over: Record<string, unknown> = {}) {
   return {
     attendees: [attendee()],
-    meta: { lastImportId: "imp_1", lastImportAt: null, lastImportByName: null, rosterCount: 1 },
+    meta: {
+      lastImportId: "imp_1",
+      lastImportAt: null,
+      lastImportByName: null,
+      rosterCount: 1,
+    },
     loading: false,
     error: null,
     offline: false,

--- a/src/components/react/admin/checkin/__tests__/buildBevyCsv.test.ts
+++ b/src/components/react/admin/checkin/__tests__/buildBevyCsv.test.ts
@@ -21,6 +21,7 @@ const attendee = (over: Partial<Attendee> = {}): Attendee => ({
   checkedInByName: null,
   note: null,
   dniVerified: false,
+  dni: null,
   pending: false,
   ...over,
 });

--- a/src/components/react/admin/checkin/types.ts
+++ b/src/components/react/admin/checkin/types.ts
@@ -22,6 +22,13 @@ export interface Attendee {
 
   dniVerified: boolean;
 
+  /**
+   * Stamped by the reconciliation, not by the Bevy import — Bevy has no
+   * DNI field. Null until reconciliation matches this row to a credential,
+   * which is most of them right up until the roster is imported.
+   */
+  dni: string | null;
+
   /** True while this row's write is still queued in the local cache. */
   pending: boolean;
 }

--- a/src/components/react/admin/checkin/useRoster.ts
+++ b/src/components/react/admin/checkin/useRoster.ts
@@ -67,9 +67,8 @@ export function useRoster(slug: string | null): State {
     (async () => {
       try {
         const db = await getFirestore();
-        const { collection, doc, onSnapshot } = await import(
-          "firebase/firestore"
-        );
+        const { collection, doc, onSnapshot } =
+          await import("firebase/firestore");
         if (cancelled) return;
 
         unsubRoster = onSnapshot(
@@ -105,6 +104,7 @@ export function useRoster(slug: string | null): State {
                 checkedInByName: data.checkedInByName ?? null,
                 note: data.note ?? null,
                 dniVerified: data.dniVerified === true,
+                dni: (data.dni as string | undefined) ?? null,
                 pending: d.metadata.hasPendingWrites,
               } satisfies Attendee;
             });
@@ -139,7 +139,8 @@ export function useRoster(slug: string | null): State {
                 loading: false,
                 error: null,
                 syncedOnce,
-                offline: snap.metadata.fromCache && (syncedOnce || disconnected),
+                offline:
+                  snap.metadata.fromCache && (syncedOnce || disconnected),
                 pendingCount: attendees.filter((a) => a.pending).length,
               };
             });
@@ -229,9 +230,8 @@ export async function setCheckedIn(
 ): Promise<void> {
   try {
     const db = await getFirestore();
-    const { doc, updateDoc, serverTimestamp } = await import(
-      "firebase/firestore"
-    );
+    const { doc, updateDoc, serverTimestamp } =
+      await import("firebase/firestore");
     void updateDoc(doc(db, `events/${slug}/roster/${attendeeId}`), {
       checkedIn,
       checkedInAt: checkedIn ? serverTimestamp() : null,

--- a/src/components/react/admin/credentials/CredentialsPanel.tsx
+++ b/src/components/react/admin/credentials/CredentialsPanel.tsx
@@ -4,6 +4,7 @@ import { useCredentials } from "./useCredentials";
 import { BevyQueue } from "./BevyQueue";
 import { PhotoModerationQueue } from "./PhotoModerationQueue";
 import { ReminderButton } from "./ReminderButton";
+import { ReconcileButton } from "./ReconcileButton";
 import {
   buildCredentialBevyCsv,
   credentialCsvFilename,
@@ -105,6 +106,7 @@ export function CredentialsPanel({ initialSlug }: { initialSlug?: string }) {
           Credenciales · {slug}
         </h1>
         <div className="flex flex-wrap items-start gap-2">
+          <ReconcileButton slug={slug} onError={setError} />
           <ReminderButton
             slug={slug}
             credentials={credentials}

--- a/src/components/react/admin/credentials/ReconcileButton.tsx
+++ b/src/components/react/admin/credentials/ReconcileButton.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { api } from "@/lib/api";
+
+interface Props {
+  slug: string;
+  onError: (message: string) => void;
+}
+
+interface Summary {
+  matched: number;
+  unmatchedCredentials: number;
+  unmatchedRoster: number;
+  ambiguous: number;
+}
+
+/**
+ * Cross-references the credentials with the imported Bevy roster.
+ *
+ * Run it after each roster import. It is idempotent, so pressing it twice
+ * is harmless — rows already reconciled are skipped rather than rewritten.
+ *
+ * Two things come out of it: the DNI lands on the check-in row so a
+ * volunteer can compare it against the document at the door, and
+ * `pending` stops meaning "nobody clicked yet" and starts meaning "not in
+ * the official panel".
+ */
+export function ReconcileButton({ slug, onError }: Props) {
+  const [busy, setBusy] = useState(false);
+  const [summary, setSummary] = useState<Summary | null>(null);
+
+  const run = async () => {
+    setBusy(true);
+    setSummary(null);
+    const res = await api.reconcileCredentials(slug);
+    setBusy(false);
+
+    if (!res.success || !res.data) {
+      onError(res.error ?? "No se pudo conciliar con el roster");
+      return;
+    }
+    setSummary(res.data);
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        onClick={run}
+        disabled={busy}
+        className="border-gray-custom text-secondary rounded border px-3 py-2 text-sm disabled:opacity-50"
+        title="Cruza las credenciales con el roster importado de Bevy"
+      >
+        {busy ? "Conciliando…" : "Conciliar con Bevy"}
+      </button>
+
+      {summary && (
+        <div className="text-tertiary text-right text-xs">
+          <p>
+            {summary.matched} emparejada(s) · {summary.unmatchedCredentials} sin
+            inscripción · {summary.unmatchedRoster} solo en Bevy
+          </p>
+          {summary.ambiguous > 0 && (
+            <p className="text-[#92400E]">
+              {summary.ambiguous} correo(s) repetidos: revísalos a mano, no se
+              emparejaron
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -289,6 +289,13 @@ const realApi = {
       `/events/${encodeURIComponent(slug)}/credentials/${id}/photo`,
       data
     ),
+  reconcileCredentials: (slug: string) =>
+    request<{
+      matched: number;
+      unmatchedCredentials: number;
+      unmatchedRoster: number;
+      ambiguous: number;
+    }>("POST", `/events/${encodeURIComponent(slug)}/credentials/reconcile`),
   sendCredentialReminders: (slug: string, credentialIds: string[]) =>
     request<{ queued: number; skipped: number }>(
       "POST",

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -113,6 +113,13 @@ export const mockApi = {
 
   setCredentialBevyStatus: () => ok(null),
   moderateCredentialPhoto: () => ok(null),
+  reconcileCredentials: () =>
+    ok({
+      matched: 0,
+      unmatchedCredentials: 0,
+      unmatchedRoster: 0,
+      ambiguous: 0,
+    }),
   sendCredentialReminders: () => ok({ queued: 0, skipped: 0 }),
   retryCredentialEmail: () => ok(null),
 


### PR DESCRIPTION
## What changed

A new endpoint that cross-references the self-declared credentials with the imported Bevy roster, plus the button that runs it and the DNI badge it puts on the check-in row.

- `functions/src/services/credentialReconcile.ts` — the matching rules, pure and emulator-free.
- `functions/src/handlers/credentials.ts` — `reconcileCredentials`, writing to both collections.
- `ReconcileButton.tsx`, and `dni` carried through `useRoster` into `AttendeeRow`.

## Why

Two things depend on this.

**The DNI reaches the door.** A matched roster row gets `dni` and `credentialId` stamped on it, so at check-in a volunteer compares the number on the document against the number on screen instead of eyeing a name. That is the entire reason the DNI is collected — without this it only served to detect duplicates.

**`pending` starts meaning what it says.** Until now `bevyStatus` only moved when a human clicked, so someone who registered on the official panel themselves still looked pending. That made the panel's headline metric wrong, and any reminder built on it would have told registered people they were not registered.

## Decisions worth reviewing

**Email is the only key.** It is the only field both sides carry: Bevy never sees the DNI, and a credential has no ticket number until this runs. Name matching was considered and rejected — `nameMatch` exists for a search box, where a near miss costs a retry, not for deciding whose identity document goes on which row.

**Two credentials sharing an email are left unmatched.** That usually means someone registered a relative from their own inbox, and guessing which of the two DNIs belongs on the roster row would stamp an identity document onto the wrong person. They surface as a count so a human resolves them, and are deliberately kept out of the "missing from Bevy" list — they need a different action, and mixing them in would mislead the panel.

**Idempotent.** Rows already `loaded` are skipped, so re-running after a fresh import only touches what is new. Pressing the button twice is harmless.

**The roster write goes through the Admin SDK.** The client-side `allow update` on roster is still pinned to the check-in fields by an `affectedKeys()` diff, so a volunteer cannot write `dni` from the browser even though they can read it.

**Ambiguous addresses are counted, not returned.** They are PII, and the panel already holds the rows they belong to.

**The DNI is shown in full on the check-in row, not masked.** It is masked in the credentials list, where the risk is a shoulder-surfer or a screenshot — but at the door the entire point is to read it against a document.

## How to test

```bash
pnpm test:functions   # 495, includes 11 on the matching rules
pnpm test             # 363, includes the DNI badge
pnpm test:rules       # 156
```

The matching tests cover: case and whitespace differences between a Bevy export and a hand-typed form; a credential with no roster row; a roster row with no credential; idempotency; the ambiguous-email refusal; and that one ambiguous address does not stop everyone else from matching.

Manually: import a roster in `/admin/checkin`, then press **Conciliar con Bevy** in `/admin/credentials?slug=…`, and confirm the matched credentials flip to `loaded` and the DNI badge appears on the corresponding check-in rows.

## Operational note

Run it after each roster import. Bevy is the system of record and people register right up to the doors opening, so the roster changes and the reconciliation is what keeps the credential side current.