### PR TITLE
feat(audit): record request context, security events and the six missing mutations

### DIFF
--- a/functions/src/handlers/access.test.ts
+++ b/functions/src/handlers/access.test.ts
@@ -155,6 +155,27 @@ vi.mock("firebase-functions", () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
+/**
+ * Los eventos de seguridad se capturan aquí. La respuesta HTTP de un canje
+ * fallido es deliberadamente idéntica en todos los casos —para no convertir el
+ * endpoint en un oráculo de invitaciones ajenas—, así que la única forma de
+ * comprobar que el MOTIVO real queda registrado es mirar el evento.
+ */
+const securityEvents: {
+  event: string;
+  uid?: string;
+  details?: Record<string, unknown>;
+}[] = [];
+vi.mock("../utils/securityAudit", () => ({
+  recordSecurityEvent: (input: {
+    event: string;
+    uid?: string;
+    details?: Record<string, unknown>;
+  }) => {
+    securityEvents.push(input);
+  },
+}));
+
 vi.mock("../services/email", () => ({
   sendInvitationEmail: async (mail: Record<string, unknown>) => {
     if (invitationEmailFails) throw new Error("smtp down");
@@ -223,6 +244,7 @@ beforeEach(() => {
   sentInvitations.length = 0;
   sentDecisions.length = 0;
   invitationEmailFails = false;
+  securityEvents.length = 0;
 });
 
 describe("createRequest", () => {
@@ -828,5 +850,174 @@ describe("listInvitations", () => {
     await handler.listInvitations(buildReq({ role: "admin" }), res);
     expect(JSON.stringify(res.__body?.data)).not.toContain("no-debe-salir");
     expect(JSON.stringify(res.__body?.data)).not.toContain("tokenHash");
+  });
+});
+
+/**
+ * El cable trampa contra un enlace de invitación robado o reenviado.
+ *
+ * Antes de esto, adivinar tokens contra `/redeem` no dejaba el menor rastro en
+ * ningún sitio: ni fila de auditoría ni línea de log. La respuesta sigue siendo
+ * un único mensaje opaco en todos los casos —eso es lo que impide usar el
+ * endpoint como oráculo—, pero el motivo real sí se registra, porque solo lo ve
+ * quien tiene `audit:read`.
+ */
+describe("canje fallido — registro del motivo", () => {
+  const TOKEN = "un-token-de-prueba";
+
+  function seedInvitation(over: Record<string, unknown> = {}) {
+    docs.set("invitations/inv-1", {
+      emailLower: "invitada@example.com",
+      role: "contributor",
+      tokenHash: hash(TOKEN),
+      expiresAt: new Date(Date.now() + 86400_000),
+      usedAt: null,
+      revokedAt: null,
+      ...over,
+    });
+    docs.set("users/u1", { uid: "u1", role: "member" });
+  }
+
+  async function attempt(opts: {
+    email?: string;
+    token?: string;
+  }): Promise<ResMock> {
+    const res = buildRes();
+    await handler.redeemInvitation(
+      buildReq({
+        email: opts.email ?? "invitada@example.com",
+        body: { token: opts.token ?? TOKEN },
+      }),
+      res
+    );
+    return res;
+  }
+
+  it.each([
+    ["token que no coincide", { token: "token-equivocado" }, "no_match"],
+    ["no es la persona invitada", { email: "otra@example.com" }, "no_match"],
+  ])("registra %s como %s", async (_label, opts, reason) => {
+    seedInvitation();
+    await attempt(opts);
+    expect(securityEvents).toEqual([
+      expect.objectContaining({
+        event: "security.invitation.redeem_failed",
+        uid: "u1",
+        details: expect.objectContaining({ reason }),
+      }),
+    ]);
+  });
+
+  it("distingue una invitación ya usada", async () => {
+    seedInvitation({ usedAt: new Date() });
+    await attempt({});
+    expect(securityEvents[0].details).toMatchObject({
+      reason: "already_used",
+      invitationId: "inv-1",
+    });
+  });
+
+  it("distingue una invitación revocada", async () => {
+    seedInvitation({ revokedAt: new Date() });
+    await attempt({});
+    expect(securityEvents[0].details).toMatchObject({ reason: "revoked" });
+  });
+
+  it("distingue una invitación caducada", async () => {
+    seedInvitation({ expiresAt: new Date(Date.now() - 86400_000) });
+    await attempt({});
+    expect(securityEvents[0].details).toMatchObject({ reason: "expired" });
+  });
+
+  // Los cuatro motivos anteriores devuelven EXACTAMENTE la misma respuesta:
+  // es lo que impide sondear invitaciones ajenas comparando errores.
+  it("la respuesta es idéntica sea cual sea el motivo", async () => {
+    const errores: (string | undefined)[] = [];
+
+    for (const over of [
+      { usedAt: new Date() },
+      { revokedAt: new Date() },
+      { expiresAt: new Date(Date.now() - 86400_000) },
+    ]) {
+      docs.clear();
+      seedInvitation(over);
+      errores.push((await attempt({})).__body?.error);
+    }
+    docs.clear();
+    seedInvitation();
+    errores.push((await attempt({ token: "otro" })).__body?.error);
+
+    expect(new Set(errores).size).toBe(1);
+    expect(errores[0]).toBe("Invitation is invalid, expired or already used");
+  });
+
+  it("un canje correcto no genera ningún evento de seguridad", async () => {
+    seedInvitation();
+    const res = await attempt({});
+    expect(res.__body?.success).toBe(true);
+    expect(securityEvents).toEqual([]);
+  });
+});
+
+/**
+ * El registro de `invitation.create` se escribe DESPUÉS de intentar el envío.
+ * Antes iba justo tras crear el documento, así que decía que la invitación se
+ * había creado mientras la persona nunca recibía el enlace — y al revisarlo
+ * después, eso manda a buscar por qué alguien no usó una invitación que en
+ * realidad nunca le llegó.
+ */
+describe("invitación creada — resultado del correo", () => {
+  const body = { email: "nueva@example.com", role: "contributor" };
+
+  it("registra emailDelivered true cuando el correo sale", async () => {
+    const res = buildRes();
+    await handler.createInvitation(
+      buildReq({ role: "admin", uid: "rev", body }),
+      res
+    );
+    expect(res.__status).toBe(201);
+    expect(auditLogEntries()[0]).toMatchObject({
+      action: "access.invitation.create",
+      outcome: "success",
+      details: { emailDelivered: true },
+    });
+  });
+
+  it("registra el fallo del correo como failure, no como éxito", async () => {
+    invitationEmailFails = true;
+    const res = buildRes();
+    await handler.createInvitation(
+      buildReq({ role: "admin", uid: "rev", body }),
+      res
+    );
+    expect(res.__status).toBe(502);
+    expect(auditLogEntries()[0]).toMatchObject({
+      action: "access.invitation.create",
+      // Sin correo la invitación existe pero no sirve de nada: tiene que
+      // saltar a la vista de quien revise, no parecer una que nadie usó.
+      outcome: "failure",
+      details: { emailDelivered: false },
+    });
+  });
+});
+
+/** La petición de acceso también deja constancia, no solo la decisión. */
+describe("solicitud de acceso — registro", () => {
+  it("audita la creación de la solicitud", async () => {
+    const res = buildRes();
+    await handler.createRequest(
+      buildReq({
+        body: { requestedRole: "organizer", motivo: "Coordino el DevFest" },
+      }),
+      res
+    );
+    expect(res.__status).toBe(201);
+    expect(auditLogEntries()[0]).toMatchObject({
+      action: "access.request.create",
+      performedBy: "u1",
+      targetType: "access_request",
+      category: "access",
+      details: { requestedRole: "organizer" },
+    });
   });
 });

--- a/functions/src/handlers/access.ts
+++ b/functions/src/handlers/access.ts
@@ -10,6 +10,7 @@ import {
   writeAuditLog,
 } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
+import { recordSecurityEvent } from "../utils/securityAudit";
 import { safeError } from "../middleware/validate";
 import {
   canAssignRole,
@@ -143,7 +144,12 @@ export async function createRequest(req: Request, res: Response) {
       return;
     }
 
-    await ref.set({
+    // La PETICIÓN también se registra, no solo la decisión. Antes el registro
+    // enseñaba una aprobación sin constancia de qué se había pedido ni cuándo,
+    // y "se aprobó el rol X" sin el "pidió el rol Y" de al lado no permite ver
+    // si alguien insistió con roles cada vez más altos.
+    const batch = admin.firestore().batch();
+    batch.set(ref, {
       uid: user.uid,
       email: user.email,
       displayName: user.displayName,
@@ -158,6 +164,17 @@ export async function createRequest(req: Request, res: Response) {
       reviewedAt: null,
       reviewNote: null,
     });
+    await commitWithAuditLog(
+      batch,
+      {
+        action: "access.request.create",
+        performedBy: user.uid,
+        targetId: user.uid,
+        targetType: "access_request",
+        details: { requestedRole: body.requestedRole, eventSlug },
+      },
+      req
+    );
 
     res.status(201).json({ success: true, data: { status: "pending" } });
   } catch (err) {
@@ -434,16 +451,17 @@ export async function createInvitation(req: Request, res: Response) {
         createdAt: FieldValue.serverTimestamp(),
       });
 
-    await writeAuditLog({
-      action: "access.invitation.create",
-      performedBy: performer.uid,
-      targetId: ref.id,
-      targetType: "invitation",
-      details: { email: email.toLowerCase(), role: body.role },
-      timestamp: FieldValue.serverTimestamp(),
-    });
-
+    // El registro se escribe DESPUÉS de intentar el envío, no antes.
+    //
+    // Antes iba justo tras crear el documento, y como el envío puede devolver
+    // 502, el registro afirmaba que la invitación se había creado mientras la
+    // persona nunca recibía el enlace. Al revisarlo después, eso es peor que
+    // no tener fila: manda a buscar por qué alguien no usó una invitación que
+    // en realidad nunca le llegó. `emailDelivered` es el dato que zanja esa
+    // pregunta.
     const url = `${SITE_ORIGIN}/admin/invitacion?token=${token}`;
+    let emailDelivered = true;
+    let emailError: unknown = null;
     try {
       await sendInvitationEmail({
         to: email,
@@ -453,10 +471,34 @@ export async function createInvitation(req: Request, res: Response) {
         expiresAt,
       });
     } catch (err) {
+      emailDelivered = false;
+      emailError = err;
+    }
+
+    await writeAuditLog(
+      {
+        action: "access.invitation.create",
+        performedBy: performer.uid,
+        targetId: ref.id,
+        targetType: "invitation",
+        details: {
+          email: email.toLowerCase(),
+          role: body.role,
+          emailDelivered,
+        },
+        // La invitación existe en la base de las dos maneras, pero sin correo
+        // no sirve para nada: se marca como fallo para que salte a la vista de
+        // quien revise, en vez de parecer una invitación normal que nadie usó.
+        outcome: emailDelivered ? "success" : "failure",
+      },
+      req
+    );
+
+    if (!emailDelivered) {
       // A diferencia de la decisión, aquí el correo ES la entrega: si no
       // sale, se avisa para poder reenviar en vez de dar por hecho que la
       // persona recibió el enlace.
-      logger.error("Invitation email failed", err);
+      logger.error("Invitation email failed", emailError);
       res.status(502).json({
         success: false,
         error: "Invitation created but the email could not be sent",
@@ -538,28 +580,45 @@ export async function redeemInvitation(req: Request, res: Response) {
     // Un único mensaje para "no existe", "no es tuya", "caducada" y "ya
     // usada": distinguirlos convierte el endpoint en un oráculo para
     // sondear invitaciones ajenas.
-    const invalid = () =>
+    // El MOTIVO real sí se registra. La respuesta sigue siendo idéntica en
+    // todos los casos —eso es lo que impide usar el endpoint como oráculo—,
+    // pero la fila de auditoría puede distinguirlos porque solo la ve quien
+    // tiene `audit:read`. Sin este registro, adivinar tokens no dejaba el
+    // menor rastro en ningún sitio, y es la superficie por la que se roba un
+    // enlace de invitación.
+    const invalid = (reason: string, invitationId?: string) => {
+      recordSecurityEvent({
+        event: "security.invitation.redeem_failed",
+        uid: user.uid,
+        details: { reason, email: user.email, invitationId },
+        req,
+      });
       res.status(400).json({
         success: false,
         error: "Invitation is invalid, expired or already used",
       });
+    };
 
     if (!match) {
-      invalid();
+      invalid("no_match");
       return;
     }
 
     const data = match.data();
-    if (
-      data.usedAt ||
-      data.revokedAt ||
-      !isNotExpired(data.expiresAt, Date.now())
-    ) {
-      invalid();
+    if (data.usedAt) {
+      invalid("already_used", match.id);
+      return;
+    }
+    if (data.revokedAt) {
+      invalid("revoked", match.id);
+      return;
+    }
+    if (!isNotExpired(data.expiresAt, Date.now())) {
+      invalid("expired", match.id);
       return;
     }
     if (!isRole(data.role) || !REQUESTABLE_ROLES.includes(data.role)) {
-      invalid();
+      invalid("bad_role", match.id);
       return;
     }
 
@@ -623,6 +682,16 @@ export async function redeemInvitation(req: Request, res: Response) {
     res.json({ success: true, data: { role: data.role } });
   } catch (err) {
     if (err instanceof Error && err.message === "ALREADY_USED") {
+      // La comprobación de arriba ya pasó, así que llegar aquí significa que
+      // otro canje del mismo enlace ganó la carrera entre esa lectura y esta
+      // transacción. Se registra con su propio motivo: dos canjes simultáneos
+      // del mismo token es exactamente el patrón de un enlace compartido.
+      recordSecurityEvent({
+        event: "security.invitation.redeem_failed",
+        uid: (req as AuthenticatedRequest).user.uid,
+        details: { reason: "race_already_used" },
+        req,
+      });
       res.status(400).json({
         success: false,
         error: "Invitation is invalid, expired or already used",

--- a/functions/src/handlers/auth.test.ts
+++ b/functions/src/handlers/auth.test.ts
@@ -1,0 +1,180 @@
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const docs = new Map<string, Record<string, unknown>>();
+let generatedIds = 0;
+
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("firebase-functions", () => ({ logger: loggerMock }));
+
+function docRef(path: string) {
+  return {
+    __path: path,
+    get: async () => {
+      const data = docs.get(path);
+      return { exists: data !== undefined, data: () => data };
+    },
+    update: async (data: Record<string, unknown>) => {
+      docs.set(path, { ...(docs.get(path) ?? {}), ...data });
+    },
+  };
+}
+
+type DocRef = ReturnType<typeof docRef>;
+
+/** Nada toca el almacén hasta `commit()`. */
+function batchMock() {
+  const ops: (() => void)[] = [];
+  const api = {
+    set: (ref: DocRef, data: Record<string, unknown>) => {
+      ops.push(() => docs.set(ref.__path, data));
+      return api;
+    },
+    update: (ref: DocRef, data: Record<string, unknown>) => {
+      ops.push(() =>
+        docs.set(ref.__path, { ...(docs.get(ref.__path) ?? {}), ...data })
+      );
+      return api;
+    },
+    commit: async () => {
+      ops.forEach((apply) => apply());
+      ops.length = 0;
+    },
+  };
+  return api;
+}
+
+vi.mock("firebase-admin", () => ({
+  firestore: () => ({
+    collection: (name: string) => ({
+      doc: (id?: string) => docRef(`${name}/${id ?? `gen-${++generatedIds}`}`),
+    }),
+    batch: () => batchMock(),
+  }),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: () => "__TS__" },
+}));
+
+import { register } from "./auth";
+
+function auditLogEntries(): Record<string, unknown>[] {
+  return [...docs.entries()]
+    .filter(([path]) => path.startsWith("audit_log/"))
+    .map(([, data]) => data);
+}
+
+interface ResMock extends Response {
+  __status: number | undefined;
+  __body: { success?: boolean; data?: unknown } | undefined;
+}
+
+function buildRes(): ResMock {
+  const res: Partial<ResMock> = {};
+  res.status = vi.fn(function (this: ResMock, code: number) {
+    this.__status = code;
+    return this;
+  }) as ResMock["status"];
+  res.json = vi.fn(function (this: ResMock, body: unknown) {
+    this.__body = body as ResMock["__body"];
+    return this;
+  }) as ResMock["json"];
+  return res as ResMock;
+}
+
+function buildReq(uid = "nuevo"): Request {
+  return {
+    user: {
+      uid,
+      email: "persona@example.com",
+      displayName: "Persona",
+      photoURL: "",
+      role: null,
+      scope: "*",
+    },
+  } as unknown as Request;
+}
+
+beforeEach(() => {
+  docs.clear();
+  generatedIds = 0;
+  loggerMock.info.mockReset();
+  loggerMock.warn.mockReset();
+  loggerMock.error.mockReset();
+});
+
+describe("register", () => {
+  it("crea la cuenta como member y lo audita", async () => {
+    const res = buildRes();
+    await register(buildReq(), res);
+
+    expect(res.__status).toBe(201);
+    expect(docs.get("users/nuevo")).toMatchObject({
+      uid: "nuevo",
+      role: "member",
+      status: "active",
+    });
+    expect(auditLogEntries()[0]).toMatchObject({
+      action: "user.register",
+      performedBy: "nuevo",
+      targetId: "nuevo",
+      targetType: "user",
+      category: "access",
+      details: { role: "member" },
+    });
+  });
+
+  // La rama de login actualiza `lastLoginAt` en CADA entrada. Auditar eso daría
+  // una fila por inicio de sesión y ahogaría el registro en ruido; el alta
+  // ocurre una vez y es lo que interesa poder fechar.
+  it("NO audita el login de una cuenta que ya existe", async () => {
+    docs.set("users/existente", {
+      uid: "existente",
+      role: "organizer",
+      status: "active",
+    });
+
+    const res = buildRes();
+    await register(buildReq("existente"), res);
+
+    expect(res.__body?.success).toBe(true);
+    expect(auditLogEntries()).toHaveLength(0);
+    // Pero sí refresca la marca de último acceso.
+    expect(docs.get("users/existente")).toMatchObject({
+      lastLoginAt: "__TS__",
+    });
+  });
+
+  it("cinco logins seguidos no dejan ninguna fila", async () => {
+    docs.set("users/existente", { uid: "existente", role: "member" });
+    for (let i = 0; i < 5; i++) {
+      await register(buildReq("existente"), buildRes());
+    }
+    expect(auditLogEntries()).toHaveLength(0);
+  });
+
+  // El alta no puede conceder permisos por el simple hecho de haber entrado con
+  // Google: subir de `member` exige una solicitud aprobada o una invitación.
+  it("el alta nunca concede permisos ni grants", async () => {
+    await register(buildReq(), buildRes());
+    expect(docs.get("users/nuevo")).toMatchObject({
+      role: "member",
+      grants: [],
+      revocations: [],
+    });
+  });
+
+  // La cuenta y su registro se confirman en el mismo batch: un alta sin rastro
+  // dejaría sin fechar la entrada de alguien al sistema.
+  it("la cuenta y su registro caen juntos", async () => {
+    await register(buildReq(), buildRes());
+    expect(docs.get("users/nuevo")).toBeDefined();
+    expect(auditLogEntries()).toHaveLength(1);
+  });
+});

--- a/functions/src/handlers/auth.ts
+++ b/functions/src/handlers/auth.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import * as admin from "firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
 import { AuthenticatedRequest } from "../middleware/auth";
+import { commitWithAuditLog } from "../utils/audit";
 
 export async function register(req: Request, res: Response) {
   try {
@@ -34,7 +35,24 @@ export async function register(req: Request, res: Response) {
       lastLoginAt: FieldValue.serverTimestamp(),
     };
 
-    await userRef.set(newUser);
+    // Solo la creación deja constancia. La rama de arriba actualiza
+    // `lastLoginAt` en CADA inicio de sesión: auditar eso daría una fila por
+    // login y ahogaría el registro en ruido sin aportar nada — el alta de una
+    // cuenta ocurre una vez, y es lo que interesa poder fechar.
+    const batch = db.batch();
+    batch.set(userRef, newUser);
+    await commitWithAuditLog(
+      batch,
+      {
+        action: "user.register",
+        performedBy: user.uid,
+        targetId: user.uid,
+        targetType: "user",
+        details: { role: "member", email: user.email || "" },
+      },
+      req
+    );
+
     res.status(201).json({ success: true, data: newUser });
   } catch {
     res.status(500).json({ success: false, error: "Registration failed" });

--- a/functions/src/handlers/credentials.ts
+++ b/functions/src/handlers/credentials.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import * as admin from "firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
+import { singleLineHeader } from "../utils/headers";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import {
@@ -294,21 +295,6 @@ async function readCredentialConfig(
 }
 
 /**
- * Collapses a header value to one bounded, control-character-free line.
- *
- * Mirrors singleLine() in services/email.ts. Applied here because the
- * user-agent is stored and later rendered in the admin panel.
- */
-function singleLineHeader(value: string | undefined): string {
-  if (!value) return "";
-  return value
-    .replace(/[\r\n\t]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, 200);
-}
-
-/**
  * PATCH /api/events/:slug/credentials/:id/image
  *
  * Public, on the same anonymous token as create.
@@ -371,6 +357,22 @@ export async function attachCredentialImage(req: Request, res: Response) {
       credentialImagePath: paths.credentialImagePath,
       updatedAt: FieldValue.serverTimestamp(),
     });
+
+    // Endpoint público, sobre el mismo token anónimo que la creación, y escribe
+    // bytes en Storage: es la única mutación pública que subía un archivo sin
+    // dejar constancia. Sin DNI, nombre ni correo en los detalles, igual que
+    // `credential.create` (ver el comentario de más arriba): `audit_log` lo lee
+    // cualquiera con `audit:read`, que es más amplio que el permiso del roster.
+    await writeAuditLog(
+      {
+        action: "credential.image",
+        performedBy: user.uid,
+        targetId: id,
+        targetType: "credential",
+        details: { slug, bytes: image.byteLength },
+      },
+      req
+    );
 
     res.json({ success: true, data: { id } });
   } catch (err) {

--- a/functions/src/handlers/proposals.test.ts
+++ b/functions/src/handlers/proposals.test.ts
@@ -471,3 +471,49 @@ describe("publishProposal", () => {
     expect(res.__status).toBe(404);
   });
 });
+
+/**
+ * Toda la superficie de escritura de un `contributor` pasa por crear y editar
+ * propuestas, y era invisible hasta que alguien revisaba: solo se auditaban la
+ * revisión y la publicación. Un colaborador externo es el perfil con menos
+ * confianza acumulada, así que es el que más falta hace poder reconstruir.
+ */
+describe("auditoría de crear y editar", () => {
+  it("audita la creación", async () => {
+    const res = buildRes();
+    await handler.createProposal(
+      buildReq("contributor", "ext", { type: "event", payload: EVENT }),
+      res
+    );
+    expect(res.__status).toBe(201);
+    expect(auditEntries[0]).toMatchObject({
+      action: "proposal.create",
+      targetType: "proposal",
+      details: { type: "event" },
+    });
+  });
+
+  // El payload puede ser grande y ya está en el propio documento; duplicarlo en
+  // los detalles solo engordaría el registro.
+  it("no mete el payload en los detalles", async () => {
+    const res = buildRes();
+    await handler.createProposal(
+      buildReq("contributor", "ext", { type: "event", payload: EVENT }),
+      res
+    );
+    expect(auditEntries[0].details).not.toHaveProperty("payload");
+  });
+
+  it("no audita una creación rechazada por validación", async () => {
+    const res = buildRes();
+    await handler.createProposal(
+      buildReq("contributor", "ext", {
+        type: "event",
+        payload: { id: "sin-titulo" },
+      }),
+      res
+    );
+    expect(res.__status).toBe(400);
+    expect(auditEntries).toHaveLength(0);
+  });
+});

--- a/functions/src/handlers/proposals.ts
+++ b/functions/src/handlers/proposals.ts
@@ -135,6 +135,23 @@ export async function createProposal(req: Request, res: Response) {
       publishedAt: null,
     });
 
+    // Toda la superficie de escritura de un `contributor` pasa por aquí, y
+    // hasta ahora era invisible hasta que alguien revisaba: solo se auditaban
+    // la revisión y la publicación. Un colaborador externo es justo el perfil
+    // con menos confianza acumulada, así que es el que más falta hace poder
+    // reconstruir. El payload NO va en los detalles — puede ser grande y ya
+    // está en el propio documento.
+    await writeAuditLog(
+      {
+        action: "proposal.create",
+        performedBy: user.uid,
+        targetId: ref.id,
+        targetType: "proposal",
+        details: { type: body.type },
+      },
+      req
+    );
+
     res.status(201).json({ success: true, data: { id: ref.id } });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });
@@ -177,11 +194,27 @@ export async function updateProposal(req: Request, res: Response) {
       return;
     }
 
+    const previousStatus = String(data.status);
     await ref.update({
       payload: parsed.data,
       status: "submitted",
       submittedAt: FieldValue.serverTimestamp(),
     });
+
+    // Reenviar reescribe el payload y devuelve el estado a `submitted`. Sin
+    // esta fila, un borrador que ya pasó por "requiere cambios" podía cambiar
+    // de contenido entre la revisión y la publicación sin que quedara constancia
+    // de que había cambiado.
+    await writeAuditLog(
+      {
+        action: "proposal.update",
+        performedBy: user.uid,
+        targetId: id,
+        targetType: "proposal",
+        details: { type: data.type, previousStatus },
+      },
+      req
+    );
 
     res.json({ success: true, data: { id } });
   } catch (err) {

--- a/functions/src/handlers/rebuild.test.ts
+++ b/functions/src/handlers/rebuild.test.ts
@@ -1,0 +1,154 @@
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const written: Record<string, unknown>[] = [];
+let dispatches = 0;
+let dispatchFails = false;
+
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("firebase-functions", () => ({ logger: loggerMock }));
+
+vi.mock("firebase-admin", () => ({
+  firestore: () => ({
+    collection: () => ({
+      doc: () => ({ __path: "audit_log/gen" }),
+      add: async (data: Record<string, unknown>) => {
+        written.push(data);
+        return { id: "gen" };
+      },
+    }),
+  }),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: () => "__TS__" },
+}));
+
+vi.mock("../config", () => ({
+  GITHUB_TOKEN: { value: () => "token" },
+}));
+
+vi.mock("../services/github", () => ({
+  GitHubService: class {
+    async triggerRebuild() {
+      dispatches += 1;
+      if (dispatchFails) throw new Error("github down");
+    }
+  },
+}));
+
+interface ResMock extends Response {
+  __status: number | undefined;
+  __body: { success?: boolean; message?: string } | undefined;
+}
+
+function buildRes(): ResMock {
+  const res: Partial<ResMock> = {};
+  res.status = vi.fn(function (this: ResMock, code: number) {
+    this.__status = code;
+    return this;
+  }) as ResMock["status"];
+  res.json = vi.fn(function (this: ResMock, body: unknown) {
+    this.__body = body as ResMock["__body"];
+    return this;
+  }) as ResMock["json"];
+  return res as ResMock;
+}
+
+function buildReq(uid = "adm"): Request {
+  return { user: { uid, role: "admin", scope: "*" } } as unknown as Request;
+}
+
+beforeEach(() => {
+  written.length = 0;
+  dispatches = 0;
+  dispatchFails = false;
+  loggerMock.info.mockReset();
+  loggerMock.warn.mockReset();
+  loggerMock.error.mockReset();
+  vi.resetModules();
+});
+
+/** El debounce vive en un módulo con estado, así que se reimporta por test. */
+async function freshHandler() {
+  return (await import("./rebuild")).triggerRebuild;
+}
+
+describe("triggerRebuild", () => {
+  it("audita el despacho real", async () => {
+    const triggerRebuild = await freshHandler();
+    const res = buildRes();
+    await triggerRebuild(buildReq(), res);
+
+    expect(dispatches).toBe(1);
+    expect(res.__body?.success).toBe(true);
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatchObject({
+      action: "site.rebuild",
+      performedBy: "adm",
+      targetType: "site",
+      outcome: "success",
+    });
+  });
+
+  // El debounce devuelve 202 y NO despacha nada. Auditarlo como un rebuild más
+  // haría que el registro contara publicaciones que nunca ocurrieron, y quien
+  // lo lea después buscaría en el sitio un cambio que no está.
+  it("la rama del debounce se registra como denied, no como éxito", async () => {
+    const triggerRebuild = await freshHandler();
+    await triggerRebuild(buildReq(), buildRes());
+
+    const res = buildRes();
+    await triggerRebuild(buildReq("otra-persona"), res);
+
+    expect(dispatches).toBe(1);
+    expect(res.__status).toBe(202);
+    expect(written).toHaveLength(2);
+    expect(written[1]).toMatchObject({
+      action: "site.rebuild",
+      performedBy: "otra-persona",
+      outcome: "denied",
+      details: { debounced: true },
+    });
+  });
+
+  it("el 202 del debounce lleva retryAfter y queda en el registro", async () => {
+    const triggerRebuild = await freshHandler();
+    await triggerRebuild(buildReq(), buildRes());
+    const res = buildRes();
+    await triggerRebuild(buildReq(), res);
+
+    expect(res.__body).toMatchObject({ message: "Rebuild already queued" });
+    expect(written[1].details).toMatchObject({ debounced: true });
+    expect(
+      (written[1].details as { retryAfter?: number }).retryAfter
+    ).toBeGreaterThan(0);
+  });
+
+  // Publicar el sitio público es la acción con más alcance del panel, así que un
+  // fallo tiene que quedar registrado y no solo devolver 500.
+  it("un fallo de GitHub se registra como failure", async () => {
+    dispatchFails = true;
+    const triggerRebuild = await freshHandler();
+    const res = buildRes();
+    await triggerRebuild(buildReq(), res);
+
+    expect(res.__status).toBe(500);
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatchObject({
+      action: "site.rebuild",
+      outcome: "failure",
+    });
+  });
+
+  it("clasifica el rebuild como operación", async () => {
+    const triggerRebuild = await freshHandler();
+    await triggerRebuild(buildReq(), buildRes());
+    expect(written[0]).toMatchObject({ category: "operations" });
+  });
+});

--- a/functions/src/handlers/rebuild.ts
+++ b/functions/src/handlers/rebuild.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from "express";
 import { safeError } from "../middleware/validate";
+import { writeAuditLog } from "../utils/audit";
+import { AuthenticatedRequest } from "../middleware/auth";
 import { GitHubService } from "../services/github";
 import { GITHUB_TOKEN } from "../config";
 
@@ -10,12 +12,28 @@ import { GITHUB_TOKEN } from "../config";
 const REBUILD_DEBOUNCE_MS = 60_000;
 let lastRebuildAt = 0;
 
-export async function triggerRebuild(_req: Request, res: Response) {
+export async function triggerRebuild(req: Request, res: Response) {
+  const user = (req as AuthenticatedRequest).user;
   try {
     const now = Date.now();
     const elapsed = now - lastRebuildAt;
     if (elapsed < REBUILD_DEBOUNCE_MS) {
       const retryAfter = Math.ceil((REBUILD_DEBOUNCE_MS - elapsed) / 1000);
+      // Se registra como `denied`, no como éxito: esta rama devuelve 202 y
+      // NO despacha nada. Auditarla como un rebuild más haría que el registro
+      // contara publicaciones que nunca ocurrieron, y quien lo lea después
+      // buscaría en el sitio un cambio que no está.
+      await writeAuditLog(
+        {
+          action: "site.rebuild",
+          performedBy: user.uid,
+          targetId: "site",
+          targetType: "site",
+          details: { debounced: true, retryAfter },
+          outcome: "denied",
+        },
+        req
+      );
       res
         .status(202)
         .json({ success: true, message: "Rebuild already queued", retryAfter });
@@ -24,8 +42,33 @@ export async function triggerRebuild(_req: Request, res: Response) {
     lastRebuildAt = now;
     const github = new GitHubService(GITHUB_TOKEN.value());
     await github.triggerRebuild();
+
+    // Después del despacho, no antes: publicar el sitio público es la acción
+    // con más alcance del panel y pronto la tendrán varias personas.
+    await writeAuditLog(
+      {
+        action: "site.rebuild",
+        performedBy: user.uid,
+        targetId: "site",
+        targetType: "site",
+        details: {},
+      },
+      req
+    );
+
     res.json({ success: true, message: "Rebuild triggered" });
   } catch (err) {
+    await writeAuditLog(
+      {
+        action: "site.rebuild",
+        performedBy: user.uid,
+        targetId: "site",
+        targetType: "site",
+        details: {},
+        outcome: "failure",
+      },
+      req
+    );
     res.status(500).json({ success: false, error: safeError(err) });
   }
 }

--- a/functions/src/index.routes.test.ts
+++ b/functions/src/index.routes.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * La garantía de cobertura de auditoría.
+ *
+ * La red de seguridad de `middleware/auditContext.ts` es el modo degradado: si
+ * un handler futuro se olvida de auditar, deja una fila `synthesized: true` que
+ * dice "aquí alguien cambió algo y el código no dijo qué". Mejor que el
+ * silencio, pero sigue siendo una fila sin `targetId` ni detalles, y hay que
+ * darse cuenta de que está.
+ *
+ * Este test es la garantía de verdad: recorre la tabla de rutas real de express
+ * y exige que cada ruta que muta esté clasificada explícitamente abajo. Añadir
+ * una ruta sin decidir si audita **rompe CI**, que es la única forma de que la
+ * decisión no se posponga hasta que haga falta el registro y no esté.
+ */
+
+vi.mock("firebase-admin", () => ({
+  initializeApp: vi.fn(),
+  firestore: () => ({ collection: () => ({}) }),
+  auth: () => ({}),
+  appCheck: () => ({}),
+  storage: () => ({}),
+}));
+
+vi.mock("firebase-functions", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Bajo este mock, `api` ES la app de express en vez de una Cloud Function
+// envuelta, así que se puede inspeccionar su router.
+vi.mock("firebase-functions/v2/https", () => ({
+  onRequest: (_opts: unknown, app: unknown) => app,
+}));
+
+vi.mock("firebase-functions/params", () => ({
+  defineSecret: (name: string) => ({ name, value: () => "" }),
+}));
+
+vi.mock("firebase-functions/v2/firestore", () => ({
+  onDocumentWritten: () => ({}),
+}));
+
+vi.mock("firebase-functions/v2/scheduler", () => ({
+  onSchedule: () => ({}),
+}));
+
+import { api } from "./index";
+
+/**
+ * Rutas que mutan y dejan constancia. Son todas: los seis huecos que quedaban
+ * —register, la solicitud de acceso, el rebuild, crear y editar propuestas, y
+ * la subida de imagen de credencial— se cerraron en este mismo cambio.
+ */
+const AUDITED_ROUTES = [
+  "POST /api/auth/register",
+  "POST /api/events",
+  "PUT /api/events/:id",
+  "DELETE /api/events/:id",
+  "POST /api/team",
+  "PUT /api/team/:id",
+  "DELETE /api/team/:id",
+  "POST /api/speakers",
+  "PUT /api/speakers/:id",
+  "DELETE /api/speakers/:id",
+  "POST /api/sponsors",
+  "PUT /api/sponsors/:id",
+  "DELETE /api/sponsors/:id",
+  "PUT /api/stats",
+  "PATCH /api/users/:uid/role",
+  "PATCH /api/users/:uid/status",
+  "PUT /api/users/:uid/grants",
+  "POST /api/proposals",
+  "PUT /api/proposals/:id",
+  "POST /api/proposals/:id/review",
+  "POST /api/proposals/:id/publish",
+  "PUT /api/events/:slug/staff/:uid",
+  "DELETE /api/events/:slug/staff/:uid",
+  "POST /api/access/requests",
+  "POST /api/access/invitations/redeem",
+  "POST /api/access/requests/:uid/decide",
+  "POST /api/access/invitations",
+  "DELETE /api/access/invitations/:id",
+  "POST /api/forms",
+  "PUT /api/forms/:id",
+  "DELETE /api/forms/:id",
+  "POST /api/locations",
+  "PUT /api/locations/:id",
+  "DELETE /api/locations/:id",
+  "POST /api/minigame-templates",
+  "PUT /api/minigame-templates/:id",
+  "DELETE /api/minigame-templates/:id",
+  "POST /api/events/:slug/minigames",
+  "PATCH /api/events/:slug/minigames/:id/state",
+  "POST /api/events/:slug/minigames/:id/quiz/advance",
+  "DELETE /api/events/:slug/minigames/:id",
+  "POST /api/events/:slug/minigames/join",
+  "POST /api/events/:slug/credentials",
+  "PATCH /api/events/:slug/credentials/:id/image",
+  "PATCH /api/events/:slug/credentials/:id/bevy",
+  "PATCH /api/events/:slug/credentials/:id/photo",
+  "POST /api/events/:slug/credentials/:id/email/retry",
+  "POST /api/events/:slug/credentials/reminders",
+  "POST /api/events/:slug/credentials/reconcile",
+  "PUT /api/settings/email",
+  "POST /api/events/:slug/minigames/:id/roulette/spin",
+  "POST /api/events/:slug/minigames/:id/bingo/draw",
+  "POST /api/events/:slug/minigames/:id/bingo/claim",
+  "PATCH /api/events/:slug/minigames/:id/words/:wordId/hidden",
+  "POST /api/certificates/send",
+  "POST /api/events/:slug/checkin/import",
+  "POST /api/rebuild",
+];
+
+/**
+ * Rutas que mutan y NO auditan a propósito.
+ *
+ * Está vacía, y que lo esté es el objetivo. Si algo entra aquí, tiene que
+ * llevar al lado el motivo por el que no auditar es la decisión correcta —no
+ * "aún no lo hemos hecho"—, porque cualquiera que lea el registro va a asumir
+ * que están todas.
+ */
+const UNAUDITED_BY_DESIGN: string[] = [];
+
+const MUTATING = /^(POST|PUT|PATCH|DELETE) /;
+
+/** Recorre la tabla de rutas real de express. */
+function registeredRoutes(): string[] {
+  const stack = (
+    api as unknown as {
+      router: {
+        stack: {
+          route?: { path: string; methods: Record<string, boolean> };
+        }[];
+      };
+    }
+  ).router.stack;
+
+  return stack.flatMap((layer) =>
+    layer.route
+      ? Object.keys(layer.route.methods)
+          .filter((m) => m !== "_all")
+          .map((m) => `${m.toUpperCase()} ${layer.route!.path}`)
+      : []
+  );
+}
+
+describe("cobertura de auditoría de las rutas", () => {
+  it("expone la tabla de rutas para poder inspeccionarla", () => {
+    // Si esto falla, express cambió cómo expone su router y el resto del test
+    // estaría pasando en vacío — que es peor que fallar.
+    expect(registeredRoutes().length).toBeGreaterThan(50);
+  });
+
+  it("toda ruta que muta está clasificada", () => {
+    const mutating = registeredRoutes().filter((r) => MUTATING.test(r));
+    const classified = new Set([...AUDITED_ROUTES, ...UNAUDITED_BY_DESIGN]);
+
+    const unclassified = mutating.filter((r) => !classified.has(r));
+    expect(
+      unclassified,
+      "Ruta que muta sin clasificar. Audítala y añádela a AUDITED_ROUTES, o " +
+        "justifica por qué no en UNAUDITED_BY_DESIGN."
+    ).toEqual([]);
+  });
+
+  // La lista se queda obsoleta en la otra dirección: una ruta que se renombra o
+  // se borra dejaría una entrada muerta, y con ella la falsa impresión de que
+  // algo está cubierto.
+  it("no quedan entradas muertas en la clasificación", () => {
+    const mutating = new Set(
+      registeredRoutes().filter((r) => MUTATING.test(r))
+    );
+    const stale = [...AUDITED_ROUTES, ...UNAUDITED_BY_DESIGN].filter(
+      (r) => !mutating.has(r)
+    );
+    expect(stale, "Entrada que ya no corresponde a ninguna ruta.").toEqual([]);
+  });
+
+  it("no hay rutas duplicadas en la clasificación", () => {
+    const all = [...AUDITED_ROUTES, ...UNAUDITED_BY_DESIGN];
+    expect(all.length).toBe(new Set(all).size);
+  });
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,6 +9,8 @@ import { requirePermission, requireAuth } from "./middleware/auth";
 import { isAllowedOrigin, rejectDisallowedOrigin } from "./middleware/cors";
 import { safeError, validateParamId } from "./middleware/validate";
 import { verifyAppCheck } from "./middleware/appCheck";
+import { auditContext } from "./middleware/auditContext";
+import { recordSecurityEvent } from "./utils/securityAudit";
 import { validateBody } from "./middleware/validateBody";
 import {
   eventSchema,
@@ -77,6 +79,38 @@ app.use(
 );
 app.use(express.json({ limit: "1mb" }));
 
+// Contexto de auditoría ANTES del limitador de perímetro: así un 429 también
+// lleva su id de correlación. Si alguien satura la API, lo que hace falta poder
+// hacer es cruzar esas respuestas rechazadas con lo que sí llegó a pasar.
+app.use(auditContext());
+
+/**
+ * Registra el 429 antes de responderlo, conservando el mensaje propio de cada
+ * limitador.
+ *
+ * Va en el nivel `rollup`: agotar un limitador es gratis por definición, así
+ * que solo la primera vez de cada (evento, red, uid) escribe fila y el resto
+ * cuenta en memoria. Sin esto, quien saturara la API no dejaba constancia
+ * ninguna en el panel, y una ráfaga de 429 es precisamente lo que distingue un
+ * pico de tráfico legítimo de alguien insistiendo.
+ */
+function limitExceeded(limiter: string) {
+  return (
+    req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction,
+    options: { statusCode: number; message: unknown }
+  ) => {
+    recordSecurityEvent({
+      event: "security.ratelimit.exceeded",
+      uid: (req as { user?: { uid?: string } }).user?.uid,
+      details: { limiter },
+      req,
+    });
+    res.status(options.statusCode).json(options.message);
+  };
+}
+
 // Latched so the warning below fires once per cold start, not per request.
 let warnedMissingIp = false;
 
@@ -112,6 +146,7 @@ app.use(
       return true;
     },
     keyGenerator: (req) => `ip:${ipKeyGenerator(req.ip as string)}`,
+    handler: limitExceeded("perimeter"),
     message: { success: false, error: "Too many requests, try again later" },
   })
 );
@@ -132,6 +167,7 @@ const writeLimiter = rateLimit({
     // used to bypass the limit by rotating the suffix.
     return `ip:${ipKeyGenerator(req.ip ?? "unknown")}`;
   },
+  handler: limitExceeded("write"),
   message: {
     success: false,
     error: "Too many write requests, slow down",
@@ -147,6 +183,7 @@ const joinLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (req) => `ip:${ipKeyGenerator(req.ip ?? "unknown")}`,
+  handler: limitExceeded("join"),
   message: {
     success: false,
     error: "Demasiados intentos, espera un momento",
@@ -171,6 +208,7 @@ const ballLimiter = rateLimit({
     const uid = (req as { user?: { uid?: string } }).user?.uid;
     return uid ? `u:${uid}` : `ip:${ipKeyGenerator(req.ip ?? "unknown")}`;
   },
+  handler: limitExceeded("ball"),
   message: {
     success: false,
     error: "Demasiadas bolas seguidas, espera un momento",
@@ -190,6 +228,7 @@ const claimLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (req) => `ip:${ipKeyGenerator(req.ip ?? "unknown")}`,
+  handler: limitExceeded("claim"),
   message: {
     success: false,
     error: "Demasiados intentos, espera un momento",
@@ -215,6 +254,7 @@ const credentialLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (req) => `ip:${ipKeyGenerator(req.ip ?? "unknown")}`,
+  handler: limitExceeded("credential"),
   message: {
     success: false,
     error:
@@ -396,6 +436,7 @@ const accessLimiter = rateLimit({
   // bypassable by rotating accounts, which is exactly what a token-guessing
   // client would do. Same reasoning as joinLimiter above.
   keyGenerator: (req) => `ip:${ipKeyGenerator(req.ip ?? "unknown")}`,
+  handler: limitExceeded("access"),
   message: {
     success: false,
     error: "Demasiados intentos, inténtalo más tarde",

--- a/functions/src/middleware/appCheck.ts
+++ b/functions/src/middleware/appCheck.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import * as admin from "firebase-admin";
 import { logger } from "firebase-functions";
+import { recordSecurityEvent } from "../utils/securityAudit";
 
 // App Check verification for the public credential endpoints.
 //
@@ -70,10 +71,18 @@ export function verifyAppCheck() {
 
     const enforce = await readAppCheckEnforcement();
 
-    logger.warn("Request without a valid App Check token", {
-      path: req.path,
-      hadToken: Boolean(token),
-      enforced: enforce,
+    // Nivel `log-only`: estos endpoints son públicos, así que provocar esto no
+    // cuesta nada ni requiere cuenta. Escribirlo en Firestore le daría a
+    // cualquiera un amplificador de una petición a una escritura.
+    //
+    // Es además la medición con la que se decide activar la exigencia: hay que
+    // confirmar en estos logs que los clientes reales sí mandan la cabecera
+    // ANTES de exigirla, porque src/lib/api.ts la omite en silencio cuando
+    // reCAPTCHA falla. Un evento en marcha no es el momento de descubrirlo.
+    recordSecurityEvent({
+      event: "security.appcheck.missing",
+      details: { hadToken: Boolean(token), enforced: enforce },
+      req,
     });
 
     if (!enforce) {

--- a/functions/src/middleware/auditContext.test.ts
+++ b/functions/src/middleware/auditContext.test.ts
@@ -1,0 +1,249 @@
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const written: Record<string, unknown>[] = [];
+
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("firebase-functions", () => ({ logger: loggerMock }));
+
+vi.mock("firebase-admin", () => ({
+  firestore: () => ({
+    collection: () => ({
+      doc: () => ({ __path: "audit_log/gen" }),
+      add: async (data: Record<string, unknown>) => {
+        written.push(data);
+        return { id: "gen" };
+      },
+    }),
+  }),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: () => "__TS__" },
+}));
+
+import { auditContext, truncateIp } from "./auditContext";
+
+/** Simula el ciclo de vida: entra la petición, responde, se dispara `finish`. */
+function run(opts: {
+  method?: string;
+  path?: string;
+  routePath?: string;
+  status?: number;
+  ip?: string;
+  userAgent?: string;
+  claimed?: boolean;
+  uid?: string;
+}) {
+  const handlers: (() => void)[] = [];
+  const headers: Record<string, string> = {};
+
+  const req = {
+    method: opts.method ?? "POST",
+    path: opts.path ?? "/api/users/abc/role",
+    baseUrl: "",
+    ip: opts.ip ?? "181.65.42.117",
+    route: opts.routePath ? { path: opts.routePath } : undefined,
+    get: (name: string) =>
+      name.toLowerCase() === "user-agent" ? opts.userAgent : undefined,
+    ...(opts.uid ? { user: { uid: opts.uid } } : {}),
+  } as unknown as Request;
+
+  const res = {
+    statusCode: opts.status ?? 200,
+    setHeader: (k: string, v: string) => {
+      headers[k] = v;
+    },
+    on: (event: string, cb: () => void) => {
+      if (event === "finish") handlers.push(cb);
+    },
+  } as unknown as Response;
+
+  const next = vi.fn();
+  auditContext()(req, res, next);
+
+  // El handler reclama la petición DESPUÉS del middleware, como en la realidad.
+  if (opts.claimed) req.auditClaimed = true;
+
+  handlers.forEach((h) => h());
+  return { req, res, next, headers };
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+beforeEach(() => {
+  written.length = 0;
+  loggerMock.info.mockReset();
+  loggerMock.warn.mockReset();
+  loggerMock.error.mockReset();
+});
+
+describe("truncateIp", () => {
+  it.each([
+    ["181.65.42.117", "181.65.42.0/24"],
+    ["10.0.0.1", "10.0.0.0/24"],
+    ["255.255.255.255", "255.255.255.0/24"],
+  ])("IPv4 %s → %s", (ip, expected) => {
+    expect(truncateIp(ip)).toBe(expected);
+  });
+
+  // Detrás de un proxy una IPv4 puede llegar mapeada a IPv6; sin desmapear,
+  // se guardaría "::ffff:181::/48" y el prefijo perdería todo su sentido.
+  it("desmapea la IPv4 embebida en IPv6", () => {
+    expect(truncateIp("::ffff:181.65.42.117")).toBe("181.65.42.0/24");
+  });
+
+  // /48 y no /64: en IPv6 un /64 es una sola máquina, así que el equivalente
+  // honesto al /24 de IPv4 es la asignación de sitio.
+  it.each([
+    ["2001:db8:1234:5678::1", "2001:db8:1234::/48"],
+    ["2001:db8:1234::1", "2001:db8:1234::/48"],
+  ])("IPv6 %s → %s", (ip, expected) => {
+    expect(truncateIp(ip)).toBe(expected);
+  });
+
+  it("no revienta sin dirección", () => {
+    expect(truncateIp(undefined)).toBeNull();
+    expect(truncateIp("")).toBeNull();
+    expect(truncateIp("no-es-una-ip")).toBeNull();
+  });
+
+  it("nunca devuelve la dirección completa", () => {
+    expect(truncateIp("181.65.42.117")).not.toContain("117");
+  });
+});
+
+describe("contexto", () => {
+  it("pone requestId, método y prefijo, y llama a next()", () => {
+    const { req, next } = run({});
+    expect(req.auditContext?.requestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(req.auditContext?.method).toBe("POST");
+    expect(req.auditContext?.ipPrefix).toBe("181.65.42.0/24");
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("expone el requestId en la cabecera para poder citarlo", () => {
+    const { req, headers } = run({});
+    expect(headers["X-Request-Id"]).toBe(req.auditContext?.requestId);
+  });
+
+  // Un user-agent con CRLF puede fingir varias entradas dentro de una: el
+  // registro deja de ser fiable justo cuando hay que leerlo.
+  it("colapsa saltos de línea del user-agent", () => {
+    const { req } = run({
+      userAgent: "Mozilla\r\nX-Inyectado: si\ny mas",
+    });
+    expect(req.auditContext?.userAgent).toBe("Mozilla X-Inyectado: si y mas");
+  });
+
+  it("corta el user-agent a 200 caracteres", () => {
+    const { req } = run({ userAgent: "a".repeat(500) });
+    expect(req.auditContext?.userAgent).toHaveLength(200);
+  });
+
+  it("deja el user-agent en null si no viene", () => {
+    const { req } = run({});
+    expect(req.auditContext?.userAgent).toBeNull();
+  });
+
+  // `req.route` solo existe una vez express resolvió el handler, así que el
+  // patrón se captura en `finish`. Guardar la ruta concreta metería ids en un
+  // campo cuyo único uso es agrupar.
+  it("captura el PATRÓN de la ruta, no la ruta concreta", () => {
+    const { req } = run({
+      path: "/api/users/abc123/role",
+      routePath: "/api/users/:uid/role",
+    });
+    expect(req.auditContext?.route).toBe("/api/users/:uid/role");
+  });
+
+  it("cae a la ruta concreta cuando no hay handler resuelto", () => {
+    const { req } = run({ path: "/api/no-existe", status: 404 });
+    expect(req.auditContext?.route).toBe("/api/no-existe");
+  });
+});
+
+describe("red de seguridad", () => {
+  // Es lo que convierte "un handler se olvidó de auditar" en algo visible.
+  it("una mutación sin reclamar deja fila sintética", async () => {
+    run({ method: "POST", routePath: "/api/algo-nuevo", uid: "u1" });
+    await flush();
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatchObject({
+      action: "http.post./api/algo-nuevo",
+      performedBy: "u1",
+      synthesized: true,
+      // `warning`, no `info`: significa que hay código mutando sin decir qué.
+      severity: "warning",
+    });
+  });
+
+  // Sin esta comprobación, cada mutación bien auditada dejaría además una fila
+  // sintética: el doble de filas y la mitad de credibilidad.
+  it("NO duplica cuando el handler ya auditó", async () => {
+    run({ method: "POST", claimed: true, uid: "u1" });
+    await flush();
+    expect(written).toHaveLength(0);
+  });
+
+  it("no escribe nada para un GET", async () => {
+    run({ method: "GET", routePath: "/api/users" });
+    await flush();
+    expect(written).toHaveLength(0);
+  });
+
+  it.each(["POST", "PUT", "PATCH", "DELETE"])(
+    "cubre el método %s",
+    async (method) => {
+      written.length = 0;
+      run({ method, routePath: "/api/x", uid: "u1" });
+      await flush();
+      expect(written).toHaveLength(1);
+    }
+  );
+
+  // Un 4xx sin reclamar es casi siempre validación rechazando un cuerpo
+  // malformado. Escribirlo haría a cualquiera capaz de mandar basura dueño del
+  // volumen de la colección; la línea de log sí queda.
+  it("un 4xx sin reclamar solo va a Cloud Logging", async () => {
+    run({ method: "POST", status: 400, routePath: "/api/x", uid: "u1" });
+    await flush();
+    expect(written).toHaveLength(0);
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "audit.synthesized",
+      expect.objectContaining({ outcome: "denied", status: 400 })
+    );
+  });
+
+  it("un 500 sin reclamar tampoco escribe, pero se registra como failure", async () => {
+    run({ method: "POST", status: 500, routePath: "/api/x", uid: "u1" });
+    await flush();
+    expect(written).toHaveLength(0);
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "audit.synthesized",
+      expect.objectContaining({ outcome: "failure" })
+    );
+  });
+
+  // `finish` corre tras volcar la respuesta: el framework no espera nada async
+  // de ahí, así que la línea síncrona es lo único garantizado.
+  it("la línea de log se emite de forma síncrona, sin esperar a Firestore", () => {
+    run({ method: "POST", routePath: "/api/x", uid: "u1" });
+    // Sin `await flush()`: ya tiene que estar.
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "audit.synthesized",
+      expect.objectContaining({ action: "http.post./api/x" })
+    );
+  });
+
+  it("registra unknown si no hay usuario en la petición", async () => {
+    run({ method: "POST", routePath: "/api/x" });
+    await flush();
+    expect(written[0]).toMatchObject({ performedBy: "unknown" });
+  });
+});

--- a/functions/src/middleware/auditContext.ts
+++ b/functions/src/middleware/auditContext.ts
@@ -1,0 +1,146 @@
+import { Request, Response, NextFunction } from "express";
+import { randomUUID } from "node:crypto";
+import { logger } from "firebase-functions";
+import { writeAuditLog } from "../utils/audit";
+import { singleLineHeader } from "../utils/headers";
+import type { AuditContext } from "../utils/auditTypes";
+
+/**
+ * Trunca la dirección a su prefijo de red.
+ *
+ * Es todo lo que se guarda en Firestore. Con el prefijo se puede responder a
+ * "qué más hizo esta red", que es la pregunta útil al investigar un incidente,
+ * sin conservar un dato que señale a una persona concreta — y `audit_log` lo
+ * lee cualquiera con `audit:read`. La dirección completa existe solo en Cloud
+ * Logging, que tiene su propio control de acceso.
+ *
+ * /24 en IPv4 y /48 en IPv6: en IPv6 el /64 es una sola máquina y el /48 es la
+ * asignación típica de un sitio, así que /48 es el equivalente honesto al /24.
+ */
+export function truncateIp(ip: string | undefined): string | null {
+  if (!ip) return null;
+
+  // Detrás de un proxy, una IPv4 puede llegar mapeada a IPv6.
+  const unmapped = ip.startsWith("::ffff:") ? ip.slice(7) : ip;
+
+  if (unmapped.includes(".") && !unmapped.includes(":")) {
+    const octets = unmapped.split(".");
+    if (octets.length !== 4) return null;
+    return `${octets[0]}.${octets[1]}.${octets[2]}.0/24`;
+  }
+
+  if (unmapped.includes(":")) {
+    // `::` comprime ceros; expandirla entera no aporta nada aquí, porque los
+    // tres primeros grupos son justo lo que se conserva.
+    const groups = unmapped.split(":");
+    const prefix = groups.slice(0, 3).map((g) => g || "0");
+    return `${prefix.join(":")}::/48`;
+  }
+
+  return null;
+}
+
+/** Métodos que cambian estado. Los demás no generan fila de respaldo. */
+const MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/**
+ * Patrón de la ruta, no la ruta concreta.
+ *
+ * `req.route` solo está poblado una vez express ha resuelto el handler, así
+ * que esto se llama desde el hook `finish` y no a la entrada. Cuando no hay
+ * ruta resuelta (un 404, o un rechazo en un middleware anterior) se cae a
+ * `req.path`, que en ese caso es lo único que hay.
+ */
+function routePattern(req: Request): string {
+  const route = (req as { route?: { path?: string } }).route;
+  if (route?.path) {
+    // `req.baseUrl` es "" con este montaje, pero concatenarlo mantiene el
+    // patrón correcto si algún día las rutas cuelgan de un Router.
+    return `${req.baseUrl ?? ""}${route.path}`;
+  }
+  return req.path;
+}
+
+/**
+ * Captura el contexto de la petición y deja una red de seguridad.
+ *
+ * Va registrado ANTES del limitador de perímetro, para que un 429 también
+ * lleve su id de correlación: si alguien satura la API, lo que se quiere poder
+ * hacer es cruzar esas respuestas con lo que sí llegó a pasar.
+ */
+export function auditContext() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const context: AuditContext = {
+      requestId: randomUUID(),
+      method: req.method,
+      // Se rellena en el hook `finish`, cuando express ya resolvió la ruta.
+      route: req.path,
+      ipPrefix: truncateIp(req.ip),
+      userAgent: singleLineHeader(req.get("user-agent")) || null,
+    };
+    req.auditContext = context;
+
+    // Útil para que quien reporte un fallo pueda pegar el id, y para cruzar la
+    // respuesta con su línea de Cloud Logging.
+    res.setHeader("X-Request-Id", context.requestId);
+
+    res.on("finish", () => {
+      context.route = routePattern(req);
+
+      // Un handler que auditó lo suyo ya dijo qué pasó, con su targetId y sus
+      // detalles. No hay nada que añadir.
+      if (req.auditClaimed) return;
+
+      const mutating = MUTATING.has(req.method);
+      if (!mutating) return;
+
+      // Las lecturas sensibles se auditan de forma explícita y selectiva; un
+      // GET normal no genera fila. Auditar todos los GET daría una fila por
+      // vista de página y ahogaría el registro en ruido.
+      const status = res.statusCode;
+      const outcome =
+        status >= 500 ? "failure" : status >= 400 ? "denied" : "success";
+
+      // La línea de Cloud Logging se emite de forma SÍNCRONA. `finish` corre
+      // después de volcar la respuesta, así que el framework no espera nada
+      // async de aquí y la instancia puede congelarse antes de que termine una
+      // escritura a Firestore. El log siempre sale; la fila es best-effort.
+      const uid = (req as { user?: { uid?: string } }).user?.uid ?? "unknown";
+      const action = `http.${req.method.toLowerCase()}.${context.route}`;
+
+      logger.warn("audit.synthesized", {
+        action,
+        outcome,
+        status,
+        performedBy: uid,
+        requestId: context.requestId,
+        ip: req.ip ?? null,
+      });
+
+      // Solo las mutaciones que SALIERON BIEN dejan fila. Un 4xx sin reclamar
+      // es casi siempre validación rechazando un cuerpo malformado, y eso ya
+      // está en Cloud Logging: escribirlo en Firestore convertiría a cualquiera
+      // capaz de mandar basura en dueño del volumen de la colección.
+      if (outcome !== "success") return;
+
+      void writeAuditLog({
+        action,
+        performedBy: uid,
+        targetType: "http_request",
+        details: { status },
+        outcome,
+        // `warning`, no `info`: esta fila significa que hay código mutando
+        // cosas sin decir qué. Se resalta en el visor para que alguien lo
+        // arregle, no para que se normalice.
+        severity: "warning",
+        category: "operations",
+        synthesized: true,
+      }).catch(() => {
+        // `writeAuditLog` ya registró el fallo, y aquí no hay respuesta que
+        // devolver: la petición terminó hace rato.
+      });
+    });
+
+    next();
+  };
+}

--- a/functions/src/middleware/auth.test.ts
+++ b/functions/src/middleware/auth.test.ts
@@ -32,6 +32,19 @@ vi.mock("firebase-functions", () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
+/**
+ * Se captura la llamada en vez de dejar correr el registro real: lo que se
+ * comprueba aquí es que el middleware emita el EVENTO correcto en cada
+ * rechazo. Que ese evento acabe o no en Firestore según su nivel es decisión
+ * de `utils/securityAudit`, y tiene sus propios tests.
+ */
+const securityEvents: { event: string; uid?: string }[] = [];
+vi.mock("../utils/securityAudit", () => ({
+  recordSecurityEvent: (input: { event: string; uid?: string }) => {
+    securityEvents.push(input);
+  },
+}));
+
 import { requireAuth, requirePermission } from "./auth";
 import type { AuthenticatedRequest } from "./auth";
 
@@ -80,6 +93,7 @@ beforeEach(() => {
   verifyIdToken.mockResolvedValue({ uid: "u1", email: "u@x.com" });
   docs.clear();
   readPaths.length = 0;
+  securityEvents.length = 0;
 });
 
 describe("requirePermission — token", () => {
@@ -347,5 +361,78 @@ describe("requireAuth", () => {
     const next = vi.fn() as unknown as NextFunction;
     await requireAuth()(buildReq(), res, next);
     expect(readPaths).toEqual([]);
+  });
+});
+
+/**
+ * Cada rechazo del middleware tiene que dejar rastro. Antes solo la denegación
+ * de permiso emitía una línea de Cloud Logging, y las otras tres —token
+ * inválido, cuenta sin registrar, cuenta suspendida— no registraban nada en
+ * ningún sitio: quien revisaba el panel veía únicamente lo que salió bien.
+ */
+describe("eventos de seguridad", () => {
+  it("registra el token inválido", async () => {
+    verifyIdToken.mockRejectedValue(new Error("nope"));
+    await run(requirePermission("events:read"), buildReq());
+    expect(securityEvents).toEqual([
+      expect.objectContaining({ event: "security.auth.invalid_token" }),
+    ]);
+  });
+
+  // Falta la cabecera entera: no hay token que verificar, así que no es un
+  // intento de nada. Registrarlo sería ruido de cada sonda o preflight.
+  it("no registra evento cuando falta la cabecera", async () => {
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+    await requirePermission("events:read")(
+      { headers: {}, params: {}, path: "/api/test" } as unknown as Request,
+      res,
+      next
+    );
+    expect(res.__status).toBe(401);
+    expect(securityEvents).toEqual([]);
+  });
+
+  it("registra el token válido sin doc de usuario", async () => {
+    await run(requirePermission("events:read"), buildReq());
+    expect(securityEvents).toEqual([
+      expect.objectContaining({
+        event: "security.user.unregistered",
+        uid: "u1",
+      }),
+    ]);
+  });
+
+  // La señal más limpia que hay de una cuenta comprometida, o de alguien que ya
+  // no debería estar y sigue intentándolo con un token todavía vivo.
+  it("registra el acceso de una cuenta suspendida", async () => {
+    docs.set("users/u1", { role: "admin", status: "suspended" });
+    const { res } = await run(requirePermission("events:read"), buildReq());
+    expect(res.__status).toBe(403);
+    expect(securityEvents).toEqual([
+      expect.objectContaining({
+        event: "security.account.suspended_access",
+        uid: "u1",
+      }),
+    ]);
+  });
+
+  it("registra la denegación de permiso", async () => {
+    docs.set("users/u1", { role: "member", status: "active" });
+    const { res } = await run(requirePermission("users:read"), buildReq());
+    expect(res.__status).toBe(403);
+    expect(securityEvents).toEqual([
+      expect.objectContaining({
+        event: "security.permission.denied",
+        uid: "u1",
+      }),
+    ]);
+  });
+
+  it("una petición autorizada no genera ningún evento", async () => {
+    docs.set("users/u1", { role: "admin", status: "active" });
+    const { passed } = await run(requirePermission("users:read"), buildReq());
+    expect(passed).toBe(true);
+    expect(securityEvents).toEqual([]);
   });
 });

--- a/functions/src/middleware/auth.ts
+++ b/functions/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import * as admin from "firebase-admin";
 import { logger } from "firebase-functions";
+import { recordSecurityEvent } from "../utils/securityAudit";
 import {
   GLOBAL_SCOPE,
   effectivePermissions,
@@ -77,6 +78,14 @@ async function verifyBearer(
       photoURL: decoded.picture || "",
     };
   } catch {
+    // Solo a Cloud Logging, nunca a `audit_log`: ver el nivel `log-only` en
+    // utils/securityAudit.ts. Hasta ahora esto no se registraba en NINGÚN
+    // sitio, así que un intento de adivinar tokens no dejaba el menor rastro.
+    recordSecurityEvent({
+      event: "security.auth.invalid_token",
+      details: { hadHeader: true },
+      req,
+    });
     res.status(401).json({ success: false, error: "Invalid token" });
     return null;
   }
@@ -161,6 +170,12 @@ export function requirePermission(
         .get();
 
       if (!userDoc.exists) {
+        recordSecurityEvent({
+          event: "security.user.unregistered",
+          uid: token.uid,
+          details: { permission, scope },
+          req,
+        });
         res.status(403).json({ success: false, error: "User not registered" });
         return;
       }
@@ -173,6 +188,17 @@ export function requirePermission(
       }
 
       if (data.status === "suspended") {
+        // `critical`: una cuenta suspendida con un token todavía válido
+        // intentando operar es la señal más limpia que hay de una cuenta
+        // comprometida, o de alguien que ya no debería estar y sigue
+        // probando. Provocarlo exige poseer una cuenta suspendida, así que no
+        // hay volumen que temer y se escribe siempre.
+        recordSecurityEvent({
+          event: "security.account.suspended_access",
+          uid: token.uid,
+          details: { role: data.role, permission, scope },
+          req,
+        });
         res.status(403).json({ success: false, error: "Account suspended" });
         return;
       }
@@ -200,12 +226,14 @@ export function requirePermission(
       }
 
       if (!permissions.has(permission)) {
-        logger.warn("Permiso denegado", {
+        // Esta era la señal más relevante del sistema y solo existía como una
+        // línea de Cloud Logging: quien revisaba el panel veía únicamente lo
+        // que había salido bien, nunca a alguien tanteando qué podía tocar.
+        recordSecurityEvent({
+          event: "security.permission.denied",
           uid: token.uid,
-          role: data.role,
-          permission,
-          scope,
-          path: req.path,
+          details: { role: data.role, permission, scope },
+          req,
         });
         res
           .status(403)

--- a/functions/src/utils/headers.ts
+++ b/functions/src/utils/headers.ts
@@ -1,0 +1,23 @@
+/**
+ * Colapsa el valor de una cabecera a una sola línea acotada y sin caracteres
+ * de control.
+ *
+ * Vivía dentro de `handlers/credentials.ts`, que lo aplica al user-agent que
+ * guarda como prueba de consentimiento. Al empezar a guardar el user-agent
+ * también en el registro de auditoría hacía falta en dos sitios, y una segunda
+ * copia de un saneador es como se acaba con dos que divergen: el día que a uno
+ * le añaden un caracter a filtrar, el otro sigue dejándolo pasar.
+ *
+ * Lo que evita: el valor es controlado por quien llama y acaba renderizado en
+ * el panel. Sin colapsar CRLF, una cabecera con saltos de línea puede fingir
+ * varias entradas dentro de una, que es inyección de log — el registro deja de
+ * ser fiable justo cuando hace falta leerlo.
+ */
+export function singleLineHeader(value: string | undefined): string {
+  if (!value) return "";
+  return value
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}

--- a/functions/src/utils/securityAudit.test.ts
+++ b/functions/src/utils/securityAudit.test.ts
@@ -1,0 +1,342 @@
+import type { Request } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const written: Record<string, unknown>[] = [];
+
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("firebase-functions", () => ({ logger: loggerMock }));
+
+vi.mock("firebase-admin", () => ({
+  firestore: () => ({
+    collection: () => ({
+      doc: () => ({ __path: "audit_log/gen" }),
+      add: async (data: Record<string, unknown>) => {
+        written.push(data);
+        return { id: "gen" };
+      },
+    }),
+  }),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  FieldValue: { serverTimestamp: () => "__TS__" },
+}));
+
+import {
+  __resetSecurityAuditState,
+  recordSecurityEvent,
+  SECURITY_EVENTS,
+} from "./securityAudit";
+
+function buildReq(ipPrefix = "181.65.42.0/24"): Request {
+  return {
+    ip: "181.65.42.117",
+    path: "/api/users",
+    auditContext: {
+      requestId: "req-1",
+      method: "GET",
+      route: "/api/users",
+      ipPrefix,
+      userAgent: "Mozilla/5.0",
+    },
+  } as unknown as Request;
+}
+
+/** `writeAuditLog` se llama sin await a propósito; hay que dejar correr la cola. */
+const flush = () => new Promise((r) => setImmediate(r));
+
+beforeEach(() => {
+  written.length = 0;
+  __resetSecurityAuditState();
+  loggerMock.info.mockReset();
+  loggerMock.warn.mockReset();
+  loggerMock.error.mockReset();
+});
+
+describe("nivel log-only", () => {
+  // Un token caducado lo produce cualquier pestaña abierta más de una hora, y
+  // provocarlo no requiere cuenta: en Firestore sería ruido indistinguible de
+  // un ataque Y un amplificador de una petición a una escritura.
+  it("el token inválido NUNCA llega a Firestore", async () => {
+    for (let i = 0; i < 50; i++) {
+      recordSecurityEvent({
+        event: "security.auth.invalid_token",
+        req: buildReq(),
+      });
+    }
+    await flush();
+    expect(written).toHaveLength(0);
+  });
+
+  it("pero sí deja línea de log, que antes no existía", async () => {
+    recordSecurityEvent({
+      event: "security.auth.invalid_token",
+      req: buildReq(),
+    });
+    await flush();
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "security.auth.invalid_token",
+      expect.objectContaining({ requestId: "req-1" })
+    );
+  });
+
+  it("App Check ausente tampoco llega a Firestore", async () => {
+    recordSecurityEvent({
+      event: "security.appcheck.missing",
+      details: { hadToken: false },
+      req: buildReq(),
+    });
+    await flush();
+    expect(written).toHaveLength(0);
+    expect(loggerMock.warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("nivel always", () => {
+  it("la denegación de permiso escribe siempre", async () => {
+    recordSecurityEvent({
+      event: "security.permission.denied",
+      uid: "u1",
+      details: { permission: "users:read", role: "member" },
+      req: buildReq(),
+    });
+    await flush();
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatchObject({
+      action: "security.permission.denied",
+      performedBy: "u1",
+      category: "security",
+      outcome: "denied",
+      severity: "warning",
+    });
+  });
+
+  // Provocarlo exige poseer una cuenta suspendida, así que no hay volumen que
+  // temer, y es la señal más limpia de una cuenta comprometida.
+  it("la cuenta suspendida es critical", async () => {
+    recordSecurityEvent({
+      event: "security.account.suspended_access",
+      uid: "u2",
+      req: buildReq(),
+    });
+    await flush();
+    expect(written[0]).toMatchObject({ severity: "critical" });
+  });
+
+  it("no agrupa: cinco intentos dejan cinco filas", async () => {
+    for (let i = 0; i < 5; i++) {
+      recordSecurityEvent({
+        event: "security.invitation.redeem_failed",
+        uid: "u1",
+        details: { reason: "no_match" },
+        req: buildReq(),
+      });
+    }
+    await flush();
+    expect(written).toHaveLength(5);
+  });
+
+  // El motivo real se guarda aunque la respuesta HTTP sea siempre idéntica:
+  // solo lo ve quien tiene `audit:read`, así que no filtra nada.
+  it("guarda el motivo discriminado del canje fallido", async () => {
+    recordSecurityEvent({
+      event: "security.invitation.redeem_failed",
+      uid: "u1",
+      details: { reason: "revoked", invitationId: "inv-1" },
+      req: buildReq(),
+    });
+    await flush();
+    expect(written[0].details).toMatchObject({
+      reason: "revoked",
+      invitationId: "inv-1",
+    });
+  });
+
+  it("guarda el prefijo de red, no la dirección", async () => {
+    recordSecurityEvent({
+      event: "security.permission.denied",
+      uid: "u1",
+      req: buildReq(),
+    });
+    await flush();
+    expect(written[0].details).toMatchObject({ ipPrefix: "181.65.42.0/24" });
+    expect(JSON.stringify(written[0])).not.toContain("181.65.42.117");
+    // La completa sí va a Cloud Logging.
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "security.permission.denied",
+      expect.objectContaining({ ip: "181.65.42.117" })
+    );
+  });
+});
+
+describe("nivel rollup", () => {
+  // Un sondeo único tiene que verse en segundos: es el sentido de un cable
+  // trampa. Agrupar desde la primera lo haría invisible durante un minuto.
+  it("la primera aparición escribe de inmediato", async () => {
+    recordSecurityEvent({
+      event: "security.user.unregistered",
+      uid: "u1",
+      req: buildReq(),
+    });
+    await flush();
+    expect(written).toHaveLength(1);
+  });
+
+  it("las repeticiones dentro de la ventana solo cuentan", async () => {
+    for (let i = 0; i < 30; i++) {
+      recordSecurityEvent({
+        event: "security.user.unregistered",
+        uid: "u1",
+        req: buildReq(),
+      });
+    }
+    await flush();
+    expect(written).toHaveLength(1);
+  });
+
+  it("separa por red: dos redes distintas son dos filas", async () => {
+    recordSecurityEvent({
+      event: "security.ratelimit.exceeded",
+      req: buildReq("10.0.0.0/24"),
+    });
+    recordSecurityEvent({
+      event: "security.ratelimit.exceeded",
+      req: buildReq("192.168.1.0/24"),
+    });
+    await flush();
+    expect(written).toHaveLength(2);
+  });
+
+  // Sin arrastrar el contador, "pasó 400 veces" se leería como "pasó una vez".
+  it("pasada la ventana, arrastra el recuento de la anterior", async () => {
+    vi.useFakeTimers();
+    try {
+      recordSecurityEvent({
+        event: "security.user.unregistered",
+        uid: "u1",
+        req: buildReq(),
+      });
+      for (let i = 0; i < 9; i++) {
+        recordSecurityEvent({
+          event: "security.user.unregistered",
+          uid: "u1",
+          req: buildReq(),
+        });
+      }
+      vi.advanceTimersByTime(61_000);
+      recordSecurityEvent({
+        event: "security.user.unregistered",
+        uid: "u1",
+        req: buildReq(),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    await flush();
+    expect(written).toHaveLength(2);
+    expect(written[1].details).toMatchObject({ previousWindowCount: 10 });
+  });
+});
+
+describe("presupuesto", () => {
+  // Un registro truncado sin aviso se lee como "no pasó nada más", que es la
+  // conclusión contraria a la verdad.
+  it("al agotarse avisa una sola vez y deja de escribir", async () => {
+    // 30 es el techo por instancia y minuto; se piden 60 con claves distintas
+    // para que el rollup no las agrupe.
+    for (let i = 0; i < 60; i++) {
+      recordSecurityEvent({
+        event: "security.permission.denied",
+        uid: `u${i}`,
+        req: buildReq(),
+      });
+    }
+    await flush();
+
+    const throttled = written.filter(
+      (w) => w.action === "security.audit.throttled"
+    );
+    const denials = written.filter(
+      (w) => w.action === "security.permission.denied"
+    );
+
+    expect(denials).toHaveLength(30);
+    expect(throttled).toHaveLength(1);
+    expect(throttled[0]).toMatchObject({
+      severity: "critical",
+      performedBy: "system",
+    });
+  });
+
+  it("Cloud Logging sigue recibiendo TODO aunque Firestore se corte", async () => {
+    for (let i = 0; i < 60; i++) {
+      recordSecurityEvent({
+        event: "security.permission.denied",
+        uid: `u${i}`,
+        req: buildReq(),
+      });
+    }
+    await flush();
+    // El registro completo vive en Cloud Logging; Firestore es el subconjunto
+    // revisable. Esa asimetría es el diseño, no una carencia.
+    const denialLogs = loggerMock.warn.mock.calls.filter(
+      (c) => c[0] === "security.permission.denied"
+    );
+    expect(denialLogs).toHaveLength(60);
+  });
+
+  it("el presupuesto se reinicia al rodar la ventana", async () => {
+    vi.useFakeTimers();
+    try {
+      for (let i = 0; i < 60; i++) {
+        recordSecurityEvent({
+          event: "security.permission.denied",
+          uid: `u${i}`,
+          req: buildReq(),
+        });
+      }
+      vi.advanceTimersByTime(61_000);
+      recordSecurityEvent({
+        event: "security.permission.denied",
+        uid: "despues",
+        req: buildReq(),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    await flush();
+    expect(written.filter((w) => w.performedBy === "despues")).toHaveLength(1);
+  });
+});
+
+describe("catálogo de eventos", () => {
+  // El nivel de cada evento es una decisión de seguridad, no un detalle: subir
+  // uno a `always` por descuido abre un amplificador para quien no tiene cuenta.
+  it("los eventos que cualquiera puede provocar sin cuenta son log-only", () => {
+    expect(SECURITY_EVENTS["security.auth.invalid_token"].tier).toBe(
+      "log-only"
+    );
+    expect(SECURITY_EVENTS["security.appcheck.missing"].tier).toBe("log-only");
+  });
+
+  it("los que exigen identidad autenticada escriben siempre", () => {
+    expect(SECURITY_EVENTS["security.permission.denied"].tier).toBe("always");
+    expect(SECURITY_EVENTS["security.account.suspended_access"].tier).toBe(
+      "always"
+    );
+    expect(SECURITY_EVENTS["security.invitation.redeem_failed"].tier).toBe(
+      "always"
+    );
+  });
+
+  it("nunca lanza, ni sin req ni sin uid", () => {
+    expect(() =>
+      recordSecurityEvent({ event: "security.permission.denied" })
+    ).not.toThrow();
+  });
+});

--- a/functions/src/utils/securityAudit.ts
+++ b/functions/src/utils/securityAudit.ts
@@ -1,0 +1,250 @@
+import type { Request } from "express";
+import { logger } from "firebase-functions";
+import { writeAuditLog } from "./audit";
+import type { AuditSeverity } from "./auditTypes";
+
+/**
+ * Eventos de seguridad: denegaciones, canjes fallidos, cuentas suspendidas
+ * intentando entrar.
+ *
+ * El diseño en una frase: **Cloud Logging es el registro completo; Firestore es
+ * el subconjunto revisable.** Todo evento emite siempre su línea de log —sin
+ * límite, sin coste por escritura— y solo una parte acotada llega a la
+ * colección que el panel enseña.
+ *
+ * Hace falta esa asimetría porque los eventos NO cuestan lo mismo de provocar.
+ * Un token inválido lo genera cualquiera sin cuenta y sin coste; una denegación
+ * de permiso exige una cuenta registrada. Escribir en Firestore los del primer
+ * grupo le regalaría a un atacante no autenticado un amplificador de una
+ * petición a una escritura, y el registro quedaría ahogado en ruido justo
+ * cuando hiciera falta leerlo.
+ */
+
+/**
+ * - `log-only`: nunca toca Firestore. Provocarlo es gratis y no requiere
+ *   cuenta.
+ * - `always`: escribe siempre. Requiere una identidad autenticada y ya va
+ *   detrás de un limitador, así que está acotado por construcción.
+ * - `rollup`: la primera aparición escribe, las siguientes de la misma clave
+ *   dentro de la ventana solo cuentan.
+ */
+export type SecurityTier = "log-only" | "always" | "rollup";
+
+export interface SecurityEventSpec {
+  tier: SecurityTier;
+  severity: AuditSeverity;
+}
+
+export const SECURITY_EVENTS = {
+  /**
+   * Token ausente, caducado o inválido.
+   *
+   * `log-only` y no es una omisión: los ID tokens de Firebase caducan cada
+   * hora, así que una pestaña del panel abierta toda la noche produce una
+   * ráfaga de 401 al despertar. En Firestore eso sería ruido indistinguible de
+   * un ataque, y además lo puede provocar cualquiera sin cuenta. Antes no se
+   * registraba en ningún sitio; ahora al menos queda la línea de log.
+   */
+  "security.auth.invalid_token": { tier: "log-only", severity: "notice" },
+
+  /** App Check ausente o inválido. Endpoints públicos: provocarlo es gratis. */
+  "security.appcheck.missing": { tier: "log-only", severity: "notice" },
+
+  /**
+   * Permiso denegado a una cuenta registrada. Exige tener cuenta, así que está
+   * acotado y es la señal principal de alguien tanteando qué puede tocar.
+   */
+  "security.permission.denied": { tier: "always", severity: "warning" },
+
+  /**
+   * Una cuenta suspendida con un token todavía válido intentando operar.
+   *
+   * `critical`: es la señal más limpia que hay de una cuenta comprometida o de
+   * alguien que ya no debería estar y sigue intentándolo. Provocarlo exige
+   * poseer una cuenta suspendida, así que no hay volumen que temer.
+   */
+  "security.account.suspended_access": { tier: "always", severity: "critical" },
+
+  /**
+   * Canje de invitación fallido. El cable trampa contra un enlace robado o
+   * reenviado.
+   *
+   * Antes no dejaba rastro en ningún sitio: adivinar tokens era completamente
+   * invisible. Exige correo verificado y va detrás de `accessLimiter`
+   * (5/hora/IP), así que quien lo intente consigue cinco filas por hora — está
+   * acotado por diseño y no necesita rollup.
+   */
+  "security.invitation.redeem_failed": { tier: "always", severity: "warning" },
+
+  /** Token válido pero sin doc de usuario. Un token anónimo sale gratis. */
+  "security.user.unregistered": { tier: "rollup", severity: "notice" },
+
+  /** Limitador de tasa agotado. Provocarlo es gratis por definición. */
+  "security.ratelimit.exceeded": { tier: "rollup", severity: "warning" },
+} as const satisfies Record<string, SecurityEventSpec>;
+
+export type SecurityEvent = keyof typeof SECURITY_EVENTS;
+
+const WINDOW_MS = 60_000;
+
+/**
+ * Techo de escrituras de seguridad por instancia y minuto.
+ *
+ * Con `maxInstances: 10` el techo real son 300/min. El contador es por
+ * instancia, igual que los seis limitadores de tasa que ya existen: un
+ * contador compartido en Firestore costaría una lectura y una escritura por
+ * denegación, que es precisamente la amplificación que esto evita.
+ */
+const BUDGET_PER_WINDOW = 30;
+
+interface Bucket {
+  count: number;
+  firstAt: number;
+  windowStart: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+let spent = 0;
+let budgetWindowStart = 0;
+let suppressed = 0;
+
+/** Solo para los tests: reinicia el estado en memoria. */
+export function __resetSecurityAuditState(): void {
+  buckets.clear();
+  spent = 0;
+  budgetWindowStart = 0;
+  suppressed = 0;
+}
+
+/**
+ * `true` si queda presupuesto. Al agotarse, escribe UNA fila avisando de que
+ * se está suprimiendo y deja de escribir hasta que rueda la ventana: sin ese
+ * aviso, un registro truncado se leería como "no pasó nada más".
+ */
+function withinBudget(nowMs: number): boolean {
+  if (nowMs - budgetWindowStart >= WINDOW_MS) {
+    budgetWindowStart = nowMs;
+    spent = 0;
+    suppressed = 0;
+  }
+
+  if (spent < BUDGET_PER_WINDOW) {
+    spent += 1;
+    return true;
+  }
+
+  suppressed += 1;
+  if (suppressed === 1) {
+    void writeAuditLog({
+      action: "security.audit.throttled",
+      performedBy: "system",
+      targetType: "security",
+      details: { budget: BUDGET_PER_WINDOW, windowMs: WINDOW_MS },
+      outcome: "failure",
+      severity: "critical",
+      category: "security",
+    }).catch(() => {});
+  }
+  return false;
+}
+
+export interface SecurityAuditInput {
+  event: SecurityEvent;
+  /** Uid cuando se conoce; `anonymous` cuando el token no se pudo verificar. */
+  uid?: string;
+  /** Detalles del evento. Nunca el token, ni el motivo visible para quien llama. */
+  details?: Record<string, unknown>;
+  req?: Request;
+}
+
+/**
+ * Registra un evento de seguridad según su nivel.
+ *
+ * Nunca lanza y nunca se espera: si esto fallara, no debe tumbar la respuesta
+ * de seguridad que lo motivó (un 403 tiene que salir igual).
+ */
+export function recordSecurityEvent(input: SecurityAuditInput): void {
+  const { event, uid, details, req } = input;
+  const spec: SecurityEventSpec = SECURITY_EVENTS[event];
+  const nowMs = Date.now();
+  const performedBy = uid ?? "anonymous";
+  const ipPrefix = req?.auditContext?.ipPrefix ?? null;
+
+  // Siempre, para todos los niveles, sin condiciones. Es el registro completo.
+  logger.warn(event, {
+    ...details,
+    performedBy,
+    severity: spec.severity,
+    requestId: req?.auditContext?.requestId,
+    route: req?.auditContext?.route ?? req?.path,
+    ip: req?.ip ?? null,
+  });
+
+  if (spec.tier === "log-only") return;
+
+  if (spec.tier === "rollup") {
+    const key = `${event}:${ipPrefix ?? "-"}:${performedBy}`;
+    const bucket = buckets.get(key);
+
+    if (bucket && nowMs - bucket.windowStart < WINDOW_MS) {
+      // Dentro de la ventana: solo cuenta. El volcado ocurre en la siguiente
+      // aparición pasada la ventana. Una evicción puede perder un rollup
+      // pendiente y se acepta: la fila de la primera aparición ya existe y
+      // Cloud Logging tiene todas. Un scheduler para volcarlo costaría más
+      // complejidad de la que vale un contador.
+      bucket.count += 1;
+      return;
+    }
+
+    const carried = bucket
+      ? { count: bucket.count, firstAt: bucket.firstAt }
+      : null;
+    buckets.set(key, { count: 1, firstAt: nowMs, windowStart: nowMs });
+
+    if (!withinBudget(nowMs)) return;
+
+    void writeAuditLog(
+      {
+        action: event,
+        performedBy,
+        targetType: "security",
+        details: {
+          ...details,
+          ipPrefix,
+          // La primera aparición escribe de inmediato: un sondeo único tiene
+          // que verse en segundos, que es el sentido de un cable trampa. Si la
+          // ventana anterior acumuló repeticiones, viajan aquí en vez de
+          // perderse — es la diferencia entre "pasó una vez" y "pasó 400
+          // veces y solo se ve la primera".
+          ...(carried && carried.count > 1
+            ? {
+                previousWindowCount: carried.count,
+                previousWindowFirstAt: new Date(carried.firstAt).toISOString(),
+              }
+            : {}),
+        },
+        outcome: "denied",
+        severity: spec.severity,
+        category: "security",
+      },
+      req
+    ).catch(() => {});
+    return;
+  }
+
+  if (!withinBudget(nowMs)) return;
+
+  void writeAuditLog(
+    {
+      action: event,
+      performedBy,
+      targetType: "security",
+      details: { ...details, ipPrefix },
+      outcome: "denied",
+      severity: spec.severity,
+      category: "security",
+    },
+    req
+  ).catch(() => {});
+}


### PR DESCRIPTION
## What changed

**Request context** (`middleware/auditContext.ts`). Every entry now carries a correlation id, the route *pattern*, the sanitised user-agent and a truncated network prefix. Registered before the perimeter rate limiter so a 429 carries its id too. IPv4 is truncated to /24 and IPv6 to /48; the full address goes only to Cloud Logging. The header sanitiser moved out of `handlers/credentials.ts` into `utils/headers.ts` rather than being copied a second time.

**Security events** (`utils/securityAudit.ts`), in three tiers, because the events do not cost the same to provoke:

| Tier | Events | To Firestore? |
| --- | --- | --- |
| `log-only` | invalid token, missing App Check | never |
| `rollup` | unregistered user, rate-limit 429 | first occurrence, then counted |
| `always` | permission denied, suspended-account access, failed invitation redemption | every time |

**The six unaudited mutations**: `POST /api/auth/register` (creation branch only), the access request itself, `POST /api/rebuild`, proposal create/update, and the credential image upload. Also fixed: `access.invitation.create` used to be recorded *before* the email send, so the log claimed an invitation existed while the person never got the link.

**A safety net plus a coverage test.** `res.on("finish")` writes a `synthesized: true` row when a mutating request succeeded and no handler claimed it. `index.routes.test.ts` walks Express's real route table and fails CI if a mutating route is not explicitly classified.

## Why

The failed invitation redemption left **no trace anywhere** — not a row, not a log line. That is the surface an invitation link gets stolen through, and it was completely invisible. It now records the real reason (`no_match`, `expired`, `revoked`, `already_used`, `race_already_used`) while the HTTP response stays byte-identical in all five cases, which is what stops the endpoint being used as an oracle for other people's invitations.

Permission denials and suspended-account access existed only as Cloud Logging lines, so the panel showed only what succeeded — and a log that records just the successes is no use for investigating abuse. What gives someone away is the burst of denied attempts.

## Two deliberate non-obvious choices

**Invalid tokens go to Cloud Logging only, never Firestore.** This looks like a gap and isn't. Firebase ID tokens expire hourly, so one admin with a tab open overnight produces a burst of 401s on wake — noise indistinguishable from an attack. And provoking it needs no account at all, so storing it would hand an unauthenticated caller a one-request-to-one-write amplifier. There was previously not even a log line, so this is still an improvement.

**A 4xx with no handler claim writes no row either.** An unclaimed 400 is nearly always validation rejecting a malformed body. Storing those would make anyone capable of sending garbage the owner of the collection's volume. The log line still happens.

## How to test

```bash
cd functions && pnpm build && pnpm test   # 633 tests at this commit
```

By hand against the emulator:

1. Redeem an invitation with an invented token → `security.invitation.redeem_failed` with the real reason in the audit row, while the HTTP body stays the same opaque message.
2. Have a `member` call `/api/users` → `security.permission.denied`, severity `warning`.
3. Flood `accessLimiter` (6 requests in an hour from one IP) → rollup rows, not one per request.
4. Add a `POST` route that does not audit, call it, confirm a `synthesized: true` row appears, then confirm `pnpm test` fails on the route manifest. Remove the route.

The manifest test was verified to fail in both directions — an unclassified route and a stale entry — so it is not passing vacuously.

## Notes for the reviewer

- The security write budget is 30/min **per instance**, same as the six existing rate limiters. A shared Firestore counter would cost a read and a write per denial, reintroducing the amplification this avoids. With `maxInstances: 10` from the previous PR the real ceiling is 300/min.
- The duplicate-bingo-claim "gap" was left alone on purpose: it is a reconnect replaying the claim, routine on venue wifi.
- Files are shared across the three themes (`index.ts`, `access.ts`, `credentials.ts`), so this is one commit rather than three. There is no independently revertible behaviour change here — it is all additive instrumentation.