### PR TITLE
fix(functions): make the Resend secrets survive a project without Resend

### DIFF
--- a/functions/src/handlers/emailSettings.ts
+++ b/functions/src/handlers/emailSettings.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_TRANSPORT,
   dailyCapFor,
   isEmailTransport,
+  isResendConfigured,
 } from "../services/emailTransport";
 import type { EmailTransportInput } from "../schemas/credentials";
 
@@ -32,6 +33,9 @@ export async function getEmailSettings(req: Request, res: Response) {
       data: {
         transport,
         dailyCap: dailyCapFor(transport),
+        // So the panel can warn BEFORE the switch is flipped rather than
+        // leaving the operator to discover it through failed sends.
+        resendConfigured: isResendConfigured(),
         updatedAt: snap.data()?.updatedAt ?? null,
       },
     });

--- a/functions/src/services/emailTransport.test.ts
+++ b/functions/src/services/emailTransport.test.ts
@@ -4,6 +4,7 @@ import {
   EMAIL_TRANSPORTS,
   dailyCapFor,
   isEmailTransport,
+  isResendConfigured,
 } from "./emailTransport";
 
 describe("isEmailTransport", () => {
@@ -53,5 +54,16 @@ describe("dailyCapFor", () => {
       expect(dailyCapFor(t)).toBeGreaterThan(0);
       expect(Number.isInteger(dailyCapFor(t))).toBe(true);
     }
+  });
+});
+
+describe("isResendConfigured", () => {
+  it("is exported so the panel can warn before the switch is flipped", () => {
+    // The value itself depends on the deployed secret, so what is pinned
+    // here is that the check exists and answers a boolean. Its job is to
+    // tell a real key from the filler value a project without a Resend
+    // account must still carry — firebase-functions has no optional
+    // secret, so a declared one blocks the deploy until it has some value.
+    expect(typeof isResendConfigured).toBe("function");
   });
 });

--- a/functions/src/services/emailTransport.ts
+++ b/functions/src/services/emailTransport.ts
@@ -85,14 +85,32 @@ export async function sendEmail(
   });
 }
 
+/**
+ * Whether the Resend credentials are real rather than a placeholder.
+ *
+ * The secrets have to EXIST for the project to deploy — firebase-functions
+ * has no notion of an optional secret, so a declared one blocks the deploy
+ * until it has some value. That means a project with no Resend account
+ * still carries a filler value here, and it must not be mistaken for a
+ * working key: sending with it would fail as an opaque 401 from the API
+ * instead of a message naming what is missing.
+ *
+ * Resend issues keys prefixed `re_`, which makes the distinction checkable
+ * rather than a guess about magic words.
+ */
+export function isResendConfigured(): boolean {
+  return RESEND_API_KEY.value().trim().startsWith("re_");
+}
+
 async function sendViaResend(mail: OutgoingEmail): Promise<void> {
-  const key = RESEND_API_KEY.value();
-  if (!key) {
+  const key = RESEND_API_KEY.value().trim();
+  if (!isResendConfigured()) {
     // A clearer failure than whatever the API returns for an empty bearer
     // token, and it names the fix.
     throw new Error(
-      "RESEND_API_KEY is not set; configure it or switch the transport back " +
-        "to gmail in the admin panel"
+      "RESEND_API_KEY is not configured (it should start with re_). Set it " +
+        "with `firebase functions:secrets:set RESEND_API_KEY`, or switch the " +
+        "transport back to gmail in the admin panel."
     );
   }
 

--- a/src/components/react/admin/credentials/EmailTransportSetting.tsx
+++ b/src/components/react/admin/credentials/EmailTransportSetting.tsx
@@ -31,6 +31,7 @@ export function EmailTransportSetting({ onError }: Props) {
   const { can } = useAuth();
   const [transport, setTransport] = useState<Transport | null>(null);
   const [dailyCap, setDailyCap] = useState<number | null>(null);
+  const [resendReady, setResendReady] = useState(true);
   const [busy, setBusy] = useState(false);
 
   const allowed = can("email:transport");
@@ -44,6 +45,7 @@ export function EmailTransportSetting({ onError }: Props) {
       if (res.success && res.data) {
         setTransport(res.data.transport);
         setDailyCap(res.data.dailyCap);
+        setResendReady(res.data.resendConfigured);
       }
     })();
     return () => {
@@ -94,6 +96,12 @@ export function EmailTransportSetting({ onError }: Props) {
         {LABELS[transport].sender}
         {dailyCap !== null && ` · hasta ${dailyCap} correos al día`}
       </p>
+      {!resendReady && (
+        <p className="mt-2 rounded bg-[#FEF3C7] px-2 py-1 text-xs text-[#92400E]">
+          Resend todavía no tiene una clave válida configurada. Si lo eliges,
+          los envíos quedarán en cola reintentando hasta que se configure.
+        </p>
+      )}
       <p className="text-tertiary mt-1 text-xs">
         Las respuestas llegan a tu correo con cualquiera de los dos. Al pasar el
         límite diario la cola continúa al día siguiente; nadie se queda sin

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -297,10 +297,11 @@ const realApi = {
       data
     ),
   getEmailSettings: () =>
-    request<{ transport: "gmail" | "resend"; dailyCap: number }>(
-      "GET",
-      "/settings/email"
-    ),
+    request<{
+      transport: "gmail" | "resend";
+      dailyCap: number;
+      resendConfigured: boolean;
+    }>("GET", "/settings/email"),
   setEmailTransport: (transport: "gmail" | "resend") =>
     request<{ transport: "gmail" | "resend"; dailyCap: number }>(
       "PUT",

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -113,7 +113,8 @@ export const mockApi = {
 
   setCredentialBevyStatus: () => ok(null),
   moderateCredentialPhoto: () => ok(null),
-  getEmailSettings: () => ok({ transport: "gmail", dailyCap: 350 }),
+  getEmailSettings: () =>
+    ok({ transport: "gmail", dailyCap: 350, resendConfigured: false }),
   setEmailTransport: (transport: "gmail" | "resend") =>
     ok({ transport, dailyCap: transport === "resend" ? 90 : 350 }),
   reconcileCredentials: () =>


### PR DESCRIPTION
> **The deploy is currently failing on `main`.** This does not fix that on its own — the secrets still have to be created — but it makes the state afterwards behave sanely.

## What happened

The deploy fails with:

```
Error: In non-interactive mode but have no value for the secret: RESEND_API_KEY
```

The PR that introduced the Resend transport claimed the secrets were optional. **They are not.** `firebase-functions` has no notion of an optional secret: a declared one blocks the deploy until it has some value, whether or not the code ever reads it. That claim was wrong, and this is the consequence.

## The immediate unblock

Two commands, once:

```bash
firebase functions:secrets:set RESEND_API_KEY --project appgdgica
firebase functions:secrets:set RESEND_FROM --project appgdgica
```

With no Resend account yet, any filler value works.

## What this PR changes

Not the requirement — that is unavoidable and is now documented rather than misdescribed. What changes is **what a filler value does**.

A project without a Resend account still has to put something in the secret to deploy, and that something must not be mistaken for a working key: sending with it would fail as an opaque `401` from the API instead of a message naming what is missing.

Resend issues keys prefixed `re_`, so the check is a real property of the value rather than a guess about magic words like `"unset"` or `"pending"`.

The settings endpoint now reports whether Resend is genuinely configured, and the panel warns **before** the switch is flipped rather than leaving the operator to discover it through failed sends. Choosing Resend anyway stays safe: those sends queue and retry, and switching back is a click.

## How to test

```bash
pnpm test:functions   # 521
pnpm test             # 381
```

Manually, as an admin in `/admin/credentials?slug=…`: with a filler secret the panel shows the warning; with a real `re_` key it does not.