### PR TITLE
refactor(audit): close the action union and sweep the call sites

### DIFF
--- a/functions/src/handlers/access.ts
+++ b/functions/src/handlers/access.ts
@@ -532,14 +532,16 @@ export async function revokeInvitation(req: Request, res: Response) {
 
     await ref.update({ revokedAt: FieldValue.serverTimestamp() });
 
-    await writeAuditLog({
-      action: "access.invitation.revoke",
-      performedBy: performer.uid,
-      targetId: id,
-      targetType: "invitation",
-      details: {},
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "access.invitation.revoke",
+        performedBy: performer.uid,
+        targetId: id,
+        targetType: "invitation",
+        details: {},
+      },
+      req
+    );
 
     res.json({ success: true });
   } catch (err) {

--- a/functions/src/handlers/certificates.ts
+++ b/functions/src/handlers/certificates.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { logger } from "firebase-functions";
 import { AuthenticatedRequest } from "../middleware/auth";
@@ -92,14 +91,16 @@ export async function sendCertificates(req: Request, res: Response) {
     const sent = results.filter((r) => r.ok).length;
     const failed = results.length - sent;
 
-    await writeAuditLog({
-      action: "certificate.send",
-      performedBy: user.uid,
-      targetId: body.eventName,
-      targetType: "certificate",
-      details: { eventName: body.eventName, sent, failed },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "certificate.send",
+        performedBy: user.uid,
+        targetId: body.eventName,
+        targetType: "certificate",
+        details: { eventName: body.eventName, sent, failed },
+      },
+      req
+    );
 
     res.json({
       success: true,

--- a/functions/src/handlers/checkin.ts
+++ b/functions/src/handlers/checkin.ts
@@ -48,7 +48,9 @@ export async function importRoster(req: Request, res: Response) {
     const rawRows = (req.body.rows ?? []) as RosterRow[];
 
     if (rawRows.length === 0) {
-      res.status(400).json({ success: false, error: "No hay filas que importar" });
+      res
+        .status(400)
+        .json({ success: false, error: "No hay filas que importar" });
       return;
     }
 
@@ -156,21 +158,23 @@ export async function importRoster(req: Request, res: Response) {
       { merge: true }
     );
 
-    await writeAuditLog({
-      action: "checkin.import",
-      performedBy: user.uid,
-      targetId: slug,
-      targetType: "checkin_roster",
-      details: {
-        importId,
-        total: rows.length,
-        created,
-        updated,
-        stale,
-        unusableTickets,
+    await writeAuditLog(
+      {
+        action: "checkin.import",
+        performedBy: user.uid,
+        targetId: slug,
+        targetType: "checkin_roster",
+        details: {
+          importId,
+          total: rows.length,
+          created,
+          updated,
+          stale,
+          unusableTickets,
+        },
       },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+      req
+    );
 
     res.json({
       success: true,

--- a/functions/src/handlers/credentials.ts
+++ b/functions/src/handlers/credentials.ts
@@ -233,20 +233,22 @@ export async function createCredential(req: Request, res: Response) {
     // No DNI, name or email in the audit details: audit_log is readable by
     // a different set of eyes than the credentials collection, and the
     // document id is enough to trace the record.
-    await writeAuditLog({
-      action: "credential.create",
-      performedBy: user.uid,
-      targetId: credentialRef.id,
-      targetType: "credential",
-      details: {
-        eventSlug: slug,
-        sequenceNumber,
-        groupLetter,
-        avatarKind: body.avatarKind,
-        hasPhoto: Boolean(photo),
+    await writeAuditLog(
+      {
+        action: "credential.create",
+        performedBy: user.uid,
+        targetId: credentialRef.id,
+        targetType: "credential",
+        details: {
+          eventSlug: slug,
+          sequenceNumber,
+          groupLetter,
+          avatarKind: body.avatarKind,
+          hasPhoto: Boolean(photo),
+        },
       },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+      req
+    );
 
     res.json({
       success: true,
@@ -415,14 +417,16 @@ export async function setBevyStatus(req: Request, res: Response) {
       updatedAt: FieldValue.serverTimestamp(),
     });
 
-    await writeAuditLog({
-      action: "credential.bevy_status",
-      performedBy: user.uid,
-      targetId: id,
-      targetType: "credential",
-      details: { eventSlug: slug, status: body.status },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "credential.bevy_status",
+        performedBy: user.uid,
+        targetId: id,
+        targetType: "credential",
+        details: { eventSlug: slug, status: body.status },
+      },
+      req
+    );
 
     res.json({ success: true, data: { id, status: body.status } });
   } catch (err) {
@@ -490,14 +494,16 @@ export async function moderatePhoto(req: Request, res: Response) {
       });
     }
 
-    await writeAuditLog({
-      action: "credential.moderate_photo",
-      performedBy: user.uid,
-      targetId: id,
-      targetType: "credential",
-      details: { eventSlug: slug, action: body.action },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "credential.moderate_photo",
+        performedBy: user.uid,
+        targetId: id,
+        targetType: "credential",
+        details: { eventSlug: slug, action: body.action },
+      },
+      req
+    );
 
     res.json({ success: true, data: { id, action: body.action } });
   } catch (err) {
@@ -543,14 +549,16 @@ export async function retryEmail(req: Request, res: Response) {
       updatedAt: FieldValue.serverTimestamp(),
     });
 
-    await writeAuditLog({
-      action: "credential.email_retry",
-      performedBy: user.uid,
-      targetId: id,
-      targetType: "credential",
-      details: { eventSlug: slug },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "credential.email_retry",
+        performedBy: user.uid,
+        targetId: id,
+        targetType: "credential",
+        details: { eventSlug: slug },
+      },
+      req
+    );
 
     res.json({ success: true, data: { id } });
   } catch (err) {
@@ -630,14 +638,20 @@ export async function sendReminders(req: Request, res: Response) {
       await batch.commit();
     }
 
-    await writeAuditLog({
-      action: "credential.reminders",
-      performedBy: user.uid,
-      targetId: slug,
-      targetType: "event",
-      details: { requested: ids.length, queued, skipped: ids.length - queued },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "credential.reminders",
+        performedBy: user.uid,
+        targetId: slug,
+        targetType: "event",
+        details: {
+          requested: ids.length,
+          queued,
+          skipped: ids.length - queued,
+        },
+      },
+      req
+    );
 
     res.json({
       success: true,
@@ -737,21 +751,23 @@ export async function reconcileCredentials(req: Request, res: Response) {
       await batch.commit();
     }
 
-    await writeAuditLog({
-      action: "credential.reconcile",
-      performedBy: user.uid,
-      targetId: slug,
-      targetType: "event",
-      details: {
-        credentials: credentials.length,
-        roster: attendees.length,
-        matched: result.matches.length,
-        unmatchedCredentials: result.unmatchedCredentialIds.length,
-        unmatchedRoster: result.unmatchedAttendeeIds.length,
-        ambiguous: result.ambiguousEmails.length,
+    await writeAuditLog(
+      {
+        action: "credential.reconcile",
+        performedBy: user.uid,
+        targetId: slug,
+        targetType: "event",
+        details: {
+          credentials: credentials.length,
+          roster: attendees.length,
+          matched: result.matches.length,
+          unmatchedCredentials: result.unmatchedCredentialIds.length,
+          unmatchedRoster: result.unmatchedAttendeeIds.length,
+          ambiguous: result.ambiguousEmails.length,
+        },
       },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+      req
+    );
 
     res.json({
       success: true,

--- a/functions/src/handlers/emailSettings.ts
+++ b/functions/src/handlers/emailSettings.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -62,14 +61,16 @@ export async function setEmailSettings(req: Request, res: Response) {
 
     await writeEmailTransport(transport, user.uid);
 
-    await writeAuditLog({
-      action: "settings.email_transport",
-      performedBy: user.uid,
-      targetId: "email",
-      targetType: "settings",
-      details: { transport },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "settings.email_transport",
+        performedBy: user.uid,
+        targetId: "email",
+        targetType: "settings",
+        details: { transport },
+      },
+      req
+    );
 
     res.json({
       success: true,

--- a/functions/src/handlers/events.ts
+++ b/functions/src/handlers/events.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import {
@@ -90,14 +89,16 @@ export async function createEvent(req: Request, res: Response) {
     triggerRebuildAndLog(github);
 
     // Audit log
-    await writeAuditLog({
-      action: "event.create",
-      performedBy: user.uid,
-      targetId: event.id,
-      targetType: "event",
-      details: { title: event.title },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "event.create",
+        performedBy: user.uid,
+        targetId: event.id,
+        targetType: "event",
+        details: { title: event.title },
+      },
+      req
+    );
 
     res.status(201).json({ success: true, data: { id: event.id } });
   } catch (err) {
@@ -146,14 +147,16 @@ export async function updateEvent(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "event.update",
-      performedBy: user.uid,
-      targetId: eventId,
-      targetType: "event",
-      details: { title: event.title },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "event.update",
+        performedBy: user.uid,
+        targetId: eventId,
+        targetType: "event",
+        details: { title: event.title },
+      },
+      req
+    );
 
     res.json({ success: true, data: { id: eventId } });
   } catch (err) {
@@ -190,14 +193,16 @@ export async function deleteEvent(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "event.delete",
-      performedBy: user.uid,
-      targetId: eventId,
-      targetType: "event",
-      details: {},
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "event.delete",
+        performedBy: user.uid,
+        targetId: eventId,
+        targetType: "event",
+        details: {},
+      },
+      req
+    );
 
     res.json({ success: true });
   } catch (err) {

--- a/functions/src/handlers/forms.ts
+++ b/functions/src/handlers/forms.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { GitHubService } from "../services/github";
@@ -69,14 +68,16 @@ export async function addForm(req: Request, res: Response) {
       sha
     );
 
-    await writeAuditLog({
-      action: "form.create",
-      performedBy: user.uid,
-      targetId: entry.id,
-      targetType: "form",
-      details: { name: entry.name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "form.create",
+        performedBy: user.uid,
+        targetId: entry.id,
+        targetType: "form",
+        details: { name: entry.name },
+      },
+      req
+    );
 
     res.status(201).json({ success: true, data: entry });
   } catch (err) {
@@ -109,14 +110,16 @@ export async function updateForm(req: Request, res: Response) {
       sha
     );
 
-    await writeAuditLog({
-      action: "form.update",
-      performedBy: user.uid,
-      targetId: formId,
-      targetType: "form",
-      details: { name: forms[index].name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "form.update",
+        performedBy: user.uid,
+        targetId: formId,
+        targetType: "form",
+        details: { name: forms[index].name },
+      },
+      req
+    );
 
     res.json({ success: true, data: forms[index] });
   } catch (err) {
@@ -146,14 +149,16 @@ export async function deleteForm(req: Request, res: Response) {
       sha
     );
 
-    await writeAuditLog({
-      action: "form.delete",
-      performedBy: user.uid,
-      targetId: formId,
-      targetType: "form",
-      details: {},
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "form.delete",
+        performedBy: user.uid,
+        targetId: formId,
+        targetType: "form",
+        details: {},
+      },
+      req
+    );
 
     res.json({ success: true });
   } catch (err) {

--- a/functions/src/handlers/locations.ts
+++ b/functions/src/handlers/locations.ts
@@ -45,14 +45,16 @@ export async function create(req: Request, res: Response) {
       createdAt: FieldValue.serverTimestamp(),
       createdBy: user.uid,
     });
-    await writeAuditLog({
-      action: "location.create",
-      performedBy: user.uid,
-      targetId: ref.id,
-      targetType: "location",
-      details: { name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "location.create",
+        performedBy: user.uid,
+        targetId: ref.id,
+        targetType: "location",
+        details: { name },
+      },
+      req
+    );
     res.status(201).json({ success: true, data: { id: ref.id } });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });
@@ -78,14 +80,16 @@ export async function update(req: Request, res: Response) {
       return;
     }
     await ref.update({ name, address, map_url, map_embed });
-    await writeAuditLog({
-      action: "location.update",
-      performedBy: user.uid,
-      targetId: id,
-      targetType: "location",
-      details: { name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "location.update",
+        performedBy: user.uid,
+        targetId: id,
+        targetType: "location",
+        details: { name },
+      },
+      req
+    );
     res.json({ success: true, data: { id } });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });
@@ -104,14 +108,16 @@ export async function remove(req: Request, res: Response) {
     }
     const name = (doc.data()?.name as string) || id;
     await ref.delete();
-    await writeAuditLog({
-      action: "location.delete",
-      performedBy: user.uid,
-      targetId: id,
-      targetType: "location",
-      details: { name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "location.delete",
+        performedBy: user.uid,
+        targetId: id,
+        targetType: "location",
+        details: { name },
+      },
+      req
+    );
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ success: false, error: safeError(err) });

--- a/functions/src/handlers/minigameBingo.ts
+++ b/functions/src/handlers/minigameBingo.ts
@@ -130,14 +130,16 @@ export async function drawBall(req: Request, res: Response) {
       return;
     }
 
-    await writeAuditLog({
-      action: "minigame_instance.bingo.draw",
-      performedBy: user.uid,
-      targetId: id,
-      targetType: "minigame_instance",
-      details: { slug, term: drawn.term, drawCount: drawn.drawCount },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "minigame_instance.bingo.draw",
+        performedBy: user.uid,
+        targetId: id,
+        targetType: "minigame_instance",
+        details: { slug, term: drawn.term, drawCount: drawn.drawCount },
+      },
+      req
+    );
 
     res.json({
       success: true,
@@ -239,19 +241,21 @@ export async function claim(req: Request, res: Response) {
     });
 
     if (!result.alreadyWon) {
-      await writeAuditLog({
-        action: "minigame_participant.bingo.claim",
-        performedBy: user.uid,
-        targetId: id,
-        targetType: "minigame_instance",
-        details: {
-          slug,
-          alias: participant.alias ?? "Anónimo",
-          rank: result.rank,
-          winDraw: result.winDraw,
+      await writeAuditLog(
+        {
+          action: "minigame_participant.bingo.claim",
+          performedBy: user.uid,
+          targetId: id,
+          targetType: "minigame_instance",
+          details: {
+            slug,
+            alias: participant.alias ?? "Anónimo",
+            rank: result.rank,
+            winDraw: result.winDraw,
+          },
         },
-        timestamp: FieldValue.serverTimestamp(),
-      });
+        req
+      );
     }
 
     res.json({

--- a/functions/src/handlers/minigameInstances.ts
+++ b/functions/src/handlers/minigameInstances.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
-import { writeAuditLog } from "../utils/audit";
+import { auditEntryFor, writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import { ensureDrawOrder } from "../services/bingoDrawStore";
@@ -21,21 +21,8 @@ function modeForType(type: MinigameTemplateType): "global" | "realtime" {
   return type === "poll" || type === "quiz" ? "realtime" : "global";
 }
 
-function auditEntry(
-  action: string,
-  performedBy: string,
-  targetId: string,
-  details: AuditDetails
-) {
-  return {
-    action,
-    performedBy,
-    targetId,
-    targetType: "minigame_instance",
-    details,
-    timestamp: FieldValue.serverTimestamp(),
-  };
-}
+/** Entradas de este handler: `targetType` fijo, detalles tipados arriba. */
+const auditEntry = auditEntryFor<AuditDetails>("minigame_instance");
 
 function eventDocRef(slug: string) {
   return admin.firestore().collection("events").doc(slug);
@@ -152,7 +139,8 @@ export async function attach(req: Request, res: Response) {
         type: tpl.type,
         title: tpl.title,
         templateId,
-      })
+      }),
+      req
     );
 
     res
@@ -195,7 +183,8 @@ export async function setState(req: Request, res: Response) {
       auditEntry(`minigame_instance.state.${state}`, user.uid, id, {
         slug,
         state,
-      })
+      }),
+      req
     );
 
     res.json({ success: true, data: { id, state } });
@@ -257,7 +246,8 @@ export async function quizAdvance(req: Request, res: Response) {
         slug,
         fromIndex,
         toIndex,
-      })
+      }),
+      req
     );
 
     res.json({ success: true, data: { id, currentQuestionIndex: toIndex } });
@@ -296,7 +286,8 @@ export async function remove(req: Request, res: Response) {
       auditEntry("minigame_instance.delete", user.uid, id, {
         slug,
         title: data?.title,
-      })
+      }),
+      req
     );
 
     res.json({ success: true });

--- a/functions/src/handlers/minigameJoin.ts
+++ b/functions/src/handlers/minigameJoin.ts
@@ -234,18 +234,20 @@ export async function join(req: Request, res: Response) {
       })
     );
 
-    await writeAuditLog({
-      action: "minigame_participant.join",
-      performedBy: user.uid,
-      targetId: slug,
-      targetType: "event",
-      details: {
-        alias: canonicalAlias,
-        instanceCount: summaries.length,
-        newJoins: summaries.filter((s) => s.joined).length,
+    await writeAuditLog(
+      {
+        action: "minigame_participant.join",
+        performedBy: user.uid,
+        targetId: slug,
+        targetType: "event",
+        details: {
+          alias: canonicalAlias,
+          instanceCount: summaries.length,
+          newJoins: summaries.filter((s) => s.joined).length,
+        },
       },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+      req
+    );
 
     res.json({
       success: true,

--- a/functions/src/handlers/minigameRoulette.ts
+++ b/functions/src/handlers/minigameRoulette.ts
@@ -79,14 +79,17 @@ export async function spin(req: Request, res: Response) {
       return spinCount;
     });
 
-    await writeAuditLog({
-      action: "minigame_instance.roulette.spin",
-      performedBy: user.uid,
-      targetId: id,
-      targetType: "minigame_instance",
-      details: { slug, winnerId: winner.id, alias, spinNumber },
-      timestamp: now,
-    });
+    await writeAuditLog(
+      {
+        action: "minigame_instance.roulette.spin",
+        performedBy: user.uid,
+        targetId: id,
+        targetType: "minigame_instance",
+        details: { slug, winnerId: winner.id, alias, spinNumber },
+        timestamp: now,
+      },
+      req
+    );
 
     res.json({
       success: true,

--- a/functions/src/handlers/minigameTemplates.ts
+++ b/functions/src/handlers/minigameTemplates.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
-import { writeAuditLog } from "../utils/audit";
+import { auditEntryFor, writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 import type { MinigameTemplate } from "../schemas";
@@ -14,21 +14,8 @@ interface AuditDetails {
   version?: number;
 }
 
-function auditEntry(
-  action: string,
-  performedBy: string,
-  targetId: string,
-  details: AuditDetails
-) {
-  return {
-    action,
-    performedBy,
-    targetId,
-    targetType: "minigame_template",
-    details,
-    timestamp: FieldValue.serverTimestamp(),
-  };
-}
+/** Entradas de este handler: `targetType` fijo, detalles tipados arriba. */
+const auditEntry = auditEntryFor<AuditDetails>("minigame_template");
 
 function toIso(ts: Timestamp | null | undefined): string | null {
   return ts?.toDate?.().toISOString() ?? null;
@@ -77,7 +64,8 @@ export async function create(req: Request, res: Response) {
       auditEntry("minigame_template.create", user.uid, ref.id, {
         type: body.type,
         title: body.title,
-      })
+      }),
+      req
     );
     res.status(201).json({ success: true, data: { id: ref.id } });
   } catch (err) {
@@ -113,7 +101,8 @@ export async function update(req: Request, res: Response) {
         type: body.type,
         title: body.title,
         version: nextVersion,
-      })
+      }),
+      req
     );
     res.json({ success: true, data: { id, version: nextVersion } });
   } catch (err) {
@@ -139,7 +128,8 @@ export async function remove(req: Request, res: Response) {
       auditEntry("minigame_template.delete", user.uid, id, {
         type: data?.type ?? "poll",
         title: data?.title ?? id,
-      })
+      }),
+      req
     );
     res.json({ success: true });
   } catch (err) {

--- a/functions/src/handlers/minigameWords.ts
+++ b/functions/src/handlers/minigameWords.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
-import { writeAuditLog } from "../utils/audit";
+import { auditEntryFor, writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
 
@@ -12,21 +12,8 @@ interface AuditDetails {
   hidden?: boolean;
 }
 
-function auditEntry(
-  action: string,
-  performedBy: string,
-  targetId: string,
-  details: AuditDetails
-) {
-  return {
-    action,
-    performedBy,
-    targetId,
-    targetType: "minigame_word",
-    details,
-    timestamp: FieldValue.serverTimestamp(),
-  };
-}
+/** Entradas de este handler: `targetType` fijo, detalles tipados arriba. */
+const auditEntry = auditEntryFor<AuditDetails>("minigame_word");
 
 function wordsCol(slug: string, instanceId: string) {
   return admin
@@ -95,7 +82,8 @@ export async function setWordHidden(req: Request, res: Response) {
         user.uid,
         wordId,
         { slug, instanceId: id, wordId, hidden }
-      )
+      ),
+      req
     );
     res.json({ success: true, data: { id: wordId, hidden } });
   } catch (err) {

--- a/functions/src/handlers/proposals.ts
+++ b/functions/src/handlers/proposals.ts
@@ -285,14 +285,16 @@ export async function reviewProposal(req: Request, res: Response) {
       reviewNote: note,
     });
 
-    await writeAuditLog({
-      action: "proposal.review",
-      performedBy: performer.uid,
-      targetId: id,
-      targetType: "proposal",
-      details: { decision, type: data.type, reason: note },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "proposal.review",
+        performedBy: performer.uid,
+        targetId: id,
+        targetType: "proposal",
+        details: { decision, type: data.type, reason: note },
+      },
+      req
+    );
 
     res.json({ success: true, data: { id, status: decision } });
   } catch (err) {
@@ -380,18 +382,20 @@ export async function publishProposal(req: Request, res: Response) {
       publishedBy: performer.uid,
     });
 
-    await writeAuditLog({
-      action: "proposal.publish",
-      performedBy: performer.uid,
-      targetId: id,
-      targetType: "proposal",
-      details: {
-        type: data.type,
-        publishedId: targetId,
-        proposedBy: data.createdBy,
+    await writeAuditLog(
+      {
+        action: "proposal.publish",
+        performedBy: performer.uid,
+        targetId: id,
+        targetType: "proposal",
+        details: {
+          type: data.type,
+          publishedId: targetId,
+          proposedBy: data.createdBy,
+        },
       },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+      req
+    );
 
     res.json({ success: true, data: { id, publishedId: targetId } });
   } catch (err) {

--- a/functions/src/handlers/speakers.ts
+++ b/functions/src/handlers/speakers.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -49,14 +48,16 @@ export async function addSpeaker(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "speaker.create",
-      performedBy: user.uid,
-      targetId: speaker.id,
-      targetType: "speaker",
-      details: { name: speaker.name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "speaker.create",
+        performedBy: user.uid,
+        targetId: speaker.id,
+        targetType: "speaker",
+        details: { name: speaker.name },
+      },
+      req
+    );
 
     res.status(201).json({ success: true, data: { id: speaker.id } });
   } catch (err) {
@@ -96,14 +97,16 @@ export async function updateSpeaker(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "speaker.update",
-      performedBy: user.uid,
-      targetId: speakerId,
-      targetType: "speaker",
-      details: { name: updates.name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "speaker.update",
+        performedBy: user.uid,
+        targetId: speakerId,
+        targetType: "speaker",
+        details: { name: updates.name },
+      },
+      req
+    );
 
     res.json({ success: true, data: { id: speakerId } });
   } catch (err) {
@@ -141,14 +144,16 @@ export async function deleteSpeaker(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "speaker.delete",
-      performedBy: user.uid,
-      targetId: speakerId,
-      targetType: "speaker",
-      details: {},
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "speaker.delete",
+        performedBy: user.uid,
+        targetId: speakerId,
+        targetType: "speaker",
+        details: {},
+      },
+      req
+    );
 
     res.json({ success: true });
   } catch (err) {

--- a/functions/src/handlers/sponsors.ts
+++ b/functions/src/handlers/sponsors.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError, validateUrl } from "../middleware/validate";
@@ -62,14 +61,16 @@ export async function addSponsor(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "sponsor.create",
-      performedBy: user.uid,
-      targetId: sponsor.name,
-      targetType: "sponsor",
-      details: { name: sponsor.name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "sponsor.create",
+        performedBy: user.uid,
+        targetId: sponsor.name,
+        targetType: "sponsor",
+        details: { name: sponsor.name },
+      },
+      req
+    );
 
     res.status(201).json({ success: true, data: { name: sponsor.name } });
   } catch (err) {
@@ -110,14 +111,16 @@ export async function updateSponsor(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "sponsor.update",
-      performedBy: user.uid,
-      targetId: updates.name,
-      targetType: "sponsor",
-      details: { name: updates.name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "sponsor.update",
+        performedBy: user.uid,
+        targetId: updates.name,
+        targetType: "sponsor",
+        details: { name: updates.name },
+      },
+      req
+    );
 
     res.json({ success: true, data: { name: updates.name } });
   } catch (err) {
@@ -150,14 +153,16 @@ export async function deleteSponsor(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "sponsor.delete",
-      performedBy: user.uid,
-      targetId: sponsorId,
-      targetType: "sponsor",
-      details: {},
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "sponsor.delete",
+        performedBy: user.uid,
+        targetId: sponsorId,
+        targetType: "sponsor",
+        details: {},
+      },
+      req
+    );
 
     res.json({ success: true });
   } catch (err) {

--- a/functions/src/handlers/stats.ts
+++ b/functions/src/handlers/stats.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -40,14 +39,16 @@ export async function updateStats(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "stats.update",
-      performedBy: user.uid,
-      targetId: "stats",
-      targetType: "stats",
-      details: stats,
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "stats.update",
+        performedBy: user.uid,
+        targetId: "stats",
+        targetType: "stats",
+        details: stats,
+      },
+      req
+    );
 
     res.json({ success: true, data: updated });
   } catch (err) {

--- a/functions/src/handlers/team.ts
+++ b/functions/src/handlers/team.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import { FieldValue } from "firebase-admin/firestore";
 import { writeAuditLog, triggerRebuildAndLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { safeError } from "../middleware/validate";
@@ -56,14 +55,16 @@ export async function addTeamMember(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "team.create",
-      performedBy: user.uid,
-      targetId: member.id,
-      targetType: "team",
-      details: { name: member.name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "team.create",
+        performedBy: user.uid,
+        targetId: member.id,
+        targetType: "team",
+        details: { name: member.name },
+      },
+      req
+    );
 
     res.status(201).json({ success: true, data: { id: member.id } });
   } catch (err) {
@@ -97,14 +98,16 @@ export async function updateTeamMember(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "team.update",
-      performedBy: user.uid,
-      targetId: memberId,
-      targetType: "team",
-      details: { name: updates.name },
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "team.update",
+        performedBy: user.uid,
+        targetId: memberId,
+        targetType: "team",
+        details: { name: updates.name },
+      },
+      req
+    );
 
     res.json({ success: true, data: { id: memberId } });
   } catch (err) {
@@ -136,14 +139,16 @@ export async function deleteTeamMember(req: Request, res: Response) {
 
     triggerRebuildAndLog(github);
 
-    await writeAuditLog({
-      action: "team.delete",
-      performedBy: user.uid,
-      targetId: memberId,
-      targetType: "team",
-      details: {},
-      timestamp: FieldValue.serverTimestamp(),
-    });
+    await writeAuditLog(
+      {
+        action: "team.delete",
+        performedBy: user.uid,
+        targetId: memberId,
+        targetType: "team",
+        details: {},
+      },
+      req
+    );
 
     res.json({ success: true });
   } catch (err) {

--- a/functions/src/middleware/auditContext.ts
+++ b/functions/src/middleware/auditContext.ts
@@ -4,6 +4,7 @@ import { logger } from "firebase-functions";
 import { writeAuditLog } from "../utils/audit";
 import { singleLineHeader } from "../utils/headers";
 import type { AuditContext } from "../utils/auditTypes";
+import type { AuditAction } from "../utils/auditActions";
 
 /**
  * Trunca la dirección a su prefijo de red.
@@ -106,7 +107,11 @@ export function auditContext() {
       // async de aquí y la instancia puede congelarse antes de que termine una
       // escritura a Firestore. El log siempre sale; la fila es best-effort.
       const uid = (req as { user?: { uid?: string } }).user?.uid ?? "unknown";
-      const action = `http.${req.method.toLowerCase()}.${context.route}`;
+      // Anotado a propósito: TS ensancha a `string` un template con
+      // interpolaciones no literales, y `AuditAction` admite `http.${string}`
+      // precisamente para estas filas. La anotación es lo que comprueba que
+      // sigan empezando por `http.` y no se cuelen como una acción de dominio.
+      const action: AuditAction = `http.${req.method.toLowerCase()}.${context.route}`;
 
       logger.warn("audit.synthesized", {
         action,
@@ -123,19 +128,22 @@ export function auditContext() {
       // capaz de mandar basura en dueño del volumen de la colección.
       if (outcome !== "success") return;
 
-      void writeAuditLog({
-        action,
-        performedBy: uid,
-        targetType: "http_request",
-        details: { status },
-        outcome,
-        // `warning`, no `info`: esta fila significa que hay código mutando
-        // cosas sin decir qué. Se resalta en el visor para que alguien lo
-        // arregle, no para que se normalice.
-        severity: "warning",
-        category: "operations",
-        synthesized: true,
-      }).catch(() => {
+      void writeAuditLog(
+        {
+          action,
+          performedBy: uid,
+          targetType: "http_request",
+          details: { status },
+          outcome,
+          // `warning`, no `info`: esta fila significa que hay código mutando
+          // cosas sin decir qué. Se resalta en el visor para que alguien lo
+          // arregle, no para que se normalice.
+          severity: "warning",
+          category: "operations",
+          synthesized: true,
+        },
+        req
+      ).catch(() => {
         // `writeAuditLog` ya registró el fallo, y aquí no hay respuesta que
         // devolver: la petición terminó hace rato.
       });

--- a/functions/src/middleware/cors.test.ts
+++ b/functions/src/middleware/cors.test.ts
@@ -5,7 +5,11 @@ vi.mock("firebase-functions", () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
 
-import { ALLOWED_ORIGINS, isAllowedOrigin, rejectDisallowedOrigin } from "./cors";
+import {
+  ALLOWED_ORIGINS,
+  isAllowedOrigin,
+  rejectDisallowedOrigin,
+} from "./cors";
 
 const ORIGINAL = process.env.FUNCTIONS_EMULATOR;
 

--- a/functions/src/services/nameMatch.test.ts
+++ b/functions/src/services/nameMatch.test.ts
@@ -20,7 +20,9 @@ describe("normalizeSearchText", () => {
   });
 
   it("replaces punctuation with a separator rather than joining words", () => {
-    expect(normalizeSearchText("Quintanilla-Garcia")).toBe("quintanilla garcia");
+    expect(normalizeSearchText("Quintanilla-Garcia")).toBe(
+      "quintanilla garcia"
+    );
     expect(normalizeSearchText("O'Brien")).toBe("o brien");
   });
 

--- a/functions/src/utils/audit.ts
+++ b/functions/src/utils/audit.ts
@@ -6,8 +6,10 @@ import {
   deriveCategory,
   deriveSeverity,
   type AuditActor,
+  type AuditDetails,
   type AuditEntry,
 } from "./auditTypes";
+import type { AuditAction } from "./auditActions";
 
 /** Documento tal y como queda en Firestore: sin huecos que el visor tenga que adivinar. */
 type StoredAuditEntry = AuditEntry & {
@@ -108,6 +110,37 @@ export function mirrorToCloudLogging(
   } else {
     logger.info("audit", payload);
   }
+}
+
+/**
+ * Fabrica un constructor de entradas con el `targetType` ya fijado.
+ *
+ * Sustituye a tres factorías `auditEntry()` idénticas que vivían copiadas en
+ * `minigameTemplates`, `minigameWords` y `minigameInstances`. Está currificada
+ * en vez de recibir `targetType` como quinto argumento porque cinco parámetros
+ * posicionales del mismo tipo son un imán de bugs: basta intercambiar dos para
+ * escribir un registro que compila y miente.
+ *
+ * El genérico `D` conserva el tipado de detalles propio de cada archivo. Esas
+ * interfaces locales son las que impiden un typo en una CLAVE de `details`, así
+ * que aplanarlas a `AuditDetails` para quitar la duplicación habría cambiado
+ * una garantía por otra.
+ */
+export function auditEntryFor<D extends AuditDetails>(targetType: string) {
+  return (
+    action: AuditAction,
+    performedBy: string,
+    targetId: string,
+    details: D
+  ): AuditEntry => ({
+    action,
+    performedBy,
+    targetId,
+    targetType,
+    details,
+    // Sin `timestamp`: lo sella el escritor. Ponerlo aquí obligaba a importar
+    // FieldValue en cada handler para repetir el mismo valor.
+  });
 }
 
 /**

--- a/functions/src/utils/auditActions.test.ts
+++ b/functions/src/utils/auditActions.test.ts
@@ -1,0 +1,104 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  AUDIT_ACTIONS,
+  SECURITY_ACTIONS,
+  type AuditAction,
+} from "./auditActions";
+
+/**
+ * El registro de acciones se mantiene honesto de dos formas.
+ *
+ * El compilador ya impide EMITIR una acción que no esté en la lista — eso lo
+ * garantiza el tipo `AuditAction` y no hace falta probarlo aquí. Lo que el
+ * compilador no puede ver es lo contrario: una entrada que sobra. Cuando una
+ * acción se renombra o se deja de emitir, su nombre viejo se queda en la lista
+ * y nada se queja, y a partir de ahí el registro documenta una acción que el
+ * código ya no produce. Quien lea la lista para saber qué se audita se lleva
+ * una respuesta falsa.
+ */
+
+const SRC = join(__dirname, "..");
+
+/** Todo el código de producción, en un solo string. */
+function productionSources(): string {
+  const chunks: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(path);
+      } else if (
+        entry.name.endsWith(".ts") &&
+        !entry.name.endsWith(".test.ts") &&
+        // El propio registro menciona todos los nombres por definición.
+        entry.name !== "auditActions.ts"
+      ) {
+        chunks.push(readFileSync(path, "utf8"));
+      }
+    }
+  };
+  walk(SRC);
+  return chunks.join("\n");
+}
+
+describe("registro de acciones", () => {
+  const sources = productionSources();
+
+  it("no hay duplicados", () => {
+    const all = [...AUDIT_ACTIONS, ...SECURITY_ACTIONS];
+    const dupes = all.filter((a, i) => all.indexOf(a) !== i);
+    expect(dupes).toEqual([]);
+  });
+
+  it("las acciones de dominio y de seguridad no se solapan", () => {
+    const overlap = (AUDIT_ACTIONS as readonly string[]).filter((a) =>
+      (SECURITY_ACTIONS as readonly string[]).includes(a)
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  // Una entrada que ya nadie emite es peor que una que falta: la que falta no
+  // compila, ésta se queda documentando algo que no ocurre.
+  it("toda acción de dominio registrada se emite en algún sitio", () => {
+    const stale = AUDIT_ACTIONS.filter((a) => !sources.includes(`"${a}"`));
+    expect(
+      stale,
+      "Acción registrada que ningún handler emite. Si se renombró, quítala."
+    ).toEqual([]);
+  });
+
+  it("todo evento de seguridad registrado se emite en algún sitio", () => {
+    const stale = SECURITY_ACTIONS.filter((a) => !sources.includes(`"${a}"`));
+    expect(stale).toEqual([]);
+  });
+
+  it("los prefijos son coherentes", () => {
+    for (const action of SECURITY_ACTIONS) {
+      expect(action.startsWith("security.")).toBe(true);
+    }
+    for (const action of AUDIT_ACTIONS) {
+      expect(action.startsWith("security.")).toBe(false);
+      // Dos segmentos mínimo: el prefijo es lo que determina la categoría.
+      expect(action.split(".").length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  // Los estados vienen de `minigameStateSchema` en schemas/index.ts. Si alguien
+  // añade un estado allí sin tocar el tipo, esto deja de compilar — que es
+  // exactamente lo que se quiere que pase.
+  it("acepta las tres acciones de cambio de estado", () => {
+    const acciones: AuditAction[] = [
+      "minigame_instance.state.scheduled",
+      "minigame_instance.state.live",
+      "minigame_instance.state.closed",
+    ];
+    expect(acciones).toHaveLength(3);
+  });
+
+  it("acepta las filas sintéticas de la red de seguridad", () => {
+    const fila: AuditAction = "http.post./api/algo";
+    expect(fila.startsWith("http.")).toBe(true);
+  });
+});

--- a/functions/src/utils/auditActions.ts
+++ b/functions/src/utils/auditActions.ts
@@ -1,0 +1,140 @@
+/**
+ * Registro cerrado de acciones de auditoría.
+ *
+ * Existe para que `action` deje de ser `string`. Con una cadena libre, un typo
+ * —`user.role.chnage`— compilaba, se escribía y solo se descubría el día que
+ * alguien filtrase por la acción correcta y no encontrase nada: justo cuando
+ * hace falta el registro. Aquí un typo no compila.
+ *
+ * Este archivo NO importa nada a propósito. `auditTypes` lo importa y
+ * `securityAudit` importa de `auditTypes`, así que cualquier import aquí
+ * cerraría el ciclo. Es también la razón de que los nombres de los eventos de
+ * seguridad vivan en esta lista y no se deriven del catálogo de
+ * `securityAudit`: la dependencia tiene que ir en un solo sentido.
+ *
+ * Añadir una acción es añadirla aquí. Si el compilador te trajo a este archivo,
+ * la pregunta que toca no es "¿cómo lo callo?" sino si esa acción ya existe con
+ * otro nombre — dos nombres para lo mismo parten el registro en dos y ninguno
+ * de los dos filtros lo enseña completo.
+ */
+
+/**
+ * Acciones de dominio: alguien hizo algo y quedó constancia.
+ *
+ * El prefijo determina la categoría (ver `deriveCategory`), así que el nombre
+ * no es decorativo: `event.staff.assign` cae en `access` y no en `content`
+ * porque asignar staff concede permisos.
+ */
+export const AUDIT_ACTIONS = [
+  // Acceso: roles, permisos, invitaciones, solicitudes, staff por evento
+  "user.register",
+  "user.role.change",
+  "user.status.change",
+  "user.grants.change",
+  "access.request.create",
+  "access.request.approve",
+  "access.request.reject",
+  "access.invitation.create",
+  "access.invitation.redeem",
+  "access.invitation.revoke",
+  "event.staff.assign",
+  "event.staff.remove",
+
+  // Contenido publicado en el repo de datos
+  "event.create",
+  "event.update",
+  "event.delete",
+  "speaker.create",
+  "speaker.update",
+  "speaker.delete",
+  "sponsor.create",
+  "sponsor.update",
+  "sponsor.delete",
+  "team.create",
+  "team.update",
+  "team.delete",
+  "location.create",
+  "location.update",
+  "location.delete",
+  "form.create",
+  "form.update",
+  "form.delete",
+  "stats.update",
+  "proposal.create",
+  "proposal.update",
+  "proposal.review",
+  "proposal.publish",
+
+  // Operaciones
+  "site.rebuild",
+  "settings.email_transport",
+  "certificate.send",
+  "checkin.import",
+  "credential.create",
+  "credential.image",
+  "credential.bevy_status",
+  "credential.moderate_photo",
+  "credential.email_retry",
+  "credential.reminders",
+  "credential.reconcile",
+  "credential_email.drain",
+
+  // Minijuegos
+  "minigame_template.create",
+  "minigame_template.update",
+  "minigame_template.delete",
+  "minigame_instance.attach",
+  "minigame_instance.delete",
+  "minigame_instance.quiz.advance",
+  "minigame_instance.roulette.spin",
+  "minigame_instance.bingo.draw",
+  "minigame_participant.join",
+  "minigame_participant.bingo.claim",
+  "minigame_word.hide",
+  "minigame_word.unhide",
+] as const;
+
+/**
+ * Eventos de seguridad. `securityAudit.ts` constriñe su catálogo a esta lista,
+ * así que un evento nuevo tiene que declararse aquí antes de poder emitirse.
+ */
+export const SECURITY_ACTIONS = [
+  "security.auth.invalid_token",
+  "security.appcheck.missing",
+  "security.permission.denied",
+  "security.account.suspended_access",
+  "security.invitation.redeem_failed",
+  "security.user.unregistered",
+  "security.ratelimit.exceeded",
+  "security.audit.throttled",
+] as const;
+
+export type SecurityAction = (typeof SECURITY_ACTIONS)[number];
+
+/**
+ * El estado del minijuego forma parte del nombre de la acción, para poder
+ * filtrar "cuándo se abrió" sin leer los detalles de cada fila.
+ *
+ * Un miembro de literal de plantilla en vez de enumerar los tres: `state` es
+ * `z.enum(["scheduled","live","closed"])` en `schemas/index.ts`, así que TS ya
+ * infiere exactamente esa union y añadir un estado al esquema rompe aquí, que
+ * es lo que se quiere.
+ */
+type MinigameStateAction =
+  `minigame_instance.state.${"scheduled" | "live" | "closed"}`;
+
+/**
+ * Filas de la red de seguridad automática: la acción lleva el patrón de ruta
+ * resuelto en tiempo de ejecución, así que no se puede enumerar.
+ *
+ * Es el único hueco abierto de la union, y lo es a propósito: estas filas
+ * significan "un handler mutó algo sin decir qué", y llevan
+ * `synthesized: true` para que se distingan de una acción de verdad.
+ */
+type SynthesizedAction = `http.${string}`;
+
+export type AuditAction =
+  | (typeof AUDIT_ACTIONS)[number]
+  | SecurityAction
+  | MinigameStateAction
+  | SynthesizedAction;

--- a/functions/src/utils/auditTypes.ts
+++ b/functions/src/utils/auditTypes.ts
@@ -1,4 +1,5 @@
 import type { FieldValue } from "firebase-admin/firestore";
+import type { AuditAction } from "./auditActions";
 
 /**
  * Forma del registro de auditoría.
@@ -90,7 +91,11 @@ export interface AuditActor {
 }
 
 export interface AuditEntry {
-  action: string;
+  /**
+   * Del registro cerrado de `auditActions.ts`. Un typo no compila, que es
+   * justo lo que no ocurría cuando esto era `string`.
+   */
+  action: AuditAction;
   performedBy: string;
   targetId?: string;
   targetType?: string;


### PR DESCRIPTION
## What changed

- `utils/auditActions.ts` declares the 58 domain actions and the 8 security events. `action` changes from `string` to `AuditAction`.
- **All 44 remaining call sites now pass `req`**, so every entry gains the correlation id, route and network prefix that the previous PR prepared but only reached the five access-control paths.
- The explicit `timestamp: FieldValue.serverTimestamp()` is gone — the writer stamps it when absent. That left eight handlers with an orphaned `FieldValue` import, removed after verifying each no longer used it.
- The three duplicated `auditEntry()` factories collapse into one curried `auditEntryFor(targetType)`.

## Why

`action` was a free string, so `user.role.chnage` compiled, got written, and would only surface the day someone filtered by the correct name and found nothing — precisely when the record is needed. A typo no longer compiles.

Verified the type earns its keep: a typo errors *and* TypeScript suggests the right name (`Did you mean '"event.update"'?`), and a plausible invented action (`stats.change`) is rejected too.

## Three places this diverges from the obvious approach

**The registry imports nothing.** `auditTypes` imports it and `securityAudit` imports from `auditTypes`, so any import here would close the cycle. That is also why the security event names live in this list instead of being derived from `securityAudit`'s catalogue — the dependency has to run one way.

**Not one generic 5-argument factory.** That was the tempting way to kill the duplication and it would have made the call sites worse: five positional parameters all of type `string` are a bug magnet, since swapping two writes a record that compiles and lies. The curried version binds `targetType` once per file and the generic preserves each file's local `AuditDetails` interface — those interfaces are what stop a typo in a details *key*, so flattening them would have traded one guarantee for another.

**`minigameRoulette` keeps its explicit timestamp.** It is not redundant: it deliberately shares the same `serverTimestamp()` sentinel with the mutation it records so both rows carry the identical time.

## How to test

```bash
cd functions && pnpm build && pnpm test   # 640 tests at this commit
```

The registry test covers what the compiler cannot see, which is the opposite of what it looks like. The compiler already prevents *emitting* an unlisted action. What it cannot see is an entry that **is no longer emitted**: when an action is renamed, the old name stays in the list, nothing complains, and from then on the registry documents something the code no longer produces. Anyone reading the list to learn what is audited gets a false answer. Verified the test catches a planted dead entry.

## Notes for the reviewer

- The real inventory was 58 domain actions, not the 52 originally estimated. The first sweep missed the ones built with ternaries (`access.request.approve`/`reject`, `minigame_word.hide`/`unhide`); they were found by enumerating on the shape of the string rather than on the `action:` field. Three false positives were discarded — `certificate.sent`, `certificate.failed` and `audit.synthesized` are Cloud Logging message names, not actions.
- `http.${string}` is the only open hole in the union, deliberately: those rows carry a route pattern resolved at runtime and are tagged `synthesized: true`.
- Highest-churn, lowest-security-value PR of the set. Sequenced here on purpose, after the things that actually matter were in.