### PR TITLE
fix(audit): make access-control changes and their audit records atomic

### DIFF
--- a/docs/retencion-de-datos.md
+++ b/docs/retencion-de-datos.md
@@ -121,12 +121,56 @@ total.
 
 ## Lo que este procedimiento deja fuera a propósito
 
-- **`audit_log`** conserva la acción `credential.create` con el
-  `credentialId`, el correlativo y la letra de grupo — **nunca DNI, nombre ni
-  correo**. Es trazabilidad operativa sin datos personales, así que no entra
-  en los plazos de arriba.
 - **`credential_email_budget`** solo cuenta envíos por día. No contiene
   ninguna referencia a personas.
+
+## `audit_log`: qué guarda y por qué no sigue estos plazos
+
+De la credencial en sí, `audit_log` conserva la acción `credential.create` con
+el `credentialId`, el correlativo y la letra de grupo — **nunca DNI, nombre ni
+correo**. Eso sigue siendo cierto y es deliberado: la colección la lee cualquiera
+con el permiso `audit:read`, que es más amplio que el permiso para ver el roster
+con datos personales, así que el handler los omite a propósito.
+
+Lo que **sí** guarda de quien opera el panel, desde que se amplió la auditoría:
+
+| Campo               | Qué es                                                        |
+| ------------------- | ------------------------------------------------------------- |
+| `performedBy`       | uid de Firebase de quien ejecutó la acción                    |
+| `actor.email`       | correo de la cuenta con la que se actuó                       |
+| `actor.role`        | rol con el que se actuó, congelado en ese momento             |
+| `context.ipPrefix`  | **prefijo de red**, no la dirección: /24 en IPv4, /48 en IPv6 |
+| `context.userAgent` | cadena del navegador, saneada y cortada a 200 caracteres      |
+| `context.route`     | patrón de la ruta (`/api/users/:uid/role`)                    |
+| `context.requestId` | identificador para correlacionar con Cloud Logging            |
+
+Esto es un cambio respecto a lo que este documento decía antes. `audit_log` ya
+no es "trazabilidad sin datos personales": el correo identifica a una persona, y
+una dirección IP es dato personal bajo la Ley N.º 29733. Se guarda solo el
+prefijo de red precisamente para quedarse en lo que hace falta —correlacionar
+"desde esta red se hicieron estas cuarenta cosas"— sin conservar un dato que
+señale a un individuo concreto. La dirección completa existe únicamente en Cloud
+Logging, que tiene su propio control de acceso y su propia retención.
+
+**Plazo: 24 meses.** Más largo que los 12 de los datos de inscripción, y a
+propósito: un registro de auditoría sirve para reconstruir qué pasó cuando el
+problema se descubre tarde, y los abusos de permisos se descubren tarde por
+definición. Borrarlo al año dejaría sin rastro justo el caso que justifica
+tenerlo.
+
+**Qué contiene sobre asistentes**: nada más que el `credentialId`. Las personas
+que sacan una credencial no operan el panel, así que no generan entradas con
+correo ni IP. Una solicitud de borrado de un asistente **no** requiere tocar
+`audit_log`; el procedimiento de arriba está completo tal y como está.
+
+**Qué contiene sobre quien opera el panel**: lo de la tabla. Si una de esas
+personas pide el borrado de sus datos, hay que decirle con claridad que el
+registro de auditoría no se borra a petición mientras esté dentro de su plazo:
+es la constancia de decisiones que afectaron a otras personas —conceder
+permisos, publicar contenido, exportar respuestas de formularios— y borrarlo a
+petición del sujeto lo convertiría en un registro que sus propios sujetos
+pueden editar, que es lo mismo que no tener registro. Ese es el argumento que
+hay que dar, no un "no se puede".
 
 ## Después de ejecutarlo
 

--- a/functions/src/auth/guards.ts
+++ b/functions/src/auth/guards.ts
@@ -1,0 +1,55 @@
+import * as admin from "firebase-admin";
+import { canAssignRole, isRole, type Permission } from "./permissions";
+
+/**
+ * Guardas compartidas por TODOS los caminos que cambian el rol de alguien.
+ *
+ * Vivían dentro de `handlers/users.ts`, y por eso los otros dos caminos que
+ * escriben `users/{uid}.role` —aprobar una solicitud de acceso y canjear una
+ * invitación, ambos en `handlers/access.ts`— no las aplicaban. El resultado era
+ * que una invitación al correo de un admin, canjeada por ese mismo admin, lo
+ * degradaba sin que nada lo impidiera; y si era el último, dejaba la plataforma
+ * sin nadie capaz de administrarla salvo entrando a mano por la consola de
+ * Firebase. Están aquí para que el siguiente camino que toque roles no pueda
+ * saltárselas por descuido.
+ */
+
+/**
+ * Consulta de admins. Se expone la consulta y no solo el resultado porque
+ * dentro de una transacción hay que leerla con `tx.get()`, y una lectura suelta
+ * no cuenta para la transacción: dos canjes simultáneos podrían pasar los dos
+ * la comprobación y dejar cero admins.
+ */
+export function activeAdminsQuery(): admin.firestore.Query {
+  return admin.firestore().collection("users").where("role", "==", "admin");
+}
+
+/** Cuenta los que de verdad pueden operar: un admin suspendido no gobierna nada. */
+export function countActiveAdminsIn(
+  snapshot: admin.firestore.QuerySnapshot
+): number {
+  return snapshot.docs.filter((d) => d.data()?.status !== "suspended").length;
+}
+
+/**
+ * Cuenta los admins que realmente pueden operar. Se usa para no dejar la
+ * plataforma sin nadie capaz de administrarla: un descuido ahí obliga a
+ * entrar por la consola de Firebase a reparar el desastre a mano.
+ */
+export async function countActiveAdmins(): Promise<number> {
+  return countActiveAdminsIn(await activeAdminsQuery().get());
+}
+
+/**
+ * El actor debe poseer todos los permisos del rol que toca — tanto el que
+ * quita como el que pone. Sin la comprobación sobre el rol ACTUAL, alguien
+ * con `users:role:write` concedido a mano podría degradar a un admin pese a
+ * no tener sus permisos, que es escalada por la puerta de atrás.
+ */
+export function actorDominates(
+  actorPermissions: ReadonlySet<Permission>,
+  role: unknown
+): boolean {
+  if (!isRole(role)) return true; // rol corrupto: no hay nada que dominar
+  return canAssignRole(actorPermissions, role);
+}

--- a/functions/src/handlers/access.test.ts
+++ b/functions/src/handlers/access.test.ts
@@ -354,6 +354,68 @@ describe("decideRequest", () => {
     expect(sentDecisions[0]).toMatchObject({ approved: true });
   });
 
+  // Aprobar una solicitud SUSTITUYE el rol que la persona ya tenía. Este
+  // camino no pasaba por el guard de último admin de `handlers/users.ts`, así
+  // que aprobar una solicitud vieja de quien entretanto llegó a admin lo
+  // degradaba y podía dejar la plataforma sin nadie capaz de administrarla.
+  it("RECHAZA aprobar si degradaría al último admin", async () => {
+    docs.set("users/t1", { uid: "t1", role: "admin" });
+    const res = buildRes();
+    await handler.decideRequest(
+      buildReq({
+        role: "admin",
+        uid: "rev",
+        params: { uid: "t1" },
+        body: { approve: true, note: "Baja a voluntario" },
+      }),
+      res
+    );
+    expect(res.__status).toBe(400);
+    expect(res.__body?.error).toContain("last active admin");
+    expect(docs.get("users/t1")).toMatchObject({ role: "admin" });
+    expect(docs.get("access_requests/t1")).toMatchObject({ status: "pending" });
+    expect(auditLogEntries()).toHaveLength(0);
+  });
+
+  it("sí deja aprobar si queda otro admin activo", async () => {
+    docs.set("users/t1", { uid: "t1", role: "admin" });
+    docs.set("users/otro-admin", { uid: "otro-admin", role: "admin" });
+    const res = buildRes();
+    await handler.decideRequest(
+      buildReq({
+        role: "admin",
+        uid: "rev",
+        params: { uid: "t1" },
+        body: { approve: true, note: "Baja a voluntario" },
+      }),
+      res
+    );
+    expect(res.__body?.success).toBe(true);
+    expect(docs.get("users/t1")).toMatchObject({ role: "volunteer" });
+  });
+
+  // Un admin suspendido no gobierna nada, así que no cuenta para el guard.
+  it("no cuenta a un admin suspendido como admin activo", async () => {
+    docs.set("users/t1", { uid: "t1", role: "admin" });
+    docs.set("users/dormido", {
+      uid: "dormido",
+      role: "admin",
+      status: "suspended",
+    });
+    const res = buildRes();
+    await handler.decideRequest(
+      buildReq({
+        role: "admin",
+        uid: "rev",
+        params: { uid: "t1" },
+        body: { approve: true, note: "Baja a voluntario" },
+      }),
+      res
+    );
+    expect(res.__status).toBe(400);
+    expect(docs.get("users/t1")).toMatchObject({ role: "admin" });
+  });
+
   it("registra el rol anterior en la auditoría", async () => {
     const res = buildRes();
     await handler.decideRequest(
@@ -589,6 +651,39 @@ describe("redeemInvitation", () => {
     expect(res.__body?.success).toBe(true);
     expect(docs.get("users/u1")).toMatchObject({ role: "contributor" });
     expect(docs.get("invitations/inv-1")).toMatchObject({ usedBy: "u1" });
+  });
+
+  // Canjear SUSTITUYE el rol de quien canjea. Sin este guard, una invitación
+  // de organizador al correo de un admin —canjeada por ese mismo admin— lo
+  // degradaba en silencio, y si era el único dejaba la plataforma sin nadie
+  // capaz de administrarla salvo entrando a mano por la consola de Firebase.
+  it("RECHAZA canjear si degradaría al último admin", async () => {
+    seedInvitation();
+    docs.set("users/u1", { uid: "u1", role: "admin" });
+    const res = buildRes();
+    await handler.redeemInvitation(
+      buildReq({ email: "invitada@example.com", body: { token: TOKEN } }),
+      res
+    );
+    expect(res.__status).toBe(400);
+    expect(res.__body?.error).toContain("administrador");
+    // La transacción abortó entera: ni rol degradado ni invitación consumida.
+    expect(docs.get("users/u1")).toMatchObject({ role: "admin" });
+    expect(docs.get("invitations/inv-1")).toMatchObject({ usedAt: null });
+    expect(auditLogEntries()).toHaveLength(0);
+  });
+
+  it("sí deja canjear a un admin si queda otro activo", async () => {
+    seedInvitation();
+    docs.set("users/u1", { uid: "u1", role: "admin" });
+    docs.set("users/otro-admin", { uid: "otro-admin", role: "admin" });
+    const res = buildRes();
+    await handler.redeemInvitation(
+      buildReq({ email: "invitada@example.com", body: { token: TOKEN } }),
+      res
+    );
+    expect(res.__body?.success).toBe(true);
+    expect(docs.get("users/u1")).toMatchObject({ role: "contributor" });
   });
 
   // El registro va DENTRO de la transacción: antes se escribía después, y una

--- a/functions/src/handlers/access.test.ts
+++ b/functions/src/handlers/access.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const docs = new Map<string, Record<string, unknown>>();
 const updates: { path: string; data: Record<string, unknown> }[] = [];
-const auditEntries: Record<string, unknown>[] = [];
 const sentInvitations: Record<string, unknown>[] = [];
 const sentDecisions: Record<string, unknown>[] = [];
 let invitationEmailFails = false;
@@ -21,6 +20,7 @@ function snapFor(path: string) {
 
 function docRef(path: string) {
   return {
+    __path: path,
     id: path.split("/").pop() as string,
     get: async () => snapFor(path),
     set: async (data: Record<string, unknown>) => {
@@ -35,6 +35,15 @@ function docRef(path: string) {
 
 function docsUnder(name: string) {
   return [...docs.entries()].filter(([path]) => path.startsWith(`${name}/`));
+}
+
+/**
+ * Entradas realmente escritas en `audit_log`. Se leen del almacén en vez de
+ * mockear `../utils/audit`: el registro del canje va dentro de la transacción,
+ * y con la utilidad mockeada no había forma de comprobarlo.
+ */
+function auditLogEntries(): Record<string, unknown>[] {
+  return docsUnder("audit_log").map(([, data]) => data);
 }
 
 function collectionRef(name: string) {
@@ -53,7 +62,9 @@ function collectionRef(name: string) {
   });
 
   return {
-    doc: (id: string) => docRef(`${name}/${id}`),
+    // Sin id para `newAuditRef()`, que deja que Firestore lo genere.
+    doc: (id?: string) =>
+      docRef(`${name}/${id ?? `gen-${docsUnder(name).length + 1}`}`),
     add: async (data: Record<string, unknown>) => {
       const id = `gen-${docsUnder(name).length + 1}`;
       docs.set(`${name}/${id}`, data);
@@ -63,24 +74,74 @@ function collectionRef(name: string) {
   };
 }
 
+type DocRef = ReturnType<typeof docRef>;
+
+/**
+ * Batch y transacción que solo aplican al confirmar.
+ *
+ * Importa para lo que se prueba aquí: canjear una invitación cambia el rol de
+ * quien canjea, y el registro de auditoría va DENTRO de la transacción. Si el
+ * mock aplicara las escrituras al vuelo no se podría distinguir eso de las dos
+ * escrituras seguidas que había antes.
+ */
+function staged() {
+  const ops: (() => void)[] = [];
+  const api = {
+    set: (ref: DocRef, data: Record<string, unknown>) => {
+      ops.push(() => docs.set(ref.__path, data));
+      return api;
+    },
+    update: (ref: DocRef, data: Record<string, unknown>) => {
+      ops.push(() => {
+        updates.push({ path: ref.__path, data });
+        docs.set(ref.__path, { ...(docs.get(ref.__path) ?? {}), ...data });
+      });
+      return api;
+    },
+    delete: (ref: DocRef) => {
+      ops.push(() => docs.delete(ref.__path));
+      return api;
+    },
+    commit: async () => {
+      ops.forEach((apply) => apply());
+      ops.length = 0;
+    },
+    __flush: () => {
+      ops.forEach((apply) => apply());
+      ops.length = 0;
+    },
+  };
+  return api;
+}
+
 vi.mock("firebase-admin", () => ({
   firestore: () => ({
     collection: (name: string) => collectionRef(name),
-    runTransaction: async (
-      fn: (tx: {
-        get: (ref: { get: () => Promise<unknown> }) => Promise<unknown>;
-        update: (
-          ref: { update: (d: Record<string, unknown>) => Promise<void> },
-          d: Record<string, unknown>
-        ) => void;
-      }) => Promise<void>
-    ) => {
-      await fn({
-        get: async (ref) => ref.get(),
-        update: (ref, d) => {
-          void ref.update(d);
-        },
-      });
+    batch: () => staged(),
+    runTransaction: async <T>(
+      fn: (
+        tx: ReturnType<typeof staged> & {
+          get: (ref: unknown) => Promise<unknown>;
+        }
+      ) => Promise<T>
+    ): Promise<T> => {
+      const tx = staged();
+      const result = await fn(
+        Object.assign(tx, {
+          get: async (ref: unknown) => {
+            // `tx.get` acepta tanto una referencia de documento como una
+            // consulta; el guard de último admin usa la segunda.
+            const target = ref as {
+              get: () => Promise<unknown>;
+            };
+            return target.get();
+          },
+        })
+      );
+      // Solo si el callback no lanzó: una transacción abortada no deja nada,
+      // que es justo lo que comprueba el test del último admin.
+      tx.__flush();
+      return result;
     },
   }),
 }));
@@ -92,12 +153,6 @@ vi.mock("firebase-admin/firestore", () => ({
 
 vi.mock("firebase-functions", () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
-}));
-
-vi.mock("../utils/audit", () => ({
-  writeAuditLog: async (entry: Record<string, unknown>) => {
-    auditEntries.push(entry);
-  },
 }));
 
 vi.mock("../services/email", () => ({
@@ -165,7 +220,6 @@ const hash = (t: string) => createHash("sha256").update(t).digest("hex");
 beforeEach(() => {
   docs.clear();
   updates.length = 0;
-  auditEntries.length = 0;
   sentInvitations.length = 0;
   sentDecisions.length = 0;
   invitationEmailFails = false;
@@ -294,8 +348,28 @@ describe("decideRequest", () => {
       status: "approved",
       reviewedBy: "rev",
     });
-    expect(auditEntries[0]).toMatchObject({ action: "access.request.approve" });
+    expect(auditLogEntries()[0]).toMatchObject({
+      action: "access.request.approve",
+    });
     expect(sentDecisions[0]).toMatchObject({ approved: true });
+  });
+
+  it("registra el rol anterior en la auditoría", async () => {
+    const res = buildRes();
+    await handler.decideRequest(
+      buildReq({
+        role: "admin",
+        uid: "rev",
+        params: { uid: "t1" },
+        body: { approve: true, note: "Apoya en el DevFest" },
+      }),
+      res
+    );
+    expect(auditLogEntries()[0]).toMatchObject({
+      action: "access.request.approve",
+      category: "access",
+      details: { grantedRole: "volunteer", previousRole: "member" },
+    });
   });
 
   it("rechaza sin tocar el rol", async () => {
@@ -515,6 +589,23 @@ describe("redeemInvitation", () => {
     expect(res.__body?.success).toBe(true);
     expect(docs.get("users/u1")).toMatchObject({ role: "contributor" });
     expect(docs.get("invitations/inv-1")).toMatchObject({ usedBy: "u1" });
+  });
+
+  // El registro va DENTRO de la transacción: antes se escribía después, y una
+  // instancia desalojada en medio dejaba el rol elevado sin rastro alguno.
+  it("audita el canje con el rol anterior", async () => {
+    seedInvitation();
+    const res = buildRes();
+    await handler.redeemInvitation(
+      buildReq({ email: "invitada@example.com", body: { token: TOKEN } }),
+      res
+    );
+    expect(auditLogEntries()[0]).toMatchObject({
+      action: "access.invitation.redeem",
+      targetType: "invitation",
+      category: "access",
+      details: { role: "contributor", previousRole: "member" },
+    });
   });
 
   // Sin esta comprobación cualquiera con el enlace reenviado se lleva el rol.

--- a/functions/src/handlers/access.ts
+++ b/functions/src/handlers/access.ts
@@ -3,7 +3,12 @@ import * as admin from "firebase-admin";
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import { FieldValue } from "firebase-admin/firestore";
 import { logger } from "firebase-functions";
-import { writeAuditLog } from "../utils/audit";
+import {
+  commitWithAuditLog,
+  mirrorToCloudLogging,
+  stageAuditLog,
+  writeAuditLog,
+} from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import {
@@ -248,6 +253,9 @@ export async function decideRequest(req: Request, res: Response) {
       ? body.role
       : requestDoc.data()?.requestedRole;
 
+    /** Rol que la persona tenía antes de aprobarle la solicitud. */
+    let currentRole: unknown = null;
+
     if (body.approve) {
       if (!isRole(granted) || !REQUESTABLE_ROLES.includes(granted)) {
         res.status(400).json({
@@ -266,17 +274,21 @@ export async function decideRequest(req: Request, res: Response) {
         return;
       }
 
-      const userRef = db.collection("users").doc(uid);
-      if (!(await userRef.get()).exists) {
+      const userDoc = await db.collection("users").doc(uid).get();
+      if (!userDoc.exists) {
         res
           .status(404)
           .json({ success: false, error: "User account not found" });
         return;
       }
-      await userRef.update({ role: granted });
+      currentRole = userDoc.data()?.role;
     }
 
-    await requestRef.update({
+    const batch = db.batch();
+    if (body.approve) {
+      batch.update(db.collection("users").doc(uid), { role: granted });
+    }
+    batch.update(requestRef, {
       status: body.approve ? "approved" : "rejected",
       reviewedBy: performer.uid,
       reviewedAt: FieldValue.serverTimestamp(),
@@ -284,14 +296,23 @@ export async function decideRequest(req: Request, res: Response) {
       grantedRole: body.approve ? granted : null,
     });
 
-    await writeAuditLog({
-      action: body.approve ? "access.request.approve" : "access.request.reject",
-      performedBy: performer.uid,
-      targetId: uid,
-      targetType: "access_request",
-      details: { grantedRole: body.approve ? granted : null, reason: note },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await commitWithAuditLog(
+      batch,
+      {
+        action: body.approve
+          ? "access.request.approve"
+          : "access.request.reject",
+        performedBy: performer.uid,
+        targetId: uid,
+        targetType: "access_request",
+        details: {
+          grantedRole: body.approve ? granted : null,
+          previousRole: currentRole ?? null,
+          reason: note,
+        },
+      },
+      req
+    );
 
     // El correo no debe tumbar la operación: la decisión ya está tomada y
     // registrada, y un fallo de Gmail no puede deshacerla.
@@ -521,27 +542,44 @@ export async function redeemInvitation(req: Request, res: Response) {
 
     // Transacción para que dos canjes simultáneos del mismo enlace no
     // aplique el rol dos veces ni deje la invitación sin marcar.
-    await db.runTransaction(async (tx) => {
+    //
+    // El registro de auditoría se confirma DENTRO de la transacción, no después:
+    // canjear una invitación cambia el rol de quien canjea, y si la instancia
+    // moría entre el commit y la escritura del registro, quedaba una elevación
+    // de permisos sin rastro alguno. Firestore exige que todas las lecturas
+    // vayan antes de todas las escrituras, de ahí el orden de abajo.
+    const stored = await db.runTransaction(async (tx) => {
       const fresh = await tx.get(match.ref);
       const freshData = fresh.data();
       if (freshData?.usedAt || freshData?.revokedAt) {
         throw new Error("ALREADY_USED");
       }
+
+      const userSnap = await tx.get(userRef);
+      const currentRole = userSnap.data()?.role;
+
       tx.update(match.ref, {
         usedAt: FieldValue.serverTimestamp(),
         usedBy: user.uid,
       });
       tx.update(userRef, { role: data.role });
+
+      return stageAuditLog(
+        tx,
+        {
+          action: "access.invitation.redeem",
+          performedBy: user.uid,
+          targetId: match.id,
+          targetType: "invitation",
+          details: { role: data.role, previousRole: currentRole ?? null },
+        },
+        req
+      );
     });
 
-    await writeAuditLog({
-      action: "access.invitation.redeem",
-      performedBy: user.uid,
-      targetId: match.id,
-      targetType: "invitation",
-      details: { role: data.role },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    // Fuera de la transacción a propósito: el callback se puede reintentar, y
+    // espejar dentro dejaría una línea por intento.
+    mirrorToCloudLogging(stored, req);
 
     res.json({ success: true, data: { role: data.role } });
   } catch (err) {

--- a/functions/src/handlers/access.ts
+++ b/functions/src/handlers/access.ts
@@ -18,6 +18,12 @@ import {
   type Role,
 } from "../auth/permissions";
 import {
+  actorDominates,
+  activeAdminsQuery,
+  countActiveAdmins,
+  countActiveAdminsIn,
+} from "../auth/guards";
+import {
   sendAccessDecisionEmail,
   sendInvitationEmail,
 } from "../services/email";
@@ -281,7 +287,30 @@ export async function decideRequest(req: Request, res: Response) {
           .json({ success: false, error: "User account not found" });
         return;
       }
+
+      // Aprobar una solicitud SUSTITUYE el rol que la persona ya tenía, así
+      // que pasa por las mismas guardas que un cambio de rol en el panel. Sin
+      // esto, aprobar una solicitud vieja de quien entretanto llegó a admin lo
+      // degradaba sin más, y si era el último dejaba la plataforma sin nadie
+      // capaz de administrarla.
       currentRole = userDoc.data()?.role;
+      if (!actorDominates(performer.permissions, currentRole)) {
+        res.status(403).json({
+          success: false,
+          error: "Cannot manage a user whose role exceeds your own permissions",
+        });
+        return;
+      }
+
+      if (currentRole === "admin" && granted !== "admin") {
+        if ((await countActiveAdmins()) <= 1) {
+          res.status(400).json({
+            success: false,
+            error: "Cannot demote the last active admin",
+          });
+          return;
+        }
+      }
     }
 
     const batch = db.batch();
@@ -555,8 +584,18 @@ export async function redeemInvitation(req: Request, res: Response) {
         throw new Error("ALREADY_USED");
       }
 
+      // El rol actual se lee aquí y no fuera: canjear SUSTITUYE el rol, y una
+      // invitación de organizador al correo de un admin lo degradaba en
+      // silencio. La cuenta de admins también va dentro, porque una lectura
+      // suelta no entra en la transacción y dos canjes a la vez podrían pasar
+      // los dos la comprobación y dejar la plataforma con cero admins.
       const userSnap = await tx.get(userRef);
       const currentRole = userSnap.data()?.role;
+      if (currentRole === "admin" && data.role !== "admin") {
+        if (countActiveAdminsIn(await tx.get(activeAdminsQuery())) <= 1) {
+          throw new Error("LAST_ADMIN");
+        }
+      }
 
       tx.update(match.ref, {
         usedAt: FieldValue.serverTimestamp(),
@@ -587,6 +626,19 @@ export async function redeemInvitation(req: Request, res: Response) {
       res.status(400).json({
         success: false,
         error: "Invitation is invalid, expired or already used",
+      });
+      return;
+    }
+    // Este SÍ dice qué pasó, al contrario que el mensaje opaco de arriba. Ese
+    // es opaco para no convertir el endpoint en un oráculo de invitaciones
+    // ajenas; aquí no hay nada que filtrar —quien canjea es el último admin y
+    // ya lo sabe— y un error genérico le haría pensar que el enlace está roto.
+    if (err instanceof Error && err.message === "LAST_ADMIN") {
+      res.status(400).json({
+        success: false,
+        error:
+          "Canjear esta invitación te quitaría el rol de administrador y no " +
+          "queda ningún otro activo. Pide que asciendan a otra persona antes.",
       });
       return;
     }

--- a/functions/src/handlers/eventStaff.test.ts
+++ b/functions/src/handlers/eventStaff.test.ts
@@ -3,10 +3,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const docs = new Map<string, Record<string, unknown>>();
 const deleted: string[] = [];
-const auditEntries: Record<string, unknown>[] = [];
+
+/**
+ * Entradas realmente escritas en `audit_log`. Se leen del almacén en vez de
+ * mockear `../utils/audit` para que el test compruebe que la asignación de
+ * staff y su registro se confirman en el mismo batch: asignar staff concede
+ * permisos dentro del evento, así que una asignación sin rastro es el mismo
+ * problema que un cambio de rol sin rastro.
+ */
+function auditLogEntries(): Record<string, unknown>[] {
+  return [...docs.entries()]
+    .filter(([path]) => path.startsWith("audit_log/"))
+    .map(([, data]) => data);
+}
+
+let generatedIds = 0;
 
 function docRef(path: string) {
   return {
+    __path: path,
     id: path.split("/").pop() as string,
     get: async () => {
       const data = docs.get(path);
@@ -23,9 +38,40 @@ function docRef(path: string) {
   };
 }
 
+type DocRef = ReturnType<typeof docRef>;
+
+/** Nada toca el almacén hasta `commit()`: eso es lo que se está probando. */
+function batchMock() {
+  const staged: (() => void)[] = [];
+  const api = {
+    set: (ref: DocRef, data: Record<string, unknown>) => {
+      staged.push(() => docs.set(ref.__path, data));
+      return api;
+    },
+    update: (ref: DocRef, data: Record<string, unknown>) => {
+      staged.push(() =>
+        docs.set(ref.__path, { ...(docs.get(ref.__path) ?? {}), ...data })
+      );
+      return api;
+    },
+    delete: (ref: DocRef) => {
+      staged.push(() => {
+        deleted.push(ref.__path);
+        docs.delete(ref.__path);
+      });
+      return api;
+    },
+    commit: async () => {
+      staged.forEach((apply) => apply());
+      staged.length = 0;
+    },
+  };
+  return api;
+}
+
 function collectionRef(name: string) {
   return {
-    doc: (id: string) => docRef(`${name}/${id}`),
+    doc: (id?: string) => docRef(`${name}/${id ?? `gen-${++generatedIds}`}`),
     get: async () => ({
       docs: [...docs.entries()]
         .filter(([path]) => path.startsWith(`${name}/`))
@@ -40,6 +86,7 @@ function collectionRef(name: string) {
 vi.mock("firebase-admin", () => ({
   firestore: () => ({
     collection: (name: string) => collectionRef(name),
+    batch: () => batchMock(),
     collectionGroup: (name: string) => ({
       where: (field: string, _op: string, value: unknown) => ({
         get: async () => ({
@@ -65,10 +112,8 @@ vi.mock("firebase-admin/firestore", () => ({
   Timestamp: class {},
 }));
 
-vi.mock("../utils/audit", () => ({
-  writeAuditLog: async (entry: Record<string, unknown>) => {
-    auditEntries.push(entry);
-  },
+vi.mock("firebase-functions", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
 import * as handler from "./eventStaff";
@@ -109,7 +154,6 @@ const SLUG = "devfest-2026";
 beforeEach(() => {
   docs.clear();
   deleted.length = 0;
-  auditEntries.length = 0;
 });
 
 describe("assignStaff", () => {
@@ -127,7 +171,7 @@ describe("assignStaff", () => {
       assignedBy: "adm",
       reason: "Puerta del DevFest",
     });
-    expect(auditEntries[0]).toMatchObject({
+    expect(auditLogEntries()[0]).toMatchObject({
       action: "event.staff.assign",
       details: { eventSlug: SLUG },
     });
@@ -204,7 +248,9 @@ describe("removeStaff", () => {
     await handler.removeStaff(buildReq({ slug: SLUG, uid: "vol" }), res);
     expect(res.__body?.success).toBe(true);
     expect(deleted).toContain(`events/${SLUG}/staff/vol`);
-    expect(auditEntries[0]).toMatchObject({ action: "event.staff.remove" });
+    expect(auditLogEntries()[0]).toMatchObject({
+      action: "event.staff.remove",
+    });
   });
 
   it("404 si no hay asignación", async () => {

--- a/functions/src/handlers/eventStaff.ts
+++ b/functions/src/handlers/eventStaff.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
-import { writeAuditLog } from "../utils/audit";
+import { commitWithAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import {
@@ -96,7 +96,11 @@ export async function assignStaff(req: Request, res: Response) {
       expiresAt = parsed;
     }
 
-    await db.collection("events").doc(slug).collection("staff").doc(uid).set({
+    // Asignar staff concede permisos dentro del evento, así que se registra con
+    // la misma atomicidad que un cambio de rol: o queda la asignación con su
+    // constancia, o no queda ninguna de las dos.
+    const batch = db.batch();
+    batch.set(db.collection("events").doc(slug).collection("staff").doc(uid), {
       uid,
       role: targetRole,
       assignedBy: performer.uid,
@@ -104,20 +108,22 @@ export async function assignStaff(req: Request, res: Response) {
       expiresAt,
       reason,
     });
-
-    await writeAuditLog({
-      action: "event.staff.assign",
-      performedBy: performer.uid,
-      targetId: uid,
-      targetType: "event_staff",
-      details: {
-        eventSlug: slug,
-        role: targetRole,
-        expiresAt: expiresAt ? expiresAt.toISOString() : null,
-        reason,
+    await commitWithAuditLog(
+      batch,
+      {
+        action: "event.staff.assign",
+        performedBy: performer.uid,
+        targetId: uid,
+        targetType: "event_staff",
+        details: {
+          eventSlug: slug,
+          role: targetRole,
+          expiresAt: expiresAt ? expiresAt.toISOString() : null,
+          reason,
+        },
       },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+      req
+    );
 
     res.status(201).json({ success: true, data: { uid, eventSlug: slug } });
   } catch (err) {
@@ -143,16 +149,19 @@ export async function removeStaff(req: Request, res: Response) {
       return;
     }
 
-    await ref.delete();
-
-    await writeAuditLog({
-      action: "event.staff.remove",
-      performedBy: performer.uid,
-      targetId: uid,
-      targetType: "event_staff",
-      details: { eventSlug: slug },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    const batch = admin.firestore().batch();
+    batch.delete(ref);
+    await commitWithAuditLog(
+      batch,
+      {
+        action: "event.staff.remove",
+        performedBy: performer.uid,
+        targetId: uid,
+        targetType: "event_staff",
+        details: { eventSlug: slug },
+      },
+      req
+    );
 
     res.json({ success: true });
   } catch (err) {

--- a/functions/src/handlers/events.ts
+++ b/functions/src/handlers/events.ts
@@ -107,7 +107,10 @@ export async function createEvent(req: Request, res: Response) {
 
 export async function updateEvent(req: Request, res: Response) {
   try {
-    const eventId = req.params.id;
+    // `as string` como en el resto de handlers: express 5 tipa los params como
+    // `string | string[]`, y validateParamId ya rechazó cualquier cosa que no
+    // encaje en SAFE_ID_PATTERN antes de llegar aquí.
+    const eventId = req.params.id as string;
     const event = { ...req.body, id: eventId };
 
     if (!validateEventUrls(event, res)) return;
@@ -160,7 +163,7 @@ export async function updateEvent(req: Request, res: Response) {
 
 export async function deleteEvent(req: Request, res: Response) {
   try {
-    const eventId = req.params.id;
+    const eventId = req.params.id as string;
     const github = new GitHubService(GITHUB_TOKEN.value());
     const user = (req as AuthenticatedRequest).user;
 

--- a/functions/src/handlers/users.test.ts
+++ b/functions/src/handlers/users.test.ts
@@ -6,10 +6,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // falta para ejercitar la protección del último admin.
 const docs = new Map<string, Record<string, unknown>>();
 const updates: { path: string; data: Record<string, unknown> }[] = [];
-const auditEntries: Record<string, unknown>[] = [];
+
+/**
+ * Entradas de auditoría realmente escritas en `audit_log`.
+ *
+ * Antes se recogían mockeando `../utils/audit`, lo que hacía imposible
+ * comprobar lo único que de verdad importa aquí: que el registro y la mutación
+ * se confirman en el MISMO batch. Con el escritor real corriendo contra este
+ * almacén, un batch que no llegue a `commit()` no deja ni mutación ni entrada,
+ * que es exactamente la garantía que se quiere.
+ */
+function auditLogEntries(): Record<string, unknown>[] {
+  return [...docs.entries()]
+    .filter(([path]) => path.startsWith("audit_log/"))
+    .map(([, data]) => data);
+}
+
+let generatedIds = 0;
 
 function docRef(path: string) {
   return {
+    __path: path,
+    id: path.split("/").pop() as string,
     get: async () => {
       const data = docs.get(path);
       return { exists: data !== undefined, data: () => data };
@@ -21,9 +39,43 @@ function docRef(path: string) {
   };
 }
 
+type DocRef = ReturnType<typeof docRef>;
+
+/**
+ * Batch que solo aplica sus operaciones al confirmar. Que nada toque el
+ * almacén antes de `commit()` es la mitad del test: es lo que distingue un
+ * batch de dos escrituras seguidas.
+ */
+function batchMock() {
+  const staged: (() => void)[] = [];
+  const api = {
+    update: (ref: DocRef, data: Record<string, unknown>) => {
+      staged.push(() => {
+        updates.push({ path: ref.__path, data });
+        docs.set(ref.__path, { ...(docs.get(ref.__path) ?? {}), ...data });
+      });
+      return api;
+    },
+    set: (ref: DocRef, data: Record<string, unknown>) => {
+      staged.push(() => docs.set(ref.__path, data));
+      return api;
+    },
+    delete: (ref: DocRef) => {
+      staged.push(() => docs.delete(ref.__path));
+      return api;
+    },
+    commit: async () => {
+      staged.forEach((apply) => apply());
+      staged.length = 0;
+    },
+  };
+  return api;
+}
+
 function collectionRef(name: string) {
   return {
-    doc: (id: string) => docRef(`${name}/${id}`),
+    // Sin id para `newAuditRef()`, que deja que Firestore lo genere.
+    doc: (id?: string) => docRef(`${name}/${id ?? `gen-${++generatedIds}`}`),
     where: (field: string, _op: string, value: unknown) => ({
       get: async () => ({
         docs: [...docs.entries()]
@@ -43,7 +95,10 @@ function collectionRef(name: string) {
 }
 
 vi.mock("firebase-admin", () => ({
-  firestore: () => ({ collection: (name: string) => collectionRef(name) }),
+  firestore: () => ({
+    collection: (name: string) => collectionRef(name),
+    batch: () => batchMock(),
+  }),
 }));
 
 vi.mock("firebase-admin/firestore", () => ({
@@ -51,10 +106,8 @@ vi.mock("firebase-admin/firestore", () => ({
   Timestamp: class {},
 }));
 
-vi.mock("../utils/audit", () => ({
-  writeAuditLog: async (entry: Record<string, unknown>) => {
-    auditEntries.push(entry);
-  },
+vi.mock("firebase-functions", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
 import * as handler from "./users";
@@ -110,7 +163,6 @@ function seed(uid: string, data: Record<string, unknown>) {
 beforeEach(() => {
   docs.clear();
   updates.length = 0;
-  auditEntries.length = 0;
 });
 
 describe("updateRole — validación", () => {
@@ -179,7 +231,7 @@ describe("updateRole — validación", () => {
     expect(updates).toEqual([
       { path: "users/t1", data: { role: "organizer" } },
     ]);
-    expect(auditEntries[0]).toMatchObject({
+    expect(auditLogEntries()[0]).toMatchObject({
       action: "user.role.change",
       performedBy: "actor-1",
       targetId: "t1",
@@ -288,7 +340,7 @@ describe("updateStatus", () => {
     expect(updates).toEqual([
       { path: "users/t1", data: { status: "suspended" } },
     ]);
-    expect(auditEntries[0]).toMatchObject({
+    expect(auditLogEntries()[0]).toMatchObject({
       action: "user.status.change",
       details: { newStatus: "suspended", reason: "Baja temporal" },
     });

--- a/functions/src/handlers/users.ts
+++ b/functions/src/handlers/users.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
-import { FieldValue } from "firebase-admin/firestore";
-import { writeAuditLog } from "../utils/audit";
+import { commitWithAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import {
@@ -53,11 +52,11 @@ async function countActiveAdmins(): Promise<number> {
  * no tener sus permisos, que es escalada por la puerta de atrás.
  */
 function actorDominates(
-  actor: AuthenticatedRequest["user"],
+  actorPermissions: ReadonlySet<Permission>,
   role: unknown
 ): boolean {
   if (!isRole(role)) return true; // rol corrupto: no hay nada que dominar
-  return canAssignRole(actor.permissions, role);
+  return canAssignRole(actorPermissions, role);
 }
 
 export async function listUsers(_req: Request, res: Response) {
@@ -118,8 +117,8 @@ export async function updateRole(req: Request, res: Response) {
     // No escalada: nadie reparte lo que no tiene, ni en el rol que asigna ni
     // en el que retira.
     if (
-      !actorDominates(performer, role) ||
-      !actorDominates(performer, previousRole)
+      !actorDominates(performer.permissions, role) ||
+      !actorDominates(performer.permissions, previousRole)
     ) {
       res.status(403).json({
         success: false,
@@ -139,16 +138,24 @@ export async function updateRole(req: Request, res: Response) {
       }
     }
 
-    await userRef.update({ role });
-
-    await writeAuditLog({
-      action: "user.role.change",
-      performedBy: performer.uid,
-      targetId: uid,
-      targetType: "user",
-      details: { newRole: role, previousRole, reason },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    // El cambio de rol y su registro se confirman juntos. Antes iban en dos
+    // escrituras seguidas, y como `writeAuditLog` se traga sus errores, una
+    // instancia desalojada entre las dos —algo que Cloud Functions hace de
+    // rutina— dejaba a alguien con permisos nuevos y sin una sola línea que lo
+    // dijera.
+    const batch = admin.firestore().batch();
+    batch.update(userRef, { role });
+    await commitWithAuditLog(
+      batch,
+      {
+        action: "user.role.change",
+        performedBy: performer.uid,
+        targetId: uid,
+        targetType: "user",
+        details: { newRole: role, previousRole, reason },
+      },
+      req
+    );
 
     res.json({ success: true, data: { uid, role } });
   } catch (err) {
@@ -203,7 +210,7 @@ export async function updateStatus(req: Request, res: Response) {
     }
 
     const targetRole = userDoc.data()?.role;
-    if (!actorDominates(performer, targetRole)) {
+    if (!actorDominates(performer.permissions, targetRole)) {
       res.status(403).json({
         success: false,
         error: "Cannot manage a user whose role exceeds your own permissions",
@@ -221,20 +228,23 @@ export async function updateStatus(req: Request, res: Response) {
       }
     }
 
-    await userRef.update({ status });
-
-    await writeAuditLog({
-      action: "user.status.change",
-      performedBy: performer.uid,
-      targetId: uid,
-      targetType: "user",
-      details: {
-        newStatus: status,
-        previousStatus: userDoc.data()?.status ?? "active",
-        reason,
+    const batch = admin.firestore().batch();
+    batch.update(userRef, { status });
+    await commitWithAuditLog(
+      batch,
+      {
+        action: "user.status.change",
+        performedBy: performer.uid,
+        targetId: uid,
+        targetType: "user",
+        details: {
+          newStatus: status,
+          previousStatus: userDoc.data()?.status ?? "active",
+          reason,
+        },
       },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+      req
+    );
 
     res.json({ success: true, data: { uid, status } });
   } catch (err) {
@@ -363,7 +373,7 @@ export async function updateGrants(req: Request, res: Response) {
       return;
     }
 
-    if (!actorDominates(performer, userDoc.data()?.role)) {
+    if (!actorDominates(performer.permissions, userDoc.data()?.role)) {
       res.status(403).json({
         success: false,
         error: "Cannot manage a user whose role exceeds your own permissions",
@@ -371,24 +381,27 @@ export async function updateGrants(req: Request, res: Response) {
       return;
     }
 
-    await userRef.update({ grants, revocations });
-
-    await writeAuditLog({
-      action: "user.grants.change",
-      performedBy: performer.uid,
-      targetId: uid,
-      targetType: "user",
-      details: {
-        grants: grants.map((g) => ({
-          permission: g.permission,
-          scope: g.scope,
-          expiresAt: g.expiresAt ? (g.expiresAt as Date).toISOString() : null,
-        })),
-        revocations,
-        reason,
+    const batch = admin.firestore().batch();
+    batch.update(userRef, { grants, revocations });
+    await commitWithAuditLog(
+      batch,
+      {
+        action: "user.grants.change",
+        performedBy: performer.uid,
+        targetId: uid,
+        targetType: "user",
+        details: {
+          grants: grants.map((g) => ({
+            permission: g.permission,
+            scope: g.scope,
+            expiresAt: g.expiresAt ? (g.expiresAt as Date).toISOString() : null,
+          })),
+          revocations,
+          reason,
+        },
       },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+      req
+    );
 
     res.json({ success: true, data: { uid, grants, revocations } });
   } catch (err) {

--- a/functions/src/handlers/users.ts
+++ b/functions/src/handlers/users.ts
@@ -6,7 +6,6 @@ import { safeError } from "../middleware/validate";
 import {
   GLOBAL_SCOPE,
   ROLES,
-  canAssignRole,
   canGrant,
   isPermission,
   isRole,
@@ -14,6 +13,7 @@ import {
   type PermissionGrant,
   type Role,
 } from "../auth/permissions";
+import { actorDominates, countActiveAdmins } from "../auth/guards";
 
 const MAX_REASON = 500;
 const MAX_GRANTS = 50;
@@ -29,34 +29,6 @@ function readReason(body: unknown): string | null {
   const trimmed = reason.trim();
   if (trimmed.length === 0 || trimmed.length > MAX_REASON) return null;
   return trimmed;
-}
-
-/**
- * Cuenta los admins que realmente pueden operar. Se usa para no dejar la
- * plataforma sin nadie capaz de administrarla: un descuido ahí obliga a
- * entrar por la consola de Firebase a reparar el desastre a mano.
- */
-async function countActiveAdmins(): Promise<number> {
-  const snapshot = await admin
-    .firestore()
-    .collection("users")
-    .where("role", "==", "admin")
-    .get();
-  return snapshot.docs.filter((d) => d.data()?.status !== "suspended").length;
-}
-
-/**
- * El actor debe poseer todos los permisos del rol que toca — tanto el que
- * quita como el que pone. Sin la comprobación sobre el rol ACTUAL, alguien
- * con `users:role:write` concedido a mano podría degradar a un admin pese a
- * no tener sus permisos, que es escalada por la puerta de atrás.
- */
-function actorDominates(
-  actorPermissions: ReadonlySet<Permission>,
-  role: unknown
-): boolean {
-  if (!isRole(role)) return true; // rol corrupto: no hay nada que dominar
-  return canAssignRole(actorPermissions, role);
 }
 
 export async function listUsers(_req: Request, res: Response) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,7 +7,7 @@ import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { GITHUB_TOKEN, GMAIL_USER, GMAIL_APP_PASSWORD } from "./config";
 import { requirePermission, requireAuth } from "./middleware/auth";
 import { isAllowedOrigin, rejectDisallowedOrigin } from "./middleware/cors";
-import { validateParamId } from "./middleware/validate";
+import { safeError, validateParamId } from "./middleware/validate";
 import { verifyAppCheck } from "./middleware/appCheck";
 import { validateBody } from "./middleware/validateBody";
 import {
@@ -843,12 +843,48 @@ app.post(
   triggerRebuild
 );
 
+// Manejador de errores global. Va DESPUÉS de todas las rutas: express lo
+// distingue por tener cuatro parámetros, y solo recibe lo que ningún handler
+// capturó.
+//
+// Cada handler envuelve su cuerpo en try/catch y devuelve `safeError`, así que
+// esto no debería dispararse nunca. Existe porque hasta ahora un throw FUERA
+// de ese try —en `validateBody`, en un middleware, en un `JSON.parse` de un
+// cuerpo malformado— caía en el manejador por defecto de express, que responde
+// con el stack trace en texto plano. Eso filtra rutas del repo y estructura
+// interna a quien mande basura a propósito, y no deja constancia de nada.
+app.use(
+  (
+    err: unknown,
+    req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction
+  ) => {
+    logger.error("Unhandled error", {
+      requestId: req.auditContext?.requestId,
+      method: req.method,
+      path: req.path,
+      err,
+    });
+    if (res.headersSent) return;
+    res.status(500).json({ success: false, error: safeError(err) });
+  }
+);
+
 export const api = onRequest(
   {
     secrets: [GITHUB_TOKEN, GMAIL_USER, GMAIL_APP_PASSWORD],
     invoker: "public",
     timeoutSeconds: 300,
     memory: "512MiB",
+    // Techo de instancias concurrentes. Gen2 usa 100 por defecto, y sin límite
+    // tres cosas escalan a la vez sin freno: el coste de un ataque, las
+    // escrituras de auditoría que ese ataque genera, y la deriva de los seis
+    // rate limiters —que guardan su contador en memoria, así que cada
+    // instancia nueva estrena presupuesto y el límite real es
+    // `instancias × cupo`. Diez instancias sirven de sobra el tráfico de un
+    // DevFest y acotan las tres cosas de una vez.
+    maxInstances: 10,
   },
   app
 );

--- a/functions/src/types/express.d.ts
+++ b/functions/src/types/express.d.ts
@@ -1,0 +1,29 @@
+import type { AuditContext } from "../utils/auditTypes";
+
+/**
+ * Aumenta `express.Request` en vez de castear.
+ *
+ * El resto del código usa el cast `(req as AuthenticatedRequest).user`, y para
+ * `user` está bien: solo lo leen handlers que corren detrás del middleware que
+ * lo pone. Estos dos campos son distintos — los tiene que leer y escribir
+ * middleware que no sabe nada de autenticación (el que captura el contexto, el
+ * limitador de tasa, el manejador de errores), y obligar a cada uno a inventar
+ * su propio cast a una interfaz distinta es cómo se acaba con cuatro
+ * definiciones del mismo campo que nadie mantiene sincronizadas.
+ */
+declare global {
+  namespace Express {
+    interface Request {
+      /** Lo pone `auditContext()`; puede faltar si el middleware no corrió. */
+      auditContext?: AuditContext;
+      /**
+       * `true` en cuanto un handler escribe su propia entrada de auditoría.
+       * La red de seguridad automática lo consulta para no duplicar: sin esta
+       * marca, cada mutación bien auditada generaría además una fila
+       * sintética, y el registro tendría el doble de filas y la mitad de
+       * credibilidad.
+       */
+      auditClaimed?: boolean;
+    }
+  }
+}

--- a/functions/src/utils/audit.test.ts
+++ b/functions/src/utils/audit.test.ts
@@ -1,0 +1,351 @@
+import type { Request } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Orden en que ocurrieron las cosas. Importa: el espejo a Cloud Logging tiene
+ * que emitirse ANTES de escribir en Firestore en el camino no atómico, y
+ * DESPUÉS del commit en el atómico, y las dos cosas son afirmaciones sobre
+ * secuencia, no sobre contenido.
+ */
+const timeline: string[] = [];
+const written: { path: string; data: Record<string, unknown> }[] = [];
+let addFails = false;
+let generatedIds = 0;
+
+function docRef(path: string) {
+  return { __path: path, id: path.split("/").pop() as string };
+}
+
+function batchMock() {
+  const ops: (() => void)[] = [];
+  const api = {
+    set: (ref: { __path: string }, data: Record<string, unknown>) => {
+      ops.push(() => {
+        timeline.push(`set:${ref.__path}`);
+        written.push({ path: ref.__path, data });
+      });
+      return api;
+    },
+    commit: async () => {
+      timeline.push("commit");
+      ops.forEach((apply) => apply());
+      ops.length = 0;
+    },
+  };
+  return api;
+}
+
+vi.mock("firebase-admin", () => ({
+  firestore: () => ({
+    collection: (name: string) => ({
+      doc: (id?: string) => docRef(`${name}/${id ?? `gen-${++generatedIds}`}`),
+      add: async (data: Record<string, unknown>) => {
+        timeline.push("firestore.add");
+        if (addFails) throw new Error("firestore down");
+        const id = `gen-${++generatedIds}`;
+        written.push({ path: `${name}/${id}`, data });
+        return { id };
+      },
+    }),
+    batch: () => batchMock(),
+  }),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: () => "__TS__" },
+}));
+
+// `vi.hoisted` porque `vi.mock` se iza al principio del archivo: un `const`
+// normal aquí todavía no estaría inicializado cuando corre la factoría.
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("firebase-functions", () => ({ logger: loggerMock }));
+
+import {
+  buildAuditEntry,
+  commitWithAuditLog,
+  stageAuditLog,
+  writeAuditLog,
+} from "./audit";
+
+/** Un `req` como el que dejan `requirePermission` + `auditContext`. */
+function buildReq(overrides: Partial<Request> = {}): Request {
+  return {
+    ip: "181.65.42.117",
+    auditContext: {
+      requestId: "req-1",
+      method: "PATCH",
+      route: "/api/users/:uid/role",
+      ipPrefix: "181.65.42.0/24",
+      userAgent: "Mozilla/5.0",
+    },
+    user: {
+      uid: "actor-1",
+      email: "actor@example.com",
+      role: "admin",
+      scope: "*",
+    },
+    ...overrides,
+  } as unknown as Request;
+}
+
+beforeEach(() => {
+  timeline.length = 0;
+  written.length = 0;
+  addFails = false;
+  generatedIds = 0;
+  // Las implementaciones se reinstalan aquí, no en la factoría izada, porque
+  // esta necesita cerrar sobre `timeline` y la factoría corre antes de que
+  // exista.
+  loggerMock.info
+    .mockReset()
+    .mockImplementation(() => timeline.push("log.info"));
+  loggerMock.warn
+    .mockReset()
+    .mockImplementation(() => timeline.push("log.warn"));
+  loggerMock.error
+    .mockReset()
+    .mockImplementation(() => timeline.push("log.error"));
+});
+
+describe("buildAuditEntry — valores derivados", () => {
+  it("sella la marca de tiempo cuando falta", () => {
+    const entry = buildAuditEntry({ action: "event.create", performedBy: "u" });
+    expect(entry.timestamp).toBe("__TS__");
+  });
+
+  // `minigameRoulette` comparte a propósito el mismo serverTimestamp entre la
+  // mutación y su registro, para que las dos filas lleven la misma hora.
+  it("respeta la marca de tiempo que pasa quien llama", () => {
+    const own = "__SHARED__" as unknown as never;
+    const entry = buildAuditEntry({
+      action: "minigame_instance.roulette.spin",
+      performedBy: "u",
+      timestamp: own,
+    });
+    expect(entry.timestamp).toBe("__SHARED__");
+  });
+
+  it("por defecto el resultado es success", () => {
+    expect(
+      buildAuditEntry({ action: "event.create", performedBy: "u" }).outcome
+    ).toBe("success");
+  });
+
+  it.each([
+    ["event.create", "content"],
+    ["user.role.change", "access"],
+    ["access.invitation.redeem", "access"],
+    ["credential.create", "operations"],
+    ["minigame_instance.state.live", "minigame"],
+    ["security.permission.denied", "security"],
+  ])("deduce la categoría de %s → %s", (action, category) => {
+    expect(buildAuditEntry({ action, performedBy: "u" }).category).toBe(
+      category
+    );
+  });
+
+  // Asignar staff concede permisos dentro de un evento, así que cuenta como
+  // control de acceso y no como contenido, pese a empezar por `event.`.
+  it("clasifica event.staff.* como acceso, no como contenido", () => {
+    expect(
+      buildAuditEntry({ action: "event.staff.assign", performedBy: "u" })
+        .category
+    ).toBe("access");
+  });
+
+  it("sube la severidad de los cambios de acceso por encima del contenido", () => {
+    expect(
+      buildAuditEntry({ action: "user.role.change", performedBy: "u" }).severity
+    ).toBe("notice");
+    expect(
+      buildAuditEntry({ action: "event.create", performedBy: "u" }).severity
+    ).toBe("info");
+  });
+
+  it("un fallo es warning aunque la categoría sea inocua", () => {
+    expect(
+      buildAuditEntry({
+        action: "event.create",
+        performedBy: "u",
+        outcome: "failure",
+      }).severity
+    ).toBe("warning");
+  });
+
+  it("respeta la severidad explícita", () => {
+    expect(
+      buildAuditEntry({
+        action: "security.account.suspended_access",
+        performedBy: "u",
+        severity: "critical",
+      }).severity
+    ).toBe("critical");
+  });
+
+  it("saca actor y contexto del req", () => {
+    const entry = buildAuditEntry(
+      { action: "user.role.change", performedBy: "actor-1" },
+      buildReq()
+    );
+    expect(entry.actor).toEqual({
+      uid: "actor-1",
+      email: "actor@example.com",
+      role: "admin",
+      scope: "*",
+    });
+    expect(entry.context?.requestId).toBe("req-1");
+    expect(entry.context?.ipPrefix).toBe("181.65.42.0/24");
+  });
+
+  // Firestore rechaza `undefined`, así que dejar los campos a undefined
+  // convertiría una entrada sin contexto en una escritura fallida.
+  it("omite actor y contexto en vez de dejarlos en undefined", () => {
+    const entry = buildAuditEntry({ action: "event.create", performedBy: "u" });
+    expect("actor" in entry).toBe(false);
+    expect("context" in entry).toBe(false);
+  });
+
+  // `requireAuth()` deja role en null a propósito; el registro tiene que
+  // reflejar eso y no inventarse un rol.
+  it("guarda role null cuando solo se verificó el token", () => {
+    const req = buildReq({
+      user: { uid: "anon", email: "", role: null, scope: "*" },
+    } as unknown as Partial<Request>);
+    expect(
+      buildAuditEntry({ action: "x.y", performedBy: "anon" }, req).actor
+    ).toEqual({ uid: "anon", email: null, role: null, scope: "*" });
+  });
+});
+
+describe("writeAuditLog — camino no atómico", () => {
+  it("espeja a Cloud Logging ANTES de escribir en Firestore", async () => {
+    await writeAuditLog({ action: "event.create", performedBy: "u" });
+    expect(timeline).toEqual(["log.info", "firestore.add"]);
+  });
+
+  // Es la razón de ser del espejo: si Firestore falla, la línea de Cloud
+  // Logging es el único registro que queda de lo que pasó.
+  it("el espejo sobrevive a un fallo de Firestore", async () => {
+    addFails = true;
+    await writeAuditLog({ action: "event.create", performedBy: "u" });
+    expect(loggerMock.info).toHaveBeenCalledOnce();
+    expect(loggerMock.error).toHaveBeenCalledOnce();
+  });
+
+  it("se traga el fallo por defecto", async () => {
+    addFails = true;
+    await expect(
+      writeAuditLog({ action: "event.create", performedBy: "u" })
+    ).resolves.toBeUndefined();
+  });
+
+  it("relanza el fallo con critical", async () => {
+    addFails = true;
+    await expect(
+      writeAuditLog({ action: "event.create", performedBy: "u" }, undefined, {
+        critical: true,
+      })
+    ).rejects.toThrow("firestore down");
+  });
+
+  it("usa warn para lo notable y info para el resto", async () => {
+    await writeAuditLog({ action: "event.create", performedBy: "u" });
+    expect(loggerMock.info).toHaveBeenCalledOnce();
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+
+    await writeAuditLog({
+      action: "security.permission.denied",
+      performedBy: "u",
+    });
+    expect(loggerMock.warn).toHaveBeenCalledOnce();
+  });
+
+  // La red de seguridad automática de la respuesta consulta esta marca para no
+  // duplicar. Sin ella, cada mutación bien auditada dejaría además una fila
+  // sintética.
+  it("marca la petición como auditada", async () => {
+    const req = buildReq();
+    await writeAuditLog({ action: "event.create", performedBy: "u" }, req);
+    expect(req.auditClaimed).toBe(true);
+  });
+
+  it("manda la IP completa a Cloud Logging pero solo el prefijo a Firestore", async () => {
+    await writeAuditLog(
+      { action: "user.role.change", performedBy: "actor-1" },
+      buildReq()
+    );
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "audit",
+      expect.objectContaining({ ip: "181.65.42.117" })
+    );
+    const stored = written[0].data as { context?: { ipPrefix?: string } };
+    expect(stored.context?.ipPrefix).toBe("181.65.42.0/24");
+    expect(JSON.stringify(stored)).not.toContain("181.65.42.117");
+  });
+});
+
+describe("stageAuditLog — camino atómico", () => {
+  it("deja la entrada preparada sin escribir nada todavía", () => {
+    const batch = batchMock();
+    stageAuditLog(batch, { action: "user.role.change", performedBy: "u" });
+    expect(written).toHaveLength(0);
+  });
+
+  // El callback de una transacción se puede reintentar; espejar dentro dejaría
+  // una línea por intento contando como hechas cosas que Firestore descartó.
+  it("no espeja a Cloud Logging por su cuenta", () => {
+    const batch = batchMock();
+    stageAuditLog(batch, { action: "user.role.change", performedBy: "u" });
+    expect(loggerMock.info).not.toHaveBeenCalled();
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+  });
+
+  it("devuelve la entrada ya completada", () => {
+    const stored = stageAuditLog(batchMock(), {
+      action: "user.role.change",
+      performedBy: "u",
+    });
+    expect(stored).toMatchObject({
+      category: "access",
+      outcome: "success",
+      severity: "notice",
+      timestamp: "__TS__",
+    });
+  });
+});
+
+describe("commitWithAuditLog", () => {
+  it("escribe la entrada dentro del batch y espeja tras el commit", async () => {
+    const batch = batchMock();
+    await commitWithAuditLog(batch, {
+      action: "user.role.change",
+      performedBy: "u",
+    });
+    // El `set` ocurre al confirmar, y el espejo después: nada se anuncia antes
+    // de que Firestore lo haya aceptado.
+    expect(timeline).toEqual(["commit", "set:audit_log/gen-1", "log.info"]);
+  });
+
+  it("no espeja nada si el commit falla", async () => {
+    const batch = {
+      set: () => batch,
+      commit: async () => {
+        throw new Error("batch rejected");
+      },
+    } as unknown as Parameters<typeof commitWithAuditLog>[0];
+
+    await expect(
+      commitWithAuditLog(batch, {
+        action: "user.role.change",
+        performedBy: "u",
+      })
+    ).rejects.toThrow("batch rejected");
+    // Anunciar un cambio de rol que la base rechazó es peor que no anunciarlo.
+    expect(loggerMock.info).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/utils/audit.ts
+++ b/functions/src/utils/audit.ts
@@ -1,21 +1,207 @@
+import type { Request } from "express";
 import * as admin from "firebase-admin";
+import { FieldValue } from "firebase-admin/firestore";
 import { logger } from "firebase-functions";
+import {
+  deriveCategory,
+  deriveSeverity,
+  type AuditActor,
+  type AuditEntry,
+} from "./auditTypes";
+
+/** Documento tal y como queda en Firestore: sin huecos que el visor tenga que adivinar. */
+type StoredAuditEntry = AuditEntry & {
+  timestamp: FieldValue;
+  outcome: NonNullable<AuditEntry["outcome"]>;
+  category: NonNullable<AuditEntry["category"]>;
+  severity: NonNullable<AuditEntry["severity"]>;
+};
 
 /**
- * Writes an audit log entry, awaiting the write so failures surface instead of
- * being silently dropped. The entry is stored verbatim (callers set their own
- * `timestamp`, e.g. a serverTimestamp or a transaction-local value).
+ * Referencia con id ya asignado, para poder meter la escritura del registro en
+ * la misma transacción o batch que la mutación que registra. Firestore asigna
+ * el id en el cliente, así que reservarlo antes no cuesta una llamada.
+ */
+export function newAuditRef(): admin.firestore.DocumentReference {
+  return admin.firestore().collection("audit_log").doc();
+}
+
+function readActor(req: Request | undefined): AuditActor | undefined {
+  const user = (
+    req as { user?: Partial<AuditActor> & { role?: unknown } } | undefined
+  )?.user;
+  if (!user?.uid) return undefined;
+  return {
+    uid: user.uid,
+    email: user.email || null,
+    role: typeof user.role === "string" ? user.role : null,
+    scope: user.scope || "*",
+  };
+}
+
+/**
+ * Completa una entrada: sella la marca de tiempo si falta, deduce
+ * `outcome`/`category`/`severity`, y adjunta actor y contexto de la petición
+ * si se pasó `req`.
+ *
+ * Se expone aparte de `writeAuditLog` porque los sitios de control de acceso
+ * escriben su entrada dentro de una transacción y necesitan el documento, no
+ * la escritura.
+ */
+export function buildAuditEntry(
+  entry: AuditEntry,
+  req?: Request
+): StoredAuditEntry {
+  const outcome = entry.outcome ?? "success";
+  const category = entry.category ?? deriveCategory(entry.action);
+  const actor = entry.actor ?? readActor(req);
+  const context = entry.context ?? req?.auditContext;
+
+  return {
+    ...entry,
+    timestamp: entry.timestamp ?? FieldValue.serverTimestamp(),
+    outcome,
+    category,
+    severity: entry.severity ?? deriveSeverity(category, outcome),
+    // Se omiten en vez de guardarse como `undefined`: Firestore rechaza
+    // `undefined` por defecto, así que dejarlos pasar convertiría una entrada
+    // sin contexto en una escritura fallida.
+    ...(actor ? { actor } : {}),
+    ...(context ? { context } : {}),
+  };
+}
+
+/**
+ * Copia a Cloud Logging.
+ *
+ * Es la mitad del diseño, no un extra. La colección de Firestore la puede
+ * borrar cualquiera que tenga el Admin SDK —incluido quien haya comprometido
+ * el panel—, mientras que la service account de la función no puede tocar sus
+ * propios logs. Aquí va además la IP COMPLETA: Firestore solo guarda el
+ * prefijo de red porque `audit_log` lo lee cualquiera con `audit:read`, y
+ * Cloud Logging tiene su propio control de acceso y su propia retención.
+ *
+ * Se emite antes de escribir en Firestore, para que un fallo de Firestore no
+ * se lleve por delante también el registro.
+ */
+export function mirrorToCloudLogging(
+  entry: StoredAuditEntry,
+  req?: Request
+): void {
+  const payload = {
+    action: entry.action,
+    outcome: entry.outcome,
+    category: entry.category,
+    severity: entry.severity,
+    performedBy: entry.performedBy,
+    targetType: entry.targetType,
+    targetId: entry.targetId,
+    requestId: entry.context?.requestId,
+    route: entry.context?.route,
+    ip: req?.ip ?? null,
+    actorRole: entry.actor?.role,
+    synthesized: entry.synthesized === true,
+  };
+
+  if (entry.severity === "critical" || entry.severity === "warning") {
+    logger.warn("audit", payload);
+  } else {
+    logger.info("audit", payload);
+  }
+}
+
+/**
+ * Lo mínimo que hace falta para dejar preparada la escritura: lo cumplen tanto
+ * `WriteBatch` como `Transaction`, y así el mismo helper sirve para los dos.
+ */
+type AuditStager = {
+  set(ref: admin.firestore.DocumentReference, data: StoredAuditEntry): unknown;
+};
+
+/**
+ * Deja la entrada preparada en un batch o una transacción, para que se confirme
+ * junto con la mutación que registra.
+ *
+ * Devuelve la entrada construida en vez de espejarla a Cloud Logging aquí: el
+ * callback de una transacción se puede REINTENTAR, y espejar dentro dejaría una
+ * línea por intento contando como hechos cosas que Firestore acabó
+ * descartando. Quien llama espeja una sola vez cuando el commit ya salió bien.
+ */
+export function stageAuditLog(
+  stager: AuditStager,
+  entry: AuditEntry,
+  req?: Request
+): StoredAuditEntry {
+  const stored = buildAuditEntry(entry, req);
+  stager.set(newAuditRef(), stored);
+  if (req) req.auditClaimed = true;
+  return stored;
+}
+
+/**
+ * Confirma un batch que ya lleva dentro su propia entrada de auditoría y
+ * espeja a Cloud Logging solo si el commit salió bien.
+ *
+ * Aquí el espejo va DESPUÉS, al contrario que en `writeAuditLog`. La diferencia
+ * es a qué se parece un fallo en cada caso: en el camino no atómico el registro
+ * es lo único que hay y conviene emitirlo aunque Firestore falle; aquí el
+ * registro y la mutación caen juntos, así que anunciar un cambio de rol que la
+ * base rechazó sería peor que no anunciar nada.
+ */
+export async function commitWithAuditLog(
+  batch: admin.firestore.WriteBatch,
+  entry: AuditEntry,
+  req?: Request
+): Promise<void> {
+  const stored = stageAuditLog(batch, entry, req);
+  await batch.commit();
+  mirrorToCloudLogging(stored, req);
+}
+
+export interface WriteAuditLogOptions {
+  /**
+   * Relanza el error en vez de tragárselo. Para cuando quien llama puede hacer
+   * algo con el fallo — devolver un 500 y no fingir que la operación quedó
+   * registrada.
+   */
+  critical?: boolean;
+}
+
+/**
+ * Escribe una entrada de auditoría.
+ *
+ * Pasar `req` es lo que añade contexto (id de petición, ruta, prefijo de IP) y
+ * marca la petición como auditada, para que la red de seguridad no genere
+ * además una fila sintética. Es opcional porque el tipo tenía que aceptar tal
+ * cual los call sites que ya existían.
+ *
+ * OJO con lo que esta función NO garantiza: si Firestore falla, se registra el
+ * error y la operación que se estaba auditando sigue adelante como si nada.
+ * Para un cambio de rol eso no vale —una elevación de permisos sin rastro es
+ * exactamente el caso que la auditoría existe para cubrir—, y por eso esos
+ * sitios no usan esta función: construyen la entrada con `buildAuditEntry` y la
+ * confirman en la misma transacción que la mutación, de modo que o quedan las
+ * dos o no queda ninguna.
  */
 export async function writeAuditLog(
-  entry: Record<string, unknown>
+  entry: AuditEntry,
+  req?: Request,
+  opts?: WriteAuditLogOptions
 ): Promise<void> {
+  const stored = buildAuditEntry(entry, req);
+
+  if (req) req.auditClaimed = true;
+  mirrorToCloudLogging(stored, req);
+
   try {
-    await admin.firestore().collection("audit_log").add(entry);
+    await admin.firestore().collection("audit_log").add(stored);
   } catch (err) {
     logger.error("Failed to write audit log", {
       action: entry.action,
+      requestId: stored.context?.requestId,
       err,
     });
+    if (opts?.critical) throw err;
   }
 }
 

--- a/functions/src/utils/auditTypes.ts
+++ b/functions/src/utils/auditTypes.ts
@@ -1,0 +1,180 @@
+import type { FieldValue } from "firebase-admin/firestore";
+
+/**
+ * Forma del registro de auditoría.
+ *
+ * Todo lo que se añadió al ampliar la auditoría es OPCIONAL a propósito: hace
+ * que el tipo sea un superconjunto estricto de lo que ya escribían los call
+ * sites que existían, así que ninguno tuvo que cambiar para que esto
+ * compilara. La alternativa —exigir los campos nuevos de golpe— habría
+ * obligado a tocar cincuenta y dos sitios y sus tests en el mismo commit que
+ * cambia la integridad del registro, que es justo el commit que uno quiere
+ * poder revisar línea a línea.
+ */
+
+/**
+ * Si la acción se llevó a cabo, se rechazó por permisos, o falló por un error.
+ * Sin esto el registro solo contaba lo que salió bien, y un log que únicamente
+ * guarda los éxitos no sirve para investigar un abuso: lo que delata a quien
+ * está probando puertas es la ráfaga de intentos denegados.
+ */
+export type AuditOutcome = "success" | "denied" | "failure";
+
+/** Alineado con los niveles de Cloud Logging, para que el espejo sea directo. */
+export type AuditSeverity = "info" | "notice" | "warning" | "critical";
+
+/**
+ * Agrupación de primer nivel. Existe porque Firestore no sabe filtrar por
+ * prefijo de cadena: sin un campo propio, "enséñame solo lo de seguridad" no
+ * se puede consultar, y el visor solo admite un filtro a la vez porque cada
+ * uno cuesta un índice compuesto.
+ */
+export type AuditCategory =
+  | "content" // events, speakers, sponsors, team, stats, locations, forms
+  | "access" // roles, grants, status, invitaciones, solicitudes, staff
+  | "operations" // rebuild, certificados, check-in, credenciales, correo
+  | "minigame"
+  | "read" // lecturas sensibles auditadas
+  | "security"; // denegaciones, canjes fallidos, throttling
+
+export interface AuditContext {
+  /**
+   * Ata entre sí todo lo que ocurrió en una misma petición, y ata la fila de
+   * Firestore con su línea en Cloud Logging. Es lo que permite pasar de "hubo
+   * un cambio de rol raro" a "y en la misma petición se denegaron otras tres
+   * cosas".
+   */
+  requestId: string;
+  method: string;
+  /**
+   * El PATRÓN de la ruta (`/api/users/:uid/role`), no la ruta concreta. La
+   * concreta metería ids en un campo cuyo único uso es agrupar, y entonces
+   * agrupar por él no juntaría nada.
+   */
+  route: string;
+  /**
+   * Prefijo de red, no la dirección: /24 en IPv4, /48 en IPv6. Basta para
+   * correlacionar "esta red hizo estas cuarenta cosas" sin guardar un dato
+   * que identifique a una persona. La dirección completa va solo a Cloud
+   * Logging, que tiene su propia retención y su propio control de acceso.
+   */
+  ipPrefix: string | null;
+  userAgent: string | null;
+}
+
+/**
+ * Datos libres, propios de cada acción.
+ *
+ * Deliberadamente NO es `Record<string, unknown>`: una interfaz cerrada sin
+ * firma de índice no es asignable a ese tipo, así que exigirlo obligaría a los
+ * call sites que ya tipan sus detalles (`minigameTemplates`, `minigameWords`,
+ * `minigameInstances`) a añadir `[k: string]: unknown` a su interfaz — y eso
+ * haría que un typo en una clave pasara el compilador, que es exactamente lo
+ * que esas interfaces existen para impedir. El tipado fuerte vive en el call
+ * site, donde se sabe qué lleva cada acción; aquí solo hace falta saber que es
+ * un objeto serializable.
+ */
+export type AuditDetails = object;
+
+export interface AuditActor {
+  uid: string;
+  email: string | null;
+  /**
+   * El rol con el que se actuó, congelado en el momento de actuar. El doc de
+   * usuario cambia; esta fila tiene que seguir diciendo con qué autoridad se
+   * hizo lo que se hizo.
+   */
+  role: string | null;
+  /** Alcance con el que se resolvieron los permisos: `*` o el slug. */
+  scope: string;
+}
+
+export interface AuditEntry {
+  action: string;
+  performedBy: string;
+  targetId?: string;
+  targetType?: string;
+  details?: AuditDetails;
+  /**
+   * Opcional: el escritor lo sella si falta. Los call sites que pasan su
+   * propio valor lo hacen para compartir el mismo `serverTimestamp()` con la
+   * mutación que registran (ver `minigameRoulette`), y eso se conserva.
+   */
+  timestamp?: FieldValue;
+
+  outcome?: AuditOutcome;
+  severity?: AuditSeverity;
+  category?: AuditCategory;
+  actor?: AuditActor;
+  context?: AuditContext;
+  /**
+   * La puso la red de seguridad automática porque ningún handler reclamó la
+   * petición. Significa "aquí alguien cambió algo y el código no dijo qué":
+   * una fila degradada, pero visible, en lugar de silencio. Se resalta en el
+   * visor precisamente para que dé vergüenza y alguien la arregle.
+   */
+  synthesized?: true;
+}
+
+/** Prefijo de `action` → categoría. El orden importa: gana el más largo. */
+const CATEGORY_BY_PREFIX: ReadonlyArray<[string, AuditCategory]> = [
+  ["security.", "security"],
+  ["read.", "read"],
+  ["user.", "access"],
+  ["access.", "access"],
+  ["event.staff.", "access"],
+  ["proposal.", "content"],
+  ["event.", "content"],
+  ["speaker.", "content"],
+  ["sponsor.", "content"],
+  ["team.", "content"],
+  ["location.", "content"],
+  ["form.", "content"],
+  ["stats.", "content"],
+  ["minigame_instance.", "minigame"],
+  ["minigame_template.", "minigame"],
+  ["minigame_word.", "minigame"],
+  ["minigame_participant.", "minigame"],
+  ["credential.", "operations"],
+  ["credential_email.", "operations"],
+  ["certificate.", "operations"],
+  ["checkin.", "operations"],
+  ["settings.", "operations"],
+  ["site.", "operations"],
+  ["http.", "operations"],
+];
+
+/**
+ * Deduce la categoría del prefijo de la acción, para que los call sites que
+ * ya existían la ganen sin tocarlos. `event.staff.` va antes que `event.`
+ * porque asignar staff concede permisos: es control de acceso, no contenido.
+ */
+export function deriveCategory(action: string): AuditCategory {
+  let best: AuditCategory = "operations";
+  let bestLen = -1;
+  for (const [prefix, category] of CATEGORY_BY_PREFIX) {
+    if (action.startsWith(prefix) && prefix.length > bestLen) {
+      best = category;
+      bestLen = prefix.length;
+    }
+  }
+  return best;
+}
+
+/**
+ * Severidad por defecto. Un cambio de acceso que salió bien sigue siendo algo
+ * que alguien debería mirar —es el registro que importa cuando se revisa quién
+ * ganó permisos y por qué—, así que sube a `notice` en vez de quedarse en el
+ * `info` del resto del contenido.
+ */
+export function deriveSeverity(
+  category: AuditCategory,
+  outcome: AuditOutcome
+): AuditSeverity {
+  if (outcome === "failure") return "warning";
+  if (outcome === "denied")
+    return category === "security" ? "warning" : "notice";
+  if (category === "security") return "warning";
+  if (category === "access") return "notice";
+  return "info";
+}

--- a/src/pages/privacy-policy/index.astro
+++ b/src/pages/privacy-policy/index.astro
@@ -210,6 +210,32 @@ const metadata = {
     </section>
 
     <section>
+      <h2>Registro de auditoría del panel interno</h2>
+      <p>
+        Esta sección no afecta a quien se inscribe a un evento: de tu
+        inscripción, el registro de auditoría solo guarda el identificador
+        interno de tu credencial, <strong
+          >nunca tu DNI, tu nombre ni tu correo</strong
+        >.
+      </p>
+      <p>
+        Aplica a las personas del equipo que acceden al panel de administración.
+        Cada acción que realizan ahí deja constancia de quién la hizo, con qué
+        rol, sobre qué, desde qué ruta, con qué navegador y desde qué
+        <strong>prefijo de red</strong> — no la dirección IP completa. Sirve para
+        poder reconstruir qué ocurrió si hay un error o un uso indebido de permisos.
+      </p>
+      <p>
+        Ese registro se conserva <strong>24 meses</strong>. Es más que los 12
+        meses de los datos de inscripción porque un uso indebido de permisos
+        suele descubrirse tarde, y un registro que ya se borró no sirve para
+        aclararlo. Por la misma razón no se elimina a petición de la persona
+        registrada en él mientras esté dentro de ese plazo: es la constancia de
+        decisiones que afectaron a otras personas.
+      </p>
+    </section>
+
+    <section>
       <h2>Enlaces a terceros</h2>
       <p>
         El sitio contiene enlaces a páginas externas, entre ellas el panel


### PR DESCRIPTION
## What changed

- **Audit records now commit in the same batch/transaction as the mutation they record**, across all five access-control paths: role, status and grants in `handlers/users.ts`, staff assign/remove in `handlers/eventStaff.ts`, and invitation redemption in `handlers/access.ts`.
- **Applied the last-admin guard to the two paths that were missing it.** Guards moved out of `handlers/users.ts` into `auth/guards.ts`.
- `AuditEntry` is now a real type (`utils/auditTypes.ts`) carrying `outcome`, `severity`, `category`, `actor` and request `context`. Every new field is optional, so the type is a strict superset and the pre-existing call sites kept compiling untouched.
- Every entry is mirrored to Cloud Logging.
- `maxInstances: 10` on the `onRequest`, plus a global Express error handler.
- Retention doc and public privacy policy updated.

## Why

Two findings, both reachable without anyone attacking anything.

**1. The audit write happened *after* the mutation, and `writeAuditLog` swallowed its own errors.** `access.ts:534` elevated a role inside a transaction and wrote the record on line 537, outside it. Cloud Functions evicts instances routinely — a death between the two left someone holding new permissions with no record anywhere. Same shape in `users.ts:144/226/376`, `access.ts:276` and `eventStaff.ts:108/148`. Everything else in this branch is worth less than this fix.

**2. `users/{uid}.role` is written from three places and only one checked what was at stake.** `handlers/users.ts` verifies the actor dominates the target's current role and that the project keeps an active admin. `access.ts:276` (approving a request) and `access.ts:534` (redeeming an invitation) wrote the role with neither check, because the guards lived inside `users.ts` and those paths never saw them.

Concretely: an organizer invitation sent to an admin's email address, redeemed by that same admin, silently demoted them — and if they were the only one, left the project with nobody able to administer it short of the Firebase console by hand. Approving a stale request from someone who had since become admin did the same. **These are exactly the two paths used when giving new people access**, which is what makes this the first thing to merge.

## How to test

```bash
cd functions && pnpm build && pnpm test   # 556 tests at this commit
pnpm test:rules                           # from the repo root
```

Behaviour worth checking by hand against the emulator:

1. **Atomicity** — make the audit `tx.set` throw and confirm the role change did **not** apply either.
2. **Last admin, invitation path** — create an `organizer` invitation for the only admin's address and redeem it. Expected: 400, role unchanged, invitation still unused, no audit row (the whole transaction aborts).
3. **Last admin, approval path** — approve a pending request from the only admin. Expected: 400, request still `pending`.
4. Change a role from `/admin/users` and confirm `/admin/audit` shows the row with `previousRole` and `outcome`.

Both guard paths have regression tests (`handlers/access.test.ts`). The three affected test files stopped mocking `utils/audit` and now exercise the real writer against the in-memory store — with the helper mocked it was impossible to assert the one thing that matters here, that the mutation and its record land together.

## Notes for the reviewer

- Commit `ca214d4` was verified to build and pass its tests standalone, so the history is bisectable.
- `pnpm lint` fails with 498 errors on this branch **and on pristine `main`** (verified by stashing). The cause is stale worktrees under `.claude/worktrees/` making ESLint's `tsconfigRootDir` ambiguous. Unrelated to these changes and left alone.
- `countActiveAdmins` in `users.ts` remains a non-transactional read-then-write; the invitation path does it inside the transaction, where it is correct. Documented in a comment rather than fixed, since closing it needs a full-collection read inside a transaction.