### PR TITLE
feat(api): verify App Check on the public credential endpoints

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -100,7 +100,7 @@
             },
             {
               "key": "Content-Security-Policy",
-              "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://apis.google.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://securetoken.googleapis.com https://firebaseinstallations.googleapis.com; frame-src 'self' https://www.google.com https://appgdgica.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
+              "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://apis.google.com https://www.google.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://securetoken.googleapis.com https://firebaseinstallations.googleapis.com https://www.google.com; frame-src 'self' https://www.google.com https://appgdgica.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
             }
           ]
         },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,7 @@ import { GITHUB_TOKEN, GMAIL_USER, GMAIL_APP_PASSWORD } from "./config";
 import { requirePermission, requireAuth } from "./middleware/auth";
 import { isAllowedOrigin, rejectDisallowedOrigin } from "./middleware/cors";
 import { validateParamId } from "./middleware/validate";
+import { verifyAppCheck } from "./middleware/appCheck";
 import { validateBody } from "./middleware/validateBody";
 import {
   eventSchema,
@@ -656,6 +657,7 @@ app.post(
 // Public credential submission — accepts any Firebase token (incl. anon).
 app.post(
   "/api/events/:slug/credentials",
+  verifyAppCheck(),
   requireAuth(),
   slugP,
   credentialLimiter,
@@ -669,6 +671,7 @@ app.post(
 // handler pins the write to the anonymous UID that created the record.
 app.patch(
   "/api/events/:slug/credentials/:id/image",
+  verifyAppCheck(),
   requireAuth(),
   slugP,
   vid,

--- a/functions/src/middleware/appCheck.test.ts
+++ b/functions/src/middleware/appCheck.test.ts
@@ -1,0 +1,140 @@
+import { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  verifyToken: vi.fn(),
+  settingsGet: vi.fn(),
+}));
+
+vi.mock("firebase-admin", () => ({
+  appCheck: () => ({ verifyToken: mocks.verifyToken }),
+  firestore: () => ({
+    collection: () => ({ doc: () => ({ get: mocks.settingsGet }) }),
+  }),
+}));
+
+import { verifyAppCheck } from "./appCheck";
+
+function buildReq(token?: string): Request {
+  return {
+    path: "/api/events/devfest-2026/credentials",
+    header: (name: string) =>
+      name.toLowerCase() === "x-firebase-appcheck" ? token : undefined,
+  } as unknown as Request;
+}
+
+interface ResMock extends Response {
+  __status?: number;
+  __body?: unknown;
+}
+
+function buildRes(): ResMock {
+  const res: Partial<ResMock> = {};
+  res.status = vi.fn(function (this: ResMock, code: number) {
+    this.__status = code;
+    return this;
+  }) as ResMock["status"];
+  res.json = vi.fn(function (this: ResMock, body: unknown) {
+    this.__body = body;
+    return this;
+  }) as ResMock["json"];
+  return res as ResMock;
+}
+
+/** Sets what the enforcement document says. */
+function enforcement(enforce: boolean | undefined | "error") {
+  if (enforce === "error") {
+    mocks.settingsGet.mockRejectedValue(new Error("firestore down"));
+    return;
+  }
+  mocks.settingsGet.mockResolvedValue({ data: () => ({ enforce }) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("verifyAppCheck", () => {
+  it("lets a valid token through without reading the setting", async () => {
+    mocks.verifyToken.mockResolvedValue({ appId: "web" });
+    const next = vi.fn();
+    await verifyAppCheck()(buildReq("good-token"), buildRes(), next);
+
+    expect(next).toHaveBeenCalledOnce();
+    // The happy path must not pay for a Firestore read on every public
+    // request.
+    expect(mocks.settingsGet).not.toHaveBeenCalled();
+  });
+
+  it("allows an unverified request while enforcement is off", async () => {
+    // The rollout starts unenforced on purpose: rejecting before the logs
+    // show what real traffic looks like would cost registrations.
+    mocks.verifyToken.mockRejectedValue(new Error("bad"));
+    enforcement(false);
+    const next = vi.fn();
+    const res = buildRes();
+    await verifyAppCheck()(buildReq("bad-token"), res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.__status).toBeUndefined();
+  });
+
+  it("allows a request with no token at all while unenforced", async () => {
+    enforcement(false);
+    const next = vi.fn();
+    await verifyAppCheck()(buildReq(undefined), buildRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an invalid token once enforcement is on", async () => {
+    mocks.verifyToken.mockRejectedValue(new Error("bad"));
+    enforcement(true);
+    const next = vi.fn();
+    const res = buildRes();
+    await verifyAppCheck()(buildReq("bad-token"), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.__status).toBe(403);
+  });
+
+  it("rejects a missing token once enforcement is on", async () => {
+    enforcement(true);
+    const next = vi.fn();
+    const res = buildRes();
+    await verifyAppCheck()(buildReq(undefined), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.__status).toBe(403);
+  });
+
+  it("explains the refusal in Spanish and suggests an action", async () => {
+    // A blocked legitimate visitor needs something to do, not a code.
+    enforcement(true);
+    const res = buildRes();
+    await verifyAppCheck()(buildReq(undefined), res, vi.fn());
+
+    const body = res.__body as { error: string };
+    expect(body.error).toMatch(/recarga la página/i);
+  });
+
+  it("fails open when the setting cannot be read", async () => {
+    // A Firestore hiccup must not close public registration. The endpoint
+    // still has its per-IP limit and its per-event cap.
+    mocks.verifyToken.mockRejectedValue(new Error("bad"));
+    enforcement("error");
+    const next = vi.fn();
+    const res = buildRes();
+    await verifyAppCheck()(buildReq("bad-token"), res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.__status).toBeUndefined();
+  });
+
+  it("treats a missing enforce field as unenforced", async () => {
+    mocks.verifyToken.mockRejectedValue(new Error("bad"));
+    enforcement(undefined);
+    const next = vi.fn();
+    await verifyAppCheck()(buildReq("bad-token"), buildRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+});

--- a/functions/src/middleware/appCheck.ts
+++ b/functions/src/middleware/appCheck.ts
@@ -1,0 +1,91 @@
+import { Request, Response, NextFunction } from "express";
+import * as admin from "firebase-admin";
+import { logger } from "firebase-functions";
+
+// App Check verification for the public credential endpoints.
+//
+// Those endpoints accept anonymous Firebase tokens, which any client mints
+// for free from anywhere. That makes them callable by a script that never
+// loaded our page. App Check closes that: the browser proves, via
+// reCAPTCHA, that the call came from our web app before the request is
+// accepted.
+//
+// The per-IP limiter and the per-event cap bound the damage; this is what
+// stops it at the door.
+
+const HEADER = "x-firebase-appcheck";
+
+/**
+ * Enforcement lives in Firestore so it can be turned off without a deploy.
+ *
+ * That switch is the whole reason this rolls out in two steps. A false
+ * rejection costs a registration — someone with an extension blocking
+ * reCAPTCHA, or a corporate proxy — and finding that out mid-event with no
+ * way to disable it would be worse than the abuse it prevents. Start
+ * unenforced, watch the logs, then turn it on.
+ */
+export async function readAppCheckEnforcement(): Promise<boolean> {
+  try {
+    const snap = await admin
+      .firestore()
+      .collection("settings")
+      .doc("appcheck")
+      .get();
+    return snap.data()?.enforce === true;
+  } catch (err) {
+    // Fail open: a settings read failure must not close public
+    // registration. The endpoint still has its rate limit and its cap.
+    logger.warn("Could not read the App Check enforcement setting", { err });
+    return false;
+  }
+}
+
+/**
+ * Verifies the App Check token when one is present, and rejects only when
+ * enforcement is on.
+ *
+ * Unverified traffic is logged either way, so the decision to enforce can
+ * be made against real numbers rather than a guess.
+ */
+export function verifyAppCheck() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const token = req.header(HEADER);
+    let verified = false;
+
+    if (token) {
+      try {
+        await admin.appCheck().verifyToken(token);
+        verified = true;
+      } catch {
+        // Deliberately no detail in the log: a malformed token tells us
+        // nothing useful and the string is attacker-controlled.
+        verified = false;
+      }
+    }
+
+    if (verified) {
+      next();
+      return;
+    }
+
+    const enforce = await readAppCheckEnforcement();
+
+    logger.warn("Request without a valid App Check token", {
+      path: req.path,
+      hadToken: Boolean(token),
+      enforced: enforce,
+    });
+
+    if (!enforce) {
+      next();
+      return;
+    }
+
+    res.status(403).json({
+      success: false,
+      error:
+        "No pudimos verificar que la solicitud venga del sitio de GDG Ica. " +
+        "Recarga la página e inténtalo de nuevo.",
+    });
+  };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { getIdToken } from "./auth";
+import { getAppCheckToken } from "./firebase";
 import { mockApi } from "./mock-api";
 
 const USE_EMULATOR = import.meta.env.PUBLIC_USE_FIREBASE_EMULATOR === "true";
@@ -59,11 +60,17 @@ async function request<T>(
   }
 
   try {
+    // Proves the call came from this web app rather than a script that
+    // minted an anonymous token elsewhere. Omitted when unavailable; the
+    // server decides what that means.
+    const appCheckToken = await getAppCheckToken();
+
     const res = await fetch(`${API_BASE}${path}`, {
       method,
       headers: {
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
+        ...(appCheckToken ? { "X-Firebase-AppCheck": appCheckToken } : {}),
       },
       body: body ? JSON.stringify(body) : undefined,
     });

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -30,6 +30,65 @@ function getApp() {
 }
 
 const USE_EMULATOR = import.meta.env.PUBLIC_USE_FIREBASE_EMULATOR === "true";
+
+// reCAPTCHA v3 site key. Public by design: it ships in the page source,
+// and it is the SECRET key — held only by Firebase — that makes a token
+// verifiable. Enterprise was offered in the console and declined; v3 is
+// still supported and enough to tell our web app from a script.
+const RECAPTCHA_SITE_KEY = "6Le5ls8rAAAAAIOb9XYqVolbR3_LriaUektHq5Nl";
+
+let _appCheckPromise: Promise<import("firebase/app-check").AppCheck> | null =
+  null;
+
+/**
+ * Initializes App Check, once per page.
+ *
+ * Skipped against the emulator suite: reCAPTCHA cannot verify localhost,
+ * and the API accepts unverified traffic while enforcement is off anyway.
+ *
+ * Failure is swallowed on purpose — see getAppCheckToken.
+ */
+async function getAppCheck() {
+  if (!_appCheckPromise) {
+    _appCheckPromise = (async () => {
+      const app = await getApp();
+      const { initializeAppCheck, ReCaptchaV3Provider } =
+        await import("firebase/app-check");
+      return initializeAppCheck(app, {
+        provider: new ReCaptchaV3Provider(RECAPTCHA_SITE_KEY),
+        // Firebase refreshes the token before it expires, so a long
+        // session does not start failing halfway through.
+        isTokenAutoRefreshEnabled: true,
+      });
+    })();
+
+    _appCheckPromise.catch(() => {
+      _appCheckPromise = null;
+    });
+  }
+  return _appCheckPromise;
+}
+
+/**
+ * App Check token for the current page, or null.
+ *
+ * Null on any failure — reCAPTCHA blocked by an extension, a corporate
+ * proxy, the emulator — and the caller simply omits the header. The server
+ * decides what an unverified request means; the browser refusing to send
+ * anything would take that decision away from it and turn a blocked script
+ * into a lost registration.
+ */
+export async function getAppCheckToken(): Promise<string | null> {
+  if (USE_EMULATOR) return null;
+  try {
+    const appCheck = await getAppCheck();
+    const { getToken } = await import("firebase/app-check");
+    const result = await getToken(appCheck, /* forceRefresh */ false);
+    return result.token;
+  } catch {
+    return null;
+  }
+}
 let _authEmulatorConnected = false;
 let _dbPromise: Promise<import("firebase/firestore").Firestore> | null = null;
 


### PR DESCRIPTION
## What changed

App Check verification on the two **public** credential routes, rolled out unenforced.

- `functions/src/middleware/appCheck.ts` — verification plus the enforcement flag.
- `src/lib/firebase.ts` — reCAPTCHA v3 initialisation.
- `src/lib/api.ts` — attaches the token header.
- `firebase.json` — CSP for the reCAPTCHA script.

## Why

Those endpoints accept anonymous Firebase tokens, which any client mints for free from anywhere. That makes them callable by a script that never loaded the site. The per-IP limit and the per-event cap bound the damage; this is what stops it at the door.

## Why it ships unenforced

Enforcement is a flag in Firestore, so it can be switched without a deploy.

That switch is the entire reason for doing this in two steps. A false rejection costs a **real registration** — someone with an extension blocking reCAPTCHA, or behind a corporate proxy — and discovering that mid-event with no way to disable it would be worse than the abuse being prevented. Unverified traffic is logged either way, so the decision to enforce can be made against real numbers rather than a guess.

To enforce later, set `enforce: true` on `settings/appcheck`.

## Three failure decisions

**The client omits the header rather than failing** when a token cannot be obtained. What an unverified request means is the server's decision; having the browser refuse to send anything would take that decision away and turn a blocked script into a lost registration.

**The middleware fails open when the setting cannot be read.** A Firestore hiccup must not close public registration, which still has its rate limit and its cap.

**A valid token skips the settings read entirely**, so the happy path does not pay for a Firestore read on every public request.

## Scope

Applied only to the two public routes. The admin ones already sit behind a permission, where App Check adds nothing.

## The CSP change, which is the risky part

Adds `https://www.google.com` to `script-src` and `connect-src`. `gstatic.com` and the `frame-src` entry were already present for other Google embeds, so this is smaller than expected — but it is the change that breaks the page if it is wrong, and the dev server sends no CSP header, so a mistake would only surface in production.

## reCAPTCHA v3, not Enterprise

Enterprise offers more fraud signals and 10,000 free assessments a month. v3 is not deprecated and is enough to tell a browser on our site from a script — a regional DevFest is not a target for sophisticated fraud. Switching later is a provider swap.

The site key is public by design: it ships in the page source. It is the secret key, held only by Firebase, that makes a token verifiable.

## How to test

```bash
pnpm test:functions   # 520
pnpm test             # 381
pnpm test:rules       # 156
pnpm build
```

The middleware tests cover both modes, a missing token, an invalid one, the fail-open path when the setting is unreadable, and that the refusal message tells a blocked visitor what to do rather than showing a code.

**After deploying**, open the credential page and confirm the console shows **zero CSP violations** — that is where a mistake in this change surfaces, and only in production. Then watch the logs for `Request without a valid App Check token` before turning enforcement on.