### PR TITLE
feat(legal): point the consent links at the real GDG documents

### DIFF
--- a/functions/src/auth/permissions.ts
+++ b/functions/src/auth/permissions.ts
@@ -33,6 +33,7 @@ export const PERMISSIONS = [
   "checkin:operate",
   "checkin:import",
   "credentials:operate",
+  "credentials:moderate",
   "certificates:send",
   "minigames:template:read",
   "minigames:template:write",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -689,9 +689,15 @@ app.patch(
   validateBody(credentialBevyStatusSchema),
   credentials.setBevyStatus
 );
+// Photo moderation is admin-only, unlike the rest of this block. Taking a
+// photo down is a judgement call about what appears over GDG branding, and
+// it is irreversible: the Storage objects are deleted, not archived. That
+// weighs differently from marking a row loaded into Bevy, which is
+// bookkeeping a volunteer can correct. `credentials:moderate` is in no
+// role bundle, so only `admin` — which holds every permission — has it.
 app.patch(
   "/api/events/:slug/credentials/:id/photo",
-  requirePermission("credentials:operate", { scopeParam: "slug" }),
+  requirePermission("credentials:moderate", { scopeParam: "slug" }),
   slugP,
   vid,
   writeLimiter,

--- a/src/components/react/admin/credentials/CredentialsPanel.tsx
+++ b/src/components/react/admin/credentials/CredentialsPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { isDevPreview } from "@/lib/api";
+import { useAuth } from "../AuthProvider";
 import { useCredentials } from "./useCredentials";
 import { BevyQueue } from "./BevyQueue";
 import { PhotoModerationQueue } from "./PhotoModerationQueue";
@@ -24,6 +25,12 @@ function slugFromUrl(): string | null {
 type Tab = "bevy" | "photos" | "all";
 
 export function CredentialsPanel({ initialSlug }: { initialSlug?: string }) {
+  const { can } = useAuth();
+  // Taking a photo down is admin-only and irreversible. Hiding the tab is
+  // cosmetic — the API is the real gate — but showing a queue whose every
+  // button 403s is worse than not showing it.
+  const canModerate = can("credentials:moderate");
+
   const [slug] = useState<string | null>(initialSlug ?? slugFromUrl());
   const [tab, setTab] = useState<Tab>("bevy");
   const [error, setError] = useState<string | null>(null);
@@ -151,15 +158,17 @@ export function CredentialsPanel({ initialSlug }: { initialSlug?: string }) {
         <TabButton active={tab === "bevy"} onClick={() => setTab("bevy")}>
           Cola Bevy ({stats.pending})
         </TabButton>
-        <TabButton active={tab === "photos"} onClick={() => setTab("photos")}>
-          Fotos ({stats.photos})
-        </TabButton>
+        {canModerate && (
+          <TabButton active={tab === "photos"} onClick={() => setTab("photos")}>
+            Fotos ({stats.photos})
+          </TabButton>
+        )}
         <TabButton active={tab === "all"} onClick={() => setTab("all")}>
           Todos ({stats.total})
         </TabButton>
       </nav>
 
-      {tab === "photos" ? (
+      {tab === "photos" && canModerate ? (
         <PhotoModerationQueue
           slug={slug}
           credentials={credentials}

--- a/src/lib/__tests__/consent.test.ts
+++ b/src/lib/__tests__/consent.test.ts
@@ -57,6 +57,24 @@ describe("CONSENT_LINKS", () => {
     expect(CONSENT_LINKS.gdgIcaPrivacy).toBe("/privacy-policy");
   });
 
+  it("points at the real GDG documents, not a placeholder", () => {
+    // These are what the attendee accepts. Pointing them at a stand-in
+    // means storing a consent against the wrong document, which makes the
+    // whole consentAt / consentPolicyVersion record worthless as evidence.
+    expect(CONSENT_LINKS.gdgEventTerms).toBe(
+      "https://gdg.community.dev/participation-terms/"
+    );
+    expect(CONSENT_LINKS.codeOfConduct).toBe(
+      "https://www.google.com/events/policy/anti-harassmentpolicy.html"
+    );
+  });
+
+  it("does not reuse one URL for two different consents", () => {
+    // They were briefly the same placeholder. Two checkboxes linking to
+    // one document reads as a copy-paste slip and weakens both.
+    expect(CONSENT_LINKS.gdgEventTerms).not.toBe(CONSENT_LINKS.codeOfConduct);
+  });
+
   it("uses absolute https URLs for third-party documents", () => {
     for (const key of [
       "gdgEventTerms",

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -17,13 +17,18 @@ export const PRIVACY_POLICY_DATE_LABEL = "1 de agosto de 2026";
 export const CONTACT_EMAIL = "aalvaropc@gmail.com";
 
 export const CONSENT_LINKS = {
-  // TODO(gdg-ica): confirmar la URL exacta desde el panel oficial de Bevy
-  // antes de publicar. Es el enlace que el asistente acepta, asi que debe
-  // apuntar al mismo documento que veria al registrarse alli.
-  gdgEventTerms: "https://developers.google.com/community-guidelines",
+  // The agreement between the attendee and Google that governs taking part
+  // in any GDG event — recording rights, liability, and how RSVP data is
+  // shared with the local chapter. This is the document the official Bevy
+  // panel links from its first checkbox.
+  gdgEventTerms: "https://gdg.community.dev/participation-terms/",
   googlePrivacy: "https://policies.google.com/privacy",
-  // TODO(gdg-ica): idem — confirmar contra el codigo de conducta vigente.
-  codeOfConduct: "https://developers.google.com/community-guidelines",
+  // Google's event community guidelines and anti-harassment policy. The
+  // developers.google.com/community-guidelines address redirects here; the
+  // canonical target is used directly so the link cannot break if that
+  // redirect is ever retired.
+  codeOfConduct:
+    "https://www.google.com/events/policy/anti-harassmentpolicy.html",
   gdgIcaPrivacy: "/privacy-policy",
 } as const;
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -33,6 +33,7 @@ export const PERMISSIONS = [
   "checkin:operate",
   "checkin:import",
   "credentials:operate",
+  "credentials:moderate",
   "certificates:send",
   "minigames:template:read",
   "minigames:template:write",


### PR DESCRIPTION
## What changed

Replaces the two placeholder consent URLs in `src/lib/consent.ts` with the real documents, and splits photo moderation into an admin-only permission.

| Consent | URL |
|---|---|
| GDG event participation terms | `https://gdg.community.dev/participation-terms/` |
| Code of conduct | `https://www.google.com/events/policy/anti-harassmentpolicy.html` |

## Why the URLs matter more than they look

These are what the attendee accepts when they tick the boxes. A placeholder meant storing a consent against the wrong document — which makes the entire `consentAt` / `consentPolicyVersion` / `consentUserAgent` record worthless as evidence. It is the one thing the consent design exists to prevent, and it was the last blocker on turning the feature on.

Both were verified against the live Bevy event page rather than assumed. The code of conduct uses the canonical `google.com/events/policy/...` target instead of the `developers.google.com/community-guidelines` address that redirects to it, so the link cannot break if that redirect is ever retired.

Two tests pin the values, and a third asserts the two links are **not** the same URL. They briefly were, and two checkboxes pointing at one document reads as a copy-paste slip that weakens both.

## Why photo moderation becomes admin-only

`credentials:operate` covered five routes: Bevy status, photo moderation, email retry, reminders and reconciliation. Four of those are bookkeeping a volunteer can correct if they get it wrong.

Taking a photo down is not. It is a judgement call about what appears over GDG branding, and it is **irreversible** — the Storage objects are deleted, not archived. So it moves to a new `credentials:moderate`, which is deliberately in no role bundle and therefore reachable only by `admin`, since that role holds every permission by definition.

The photo tab is hidden from anyone without it. That layer is cosmetic — the API middleware is the real gate — but a queue whose every button returns 403 is worse than no queue.

## How to test

```bash
pnpm test            # 381, includes 3 on the consent links
pnpm test:functions  # 495, includes the permission drift test
pnpm build
```

The drift test compares the two permission catalogues with `toEqual`, so `credentials:moderate` had to be added to both files in the same position — they cannot be edited independently.

Manually: open `/admin/credentials?slug=…` as an organizer and confirm the **Fotos** tab is absent, then as an admin and confirm it appears.

## Effect on the launch

With this merged, the only thing standing between the feature and being live is flipping `credential.enabled` to `true` in `gdg-ica-data`.