### PR TITLE
feat(functions): let the panel choose between Gmail and Resend

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -379,6 +379,14 @@ service cloud.firestore {
       }
     }
 
+    // Which service sends credential email. Read and written only through
+    // the API, which gates it on the admin-only `email:transport`
+    // permission — a client that could flip this would redirect every
+    // credential email through a provider of its choosing.
+    match /settings/{docId} {
+      allow read, write: if false;
+    }
+
     // Daily cap on credential emails, maintained by the scheduled drain.
     // Nothing outside Cloud Functions has any business reading or writing
     // it, so it stays fully closed.

--- a/functions/src/auth/permissions.ts
+++ b/functions/src/auth/permissions.ts
@@ -34,6 +34,7 @@ export const PERMISSIONS = [
   "checkin:import",
   "credentials:operate",
   "credentials:moderate",
+  "email:transport",
   "certificates:send",
   "minigames:template:read",
   "minigames:template:write",

--- a/functions/src/config.ts
+++ b/functions/src/config.ts
@@ -8,6 +8,15 @@ export const GITHUB_TOKEN = defineSecret("GITHUB_TOKEN");
 export const GMAIL_USER = defineSecret("GMAIL_USER");
 export const GMAIL_APP_PASSWORD = defineSecret("GMAIL_APP_PASSWORD");
 
+// Resend, the alternative transport for credential email. Optional: with
+// the transport set to gmail these are never read, so the project deploys
+// fine without them until someone flips the switch.
+export const RESEND_API_KEY = defineSecret("RESEND_API_KEY");
+// Sender shown to the recipient, e.g. "GDG ICA <no-reply@gdgica.com>". It
+// must be an address on a domain verified in Resend — that verification is
+// what stops the message being treated as spoofed.
+export const RESEND_FROM = defineSecret("RESEND_FROM");
+
 // Origen canónico del sitio, usado para construir el enlace de canje de las
 // invitaciones. Es el primero de ALLOWED_ORIGINS y se fija aquí en vez de
 // derivarlo de la petición: tomarlo de la cabecera Host permitiría que un

--- a/functions/src/handlers/emailSettings.ts
+++ b/functions/src/handlers/emailSettings.ts
@@ -1,0 +1,77 @@
+import { Request, Response } from "express";
+import { FieldValue } from "firebase-admin/firestore";
+import { writeAuditLog } from "../utils/audit";
+import { AuthenticatedRequest } from "../middleware/auth";
+import { safeError } from "../middleware/validate";
+import {
+  emailSettingsRef,
+  writeEmailTransport,
+} from "../services/emailSettings";
+import {
+  DEFAULT_TRANSPORT,
+  dailyCapFor,
+  isEmailTransport,
+} from "../services/emailTransport";
+import type { EmailTransportInput } from "../schemas/credentials";
+
+/**
+ * GET /api/settings/email
+ *
+ * Reports which service sends credential email and what its daily ceiling
+ * is. The cap is returned rather than hardcoded in the panel so the two
+ * cannot drift — it belongs to the transport, not to the UI.
+ */
+export async function getEmailSettings(req: Request, res: Response) {
+  try {
+    const snap = await emailSettingsRef().get();
+    const value = snap.data()?.transport;
+    const transport = isEmailTransport(value) ? value : DEFAULT_TRANSPORT;
+
+    res.json({
+      success: true,
+      data: {
+        transport,
+        dailyCap: dailyCapFor(transport),
+        updatedAt: snap.data()?.updatedAt ?? null,
+      },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}
+
+/**
+ * PUT /api/settings/email
+ *
+ * Switches the transport. Takes effect on the next drain run, within five
+ * minutes, with no deploy — which is the point: if Resend starts failing
+ * on the day of the event, going back to Gmail is a click.
+ *
+ * Nothing already queued is lost. Documents carry no transport of their
+ * own; the drain reads the current setting each run, so a message queued
+ * under one transport simply leaves through the other.
+ */
+export async function setEmailSettings(req: Request, res: Response) {
+  try {
+    const user = (req as AuthenticatedRequest).user;
+    const { transport } = req.body as EmailTransportInput;
+
+    await writeEmailTransport(transport, user.uid);
+
+    await writeAuditLog({
+      action: "settings.email_transport",
+      performedBy: user.uid,
+      targetId: "email",
+      targetType: "settings",
+      details: { transport },
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    res.json({
+      success: true,
+      data: { transport, dailyCap: dailyCapFor(transport) },
+    });
+  } catch (err) {
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -27,6 +27,7 @@ import {
   credentialBevyStatusSchema,
   credentialPhotoModerationSchema,
   credentialReminderSchema,
+  emailTransportSchema,
 } from "./schemas";
 import { register } from "./handlers/auth";
 import * as events from "./handlers/events";
@@ -51,6 +52,7 @@ import * as minigameBingo from "./handlers/minigameBingo";
 import * as certificates from "./handlers/certificates";
 import * as checkin from "./handlers/checkin";
 import * as credentials from "./handlers/credentials";
+import * as emailSettings from "./handlers/emailSettings";
 
 admin.initializeApp();
 
@@ -726,6 +728,23 @@ app.post(
   slugP,
   writeLimiter,
   credentials.reconcileCredentials
+);
+
+// Which service sends credential email. Global configuration rather than a
+// per-event operation, so it carries its own admin-only permission — and
+// it is read on every drain run, which is what lets a failing provider be
+// swapped out mid-event without a deploy.
+app.get(
+  "/api/settings/email",
+  requirePermission("email:transport"),
+  emailSettings.getEmailSettings
+);
+app.put(
+  "/api/settings/email",
+  requirePermission("email:transport"),
+  writeLimiter,
+  validateBody(emailTransportSchema),
+  emailSettings.setEmailSettings
 );
 
 // Roulette spin

--- a/functions/src/schemas/credentials.test.ts
+++ b/functions/src/schemas/credentials.test.ts
@@ -3,6 +3,7 @@ import {
   credentialBevyStatusSchema,
   credentialCreateSchema,
   credentialPhotoModerationSchema,
+  emailTransportSchema,
   MAX_PHOTO_DATAURL_CHARS,
 } from "./credentials";
 
@@ -244,6 +245,31 @@ describe("credentialPhotoModerationSchema", () => {
   it("rejects an unknown action", () => {
     expect(
       credentialPhotoModerationSchema.safeParse({ action: "delete" }).success
+    ).toBe(false);
+  });
+});
+
+describe("emailTransportSchema", () => {
+  it.each(["gmail", "resend"])("accepts %s", (transport) => {
+    expect(emailTransportSchema.safeParse({ transport }).success).toBe(true);
+  });
+
+  it("rejects an unknown provider", () => {
+    // The handler passes this straight to the sender, so an unrecognised
+    // value must never reach it.
+    expect(
+      emailTransportSchema.safeParse({ transport: "sendgrid" }).success
+    ).toBe(false);
+  });
+
+  it("rejects an extra key", () => {
+    // Notably a `from` field: the sender follows the transport, and
+    // accepting one here would imply it can be chosen separately.
+    expect(
+      emailTransportSchema.safeParse({
+        transport: "resend",
+        from: "otro@example.com",
+      }).success
     ).toBe(false);
   });
 });

--- a/functions/src/schemas/credentials.ts
+++ b/functions/src/schemas/credentials.ts
@@ -156,7 +156,21 @@ export const credentialReminderSchema = z
   })
   .strict();
 
+/**
+ * Which service sends credential email.
+ *
+ * The sender address is not a separate field on purpose: it is determined
+ * by the transport, because email authentication forbids sending as a
+ * gmail.com address through a third party.
+ */
+export const emailTransportSchema = z
+  .object({
+    transport: z.enum(["gmail", "resend"]),
+  })
+  .strict();
+
 export type CredentialCreateInput = z.infer<typeof credentialCreateSchema>;
+export type EmailTransportInput = z.infer<typeof emailTransportSchema>;
 export type CredentialReminderInput = z.infer<typeof credentialReminderSchema>;
 export type CredentialImageInput = z.infer<typeof credentialImageSchema>;
 export type CredentialBevyStatusInput = z.infer<

--- a/functions/src/services/credentialEmail.ts
+++ b/functions/src/services/credentialEmail.ts
@@ -1,5 +1,9 @@
-import { GMAIL_USER } from "../config";
-import { getTransporter, htmlEscape, singleLine } from "./email";
+import { htmlEscape, singleLine } from "./email";
+import {
+  DEFAULT_TRANSPORT,
+  sendEmail,
+  type EmailTransport,
+} from "./emailTransport";
 
 // The credential email.
 //
@@ -28,6 +32,8 @@ export interface CredentialEmail {
   template: CredentialEmailTemplate;
   /** Page to regenerate the credential, used by the take-down notice. */
   credentialPageUrl: string;
+  /** Which service puts the message on the wire. */
+  transport?: EmailTransport;
 }
 
 /** ASCII slug for the attachment filename, as in sendCertificateEmail. */
@@ -65,8 +71,7 @@ export async function sendCredentialEmail(
         ? reminderBody(mail, eventName, firstName)
         : credentialBody(mail, eventName, firstName);
 
-  await getTransporter().sendMail({
-    from: `"GDG ICA" <${GMAIL_USER.value()}>`,
+  await sendEmail(mail.transport ?? DEFAULT_TRANSPORT, {
     to: mail.to,
     subject,
     text: body.text,

--- a/functions/src/services/emailSettings.ts
+++ b/functions/src/services/emailSettings.ts
@@ -1,0 +1,55 @@
+import * as admin from "firebase-admin";
+import { logger } from "firebase-functions";
+import { FieldValue } from "firebase-admin/firestore";
+import {
+  DEFAULT_TRANSPORT,
+  isEmailTransport,
+  type EmailTransport,
+} from "./emailTransport";
+
+// The chosen transport lives in Firestore rather than in an environment
+// variable so it can be flipped from the panel without a deploy. That
+// matters on the day of the event: if Resend starts failing, switching
+// back to Gmail is a click, not a release.
+
+const SETTINGS_PATH = { collection: "settings", doc: "email" } as const;
+
+export function emailSettingsRef(): admin.firestore.DocumentReference {
+  return admin
+    .firestore()
+    .collection(SETTINGS_PATH.collection)
+    .doc(SETTINGS_PATH.doc);
+}
+
+/**
+ * Reads the configured transport.
+ *
+ * Falls back to the default on a missing document, an unknown value, or a
+ * read failure. This runs inside the scheduled drain, and a settings
+ * problem must degrade to "keep sending the way we always did" rather than
+ * stop the queue.
+ */
+export async function readEmailTransport(): Promise<EmailTransport> {
+  try {
+    const snap = await emailSettingsRef().get();
+    const value = snap.data()?.transport;
+    return isEmailTransport(value) ? value : DEFAULT_TRANSPORT;
+  } catch (err) {
+    logger.warn("Could not read the email transport setting", { err });
+    return DEFAULT_TRANSPORT;
+  }
+}
+
+export async function writeEmailTransport(
+  transport: EmailTransport,
+  uid: string
+): Promise<void> {
+  await emailSettingsRef().set(
+    {
+      transport,
+      updatedAt: FieldValue.serverTimestamp(),
+      updatedBy: uid,
+    },
+    { merge: true }
+  );
+}

--- a/functions/src/services/emailTransport.test.ts
+++ b/functions/src/services/emailTransport.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TRANSPORT,
+  EMAIL_TRANSPORTS,
+  dailyCapFor,
+  isEmailTransport,
+} from "./emailTransport";
+
+describe("isEmailTransport", () => {
+  it.each(EMAIL_TRANSPORTS)("accepts %s", (t) => {
+    expect(isEmailTransport(t)).toBe(true);
+  });
+
+  it.each([null, undefined, 42, "sendgrid", "GMAIL", ""])(
+    "rejects %j",
+    (value) => {
+      // A stored value that is not a known transport must not be trusted:
+      // readEmailTransport falls back to the default rather than passing
+      // an unknown string to the sender.
+      expect(isEmailTransport(value)).toBe(false);
+    }
+  );
+});
+
+describe("DEFAULT_TRANSPORT", () => {
+  it("is gmail", () => {
+    // Gmail needs no new credentials, so a project that never configures
+    // Resend still sends. Switching is a deliberate act in the panel.
+    expect(DEFAULT_TRANSPORT).toBe("gmail");
+  });
+});
+
+describe("dailyCapFor", () => {
+  it("keeps Resend under its free-tier daily limit", () => {
+    // Resend's free tier stops at 100 messages a day. The monthly 3,000
+    // never binds at event scale, but the daily one does.
+    expect(dailyCapFor("resend")).toBeLessThan(100);
+  });
+
+  it("leaves headroom rather than sitting exactly on the limit", () => {
+    // The account may send other things; landing on 100 would make an
+    // unrelated message the one that fails.
+    expect(dailyCapFor("resend")).toBeLessThanOrEqual(95);
+    expect(dailyCapFor("resend")).toBeGreaterThan(50);
+  });
+
+  it("allows more through Gmail, which tolerates a higher volume", () => {
+    expect(dailyCapFor("gmail")).toBeGreaterThan(dailyCapFor("resend"));
+  });
+
+  it("returns a usable cap for every known transport", () => {
+    for (const t of EMAIL_TRANSPORTS) {
+      expect(dailyCapFor(t)).toBeGreaterThan(0);
+      expect(Number.isInteger(dailyCapFor(t))).toBe(true);
+    }
+  });
+});

--- a/functions/src/services/emailTransport.ts
+++ b/functions/src/services/emailTransport.ts
@@ -1,0 +1,132 @@
+import { logger } from "firebase-functions";
+import { GMAIL_USER, RESEND_API_KEY, RESEND_FROM } from "../config";
+import { getTransporter } from "./email";
+
+// Which service actually puts a message on the wire.
+//
+// The sender address is tied to the transport and cannot be chosen
+// separately. Email authentication is what forbids it: gmail.com publishes
+// the list of servers allowed to send as one of its addresses, Resend is
+// not on it, and it cannot be added because we do not own gmail.com.
+// Sending as a Gmail address through Resend would land in spam or be
+// rejected outright, so "pick a sender" is really "pick a transport".
+
+export type EmailTransport = "gmail" | "resend";
+
+export const EMAIL_TRANSPORTS: readonly EmailTransport[] = ["gmail", "resend"];
+
+export function isEmailTransport(value: unknown): value is EmailTransport {
+  return (
+    typeof value === "string" &&
+    (EMAIL_TRANSPORTS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Gmail is the default because it is what was configured first and needs no
+ * new credentials. Switching to Resend is a deliberate act in the panel.
+ */
+export const DEFAULT_TRANSPORT: EmailTransport = "gmail";
+
+/**
+ * Daily send budget per transport.
+ *
+ * These are not arbitrary. Resend's free tier caps at 100 messages a day —
+ * the monthly 3,000 never binds at this scale, but the daily one does — so
+ * 90 leaves headroom for anything else the account sends. Gmail's consumer
+ * limit is far higher but undocumented and enforced by suspension rather
+ * than a clean rejection, so 350 stays a deliberately conservative guess.
+ *
+ * Hitting the cap delays credentials, it never drops them: the queue picks
+ * up where it left off the next day, and the attendee already has their
+ * card on screen before the email is even queued.
+ */
+export function dailyCapFor(transport: EmailTransport): number {
+  return transport === "resend" ? 90 : 350;
+}
+
+export interface OutgoingEmail {
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+  attachments?: { filename: string; content: Buffer; contentType: string }[];
+}
+
+/** Sender shown to the recipient, per transport. */
+function senderFor(transport: EmailTransport): string {
+  return transport === "resend"
+    ? RESEND_FROM.value() || "GDG ICA <no-reply@gdgica.com>"
+    : `"GDG ICA" <${GMAIL_USER.value()}>`;
+}
+
+/**
+ * Sends one message through the selected transport.
+ *
+ * Throws on failure rather than swallowing: the queue's retry and backoff
+ * depend on hearing about it.
+ */
+export async function sendEmail(
+  transport: EmailTransport,
+  mail: OutgoingEmail
+): Promise<void> {
+  if (transport === "resend") {
+    await sendViaResend(mail);
+    return;
+  }
+
+  await getTransporter().sendMail({
+    from: senderFor("gmail"),
+    to: mail.to,
+    subject: mail.subject,
+    text: mail.text,
+    html: mail.html,
+    attachments: mail.attachments ?? [],
+  });
+}
+
+async function sendViaResend(mail: OutgoingEmail): Promise<void> {
+  const key = RESEND_API_KEY.value();
+  if (!key) {
+    // A clearer failure than whatever the API returns for an empty bearer
+    // token, and it names the fix.
+    throw new Error(
+      "RESEND_API_KEY is not set; configure it or switch the transport back " +
+        "to gmail in the admin panel"
+    );
+  }
+
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: senderFor("resend"),
+      to: [mail.to],
+      subject: mail.subject,
+      text: mail.text,
+      html: mail.html,
+      // Replies reach the organiser's own inbox even though the message
+      // leaves from the domain. This is the part of "send as my Gmail"
+      // that email actually permits.
+      reply_to: GMAIL_USER.value() || undefined,
+      attachments: (mail.attachments ?? []).map((a) => ({
+        filename: a.filename,
+        content: a.content.toString("base64"),
+      })),
+    }),
+  });
+
+  if (!res.ok) {
+    // Bounded: the body can be long, and it lands in emailLastError which
+    // the panel renders.
+    const detail = await res.text().catch(() => "");
+    logger.error("Resend rejected a message", {
+      status: res.status,
+      detail: detail.slice(0, 300),
+    });
+    throw new Error(`Resend ${res.status}: ${detail.slice(0, 200)}`);
+  }
+}

--- a/functions/src/triggers/drainCredentialEmails.ts
+++ b/functions/src/triggers/drainCredentialEmails.ts
@@ -2,15 +2,21 @@ import * as admin from "firebase-admin";
 import { logger } from "firebase-functions";
 import { onSchedule } from "firebase-functions/v2/scheduler";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
-import { GMAIL_USER, GMAIL_APP_PASSWORD } from "../config";
+import {
+  GMAIL_USER,
+  GMAIL_APP_PASSWORD,
+  RESEND_API_KEY,
+  RESEND_FROM,
+} from "../config";
 import { writeAuditLog } from "../utils/audit";
 import { sendCredentialEmail } from "../services/credentialEmail";
 import { readCredentialImage } from "../services/credentialStorage";
+import { readEmailTransport } from "../services/emailSettings";
+import { dailyCapFor } from "../services/emailTransport";
 import {
   BATCH,
   budgetDocId,
   computeBackoff,
-  DAILY_CAP,
   hasAttemptsLeft,
   isLeaseStale,
   remainingBudget,
@@ -41,7 +47,9 @@ export const drainCredentialEmails = onSchedule(
   {
     schedule: "*/5 * * * *",
     timeZone: "America/Lima",
-    secrets: [GMAIL_USER, GMAIL_APP_PASSWORD],
+    // Both transports declare their secrets: which one is used is a
+    // runtime setting, so the function must be able to reach either.
+    secrets: [GMAIL_USER, GMAIL_APP_PASSWORD, RESEND_API_KEY, RESEND_FROM],
     timeoutSeconds: 540,
     memory: "512MiB",
   },
@@ -52,14 +60,21 @@ export const drainCredentialEmails = onSchedule(
     const budgetRef = db
       .collection("credential_email_budget")
       .doc(budgetDocId(now));
+    const transport = await readEmailTransport();
+    // The ceiling belongs to the transport, not to us: Resend's free tier
+    // stops at 100 messages a day, Gmail tolerates far more. Reading it
+    // here means flipping the switch in the panel also moves the budget.
+    const cap = dailyCapFor(transport);
+
     const budgetSnap = await budgetRef.get();
     const sentToday = (budgetSnap.data()?.sent as number | undefined) ?? 0;
 
-    let remaining = remainingBudget(sentToday);
+    let remaining = remainingBudget(sentToday, cap);
     if (remaining === 0) {
       logger.warn("Credential email budget exhausted for today", {
         sentToday,
-        cap: DAILY_CAP,
+        cap,
+        transport,
       });
       return;
     }
@@ -119,6 +134,7 @@ export const drainCredentialEmails = onSchedule(
                 ? "reminder"
                 : "credential",
           credentialPageUrl: `${SITE_ORIGIN}/events/${eventSlug}/credencial`,
+          transport,
         });
 
         await ref.update({
@@ -168,7 +184,15 @@ export const drainCredentialEmails = onSchedule(
       performedBy: "system",
       targetId: budgetDocId(now),
       targetType: "credential_email_budget",
-      details: { due: due.size, claimed, sent, failed, parked, remaining },
+      details: {
+        due: due.size,
+        claimed,
+        sent,
+        failed,
+        parked,
+        remaining,
+        transport,
+      },
       timestamp: FieldValue.serverTimestamp(),
     });
   }

--- a/src/components/react/admin/credentials/CredentialsPanel.tsx
+++ b/src/components/react/admin/credentials/CredentialsPanel.tsx
@@ -6,6 +6,7 @@ import { BevyQueue } from "./BevyQueue";
 import { PhotoModerationQueue } from "./PhotoModerationQueue";
 import { ReminderButton } from "./ReminderButton";
 import { ReconcileButton } from "./ReconcileButton";
+import { EmailTransportSetting } from "./EmailTransportSetting";
 import {
   buildCredentialBevyCsv,
   credentialCsvFilename,
@@ -153,6 +154,8 @@ export function CredentialsPanel({ initialSlug }: { initialSlug?: string }) {
           {error}
         </p>
       )}
+
+      <EmailTransportSetting onError={setError} />
 
       <nav className="border-gray-custom flex gap-1 border-b">
         <TabButton active={tab === "bevy"} onClick={() => setTab("bevy")}>

--- a/src/components/react/admin/credentials/EmailTransportSetting.tsx
+++ b/src/components/react/admin/credentials/EmailTransportSetting.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { useAuth } from "../AuthProvider";
+
+type Transport = "gmail" | "resend";
+
+interface Props {
+  onError: (message: string) => void;
+}
+
+const LABELS: Record<Transport, { name: string; sender: string }> = {
+  gmail: { name: "Gmail", sender: "sale desde tu cuenta de Gmail" },
+  resend: { name: "Resend", sender: "sale desde el dominio de GDG Ica" },
+};
+
+/**
+ * Picks which service sends credential email.
+ *
+ * Admin-only, and the API enforces it — hiding the control is cosmetic.
+ *
+ * The sender address is not a separate choice: it follows the transport.
+ * Email authentication forbids sending as a gmail.com address through a
+ * third party, so "which sender" and "which service" are the same
+ * question. Replies reach the same inbox either way.
+ *
+ * The switch takes effect on the next drain run, within five minutes, and
+ * needs no deploy — which is the point. If the provider starts failing
+ * during the event, going back is a click.
+ */
+export function EmailTransportSetting({ onError }: Props) {
+  const { can } = useAuth();
+  const [transport, setTransport] = useState<Transport | null>(null);
+  const [dailyCap, setDailyCap] = useState<number | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const allowed = can("email:transport");
+
+  useEffect(() => {
+    if (!allowed) return;
+    let cancelled = false;
+    (async () => {
+      const res = await api.getEmailSettings();
+      if (cancelled) return;
+      if (res.success && res.data) {
+        setTransport(res.data.transport);
+        setDailyCap(res.data.dailyCap);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [allowed]);
+
+  if (!allowed || !transport) return null;
+
+  const change = async (next: Transport) => {
+    if (next === transport) return;
+    setBusy(true);
+    const res = await api.setEmailTransport(next);
+    setBusy(false);
+
+    if (!res.success || !res.data) {
+      onError(res.error ?? "No se pudo cambiar el proveedor de correo");
+      return;
+    }
+    setTransport(res.data.transport);
+    setDailyCap(res.data.dailyCap);
+  };
+
+  return (
+    <div className="border-gray-custom rounded-lg border bg-white p-3">
+      <p className="text-primary text-sm font-semibold">Envío de correos</p>
+
+      <div className="mt-2 flex gap-2">
+        {(Object.keys(LABELS) as Transport[]).map((option) => (
+          <button
+            key={option}
+            type="button"
+            disabled={busy}
+            onClick={() => change(option)}
+            aria-pressed={transport === option}
+            className={`rounded border px-3 py-1.5 text-sm disabled:opacity-50 ${
+              transport === option
+                ? "border-google-blue text-google-blue bg-[#EFF6FF] font-semibold"
+                : "border-gray-custom text-secondary"
+            }`}
+          >
+            {LABELS[option].name}
+          </button>
+        ))}
+      </div>
+
+      <p className="text-tertiary mt-2 text-xs">
+        {LABELS[transport].sender}
+        {dailyCap !== null && ` · hasta ${dailyCap} correos al día`}
+      </p>
+      <p className="text-tertiary mt-1 text-xs">
+        Las respuestas llegan a tu correo con cualquiera de los dos. Al pasar el
+        límite diario la cola continúa al día siguiente; nadie se queda sin
+        credencial.
+      </p>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -289,6 +289,17 @@ const realApi = {
       `/events/${encodeURIComponent(slug)}/credentials/${id}/photo`,
       data
     ),
+  getEmailSettings: () =>
+    request<{ transport: "gmail" | "resend"; dailyCap: number }>(
+      "GET",
+      "/settings/email"
+    ),
+  setEmailTransport: (transport: "gmail" | "resend") =>
+    request<{ transport: "gmail" | "resend"; dailyCap: number }>(
+      "PUT",
+      "/settings/email",
+      { transport }
+    ),
   reconcileCredentials: (slug: string) =>
     request<{
       matched: number;

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -113,6 +113,9 @@ export const mockApi = {
 
   setCredentialBevyStatus: () => ok(null),
   moderateCredentialPhoto: () => ok(null),
+  getEmailSettings: () => ok({ transport: "gmail", dailyCap: 350 }),
+  setEmailTransport: (transport: "gmail" | "resend") =>
+    ok({ transport, dailyCap: transport === "resend" ? 90 : 350 }),
   reconcileCredentials: () =>
     ok({
       matched: 0,

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -34,6 +34,7 @@ export const PERMISSIONS = [
   "checkin:import",
   "credentials:operate",
   "credentials:moderate",
+  "email:transport",
   "certificates:send",
   "minigames:template:read",
   "minigames:template:write",


### PR DESCRIPTION
## What changed

Adds Resend as an alternative transport for credential email, selectable from the admin panel.

- `services/emailTransport.ts` — the two senders and their daily budgets.
- `services/emailSettings.ts` + `handlers/emailSettings.ts` — reading and writing the choice.
- `EmailTransportSetting.tsx` — the selector.
- New admin-only permission `email:transport`; `settings/email` closed to clients in `firestore.rules`.

## Why a transport switch and not a sender field

The sender address **cannot be chosen separately**. `gmail.com` publishes the list of servers allowed to send as one of its addresses, Resend is not on it, and it cannot be added because the domain is not ours. Sending as a Gmail address through Resend would land in spam or be rejected outright.

So "which sender" and "which service" are the same question, and the UI asks it once:

| Transport | Sender |
|---|---|
| Gmail | the organiser's Gmail account, exactly as today |
| Resend | the GDG Ica domain |

Replies reach the same inbox either way — the Resend path sets `reply_to`.

## Why the choice lives in Firestore

Not an environment variable, so it can be flipped **without a deploy**. That is the entire point: if the provider starts failing during the event, going back to Gmail is a click and takes effect on the next drain run, within five minutes.

Nothing queued is lost. Documents carry no transport of their own, so the drain reads the current setting each run and a message queued under one transport simply leaves through the other.

## The daily budget now belongs to the transport

It used to be a constant of 350. Resend's free tier stops at **100 messages a day** — the monthly 3,000 never binds at event scale, but the daily one does — so Resend gets 90 and Gmail keeps 350. Flipping the switch moves the ceiling with it, so the two cannot drift.

Hitting the cap **delays** credentials, it never drops them. The queue resumes the next day, and the attendee already has their card on screen before the email is even queued.

## Failure behaviour

`readEmailTransport` falls back to Gmail on a missing document, an unknown stored value, or a read failure. This runs inside the scheduled drain, and a settings problem must degrade to "keep sending the way we always did" rather than stop the queue.

Both secrets are declared on the scheduled function, since which one is used is a runtime decision. They are **optional**: with the transport on Gmail they are never read, so the project still deploys without a Resend account.

## Permissions

`email:transport` sits in no role bundle, so only `admin` holds it — changing which service sends every credential email is global configuration, not a per-event operation. `settings/email` is denied to all clients in `firestore.rules`: anyone able to write it could redirect every credential email through a provider of their choosing.

## How to test

```bash
pnpm test:functions   # 512
pnpm test             # 381
pnpm test:rules       # 156
```

The transport tests pin the things that would silently break: an unknown stored value is rejected rather than passed to the sender, Resend's cap stays under its free-tier limit with headroom, and the schema refuses an extra `from` key — accepting one would imply the sender can be chosen separately.

Manually, once the secrets exist: open `/admin/credentials?slug=…` as an admin, switch to Resend, generate a credential and confirm the message arrives from the domain with replies going to the organiser's inbox.

## Before this can be used

Two secrets need to exist in Firebase: `RESEND_API_KEY` and `RESEND_FROM` (for example `GDG ICA <no-reply@gdgica.com>`, on a domain verified in Resend — that verification is what stops the message being treated as spoofed). Until then the selector still works; choosing Resend simply fails each send with a message naming the missing key, and the queue retries.