### PR TITLE
feat(audit): audit sensitive reads, add filters and rework the viewer

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -25,6 +25,38 @@
       ]
     },
     {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "severity", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "outcome", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "context.ipPrefix", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "minigames",
       "queryScope": "COLLECTION",
       "fields": [

--- a/functions/src/handlers/audit.test.ts
+++ b/functions/src/handlers/audit.test.ts
@@ -1,0 +1,232 @@
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Consultas construidas, para poder afirmar sobre lo que se pidió a Firestore. */
+interface RecordedQuery {
+  wheres: { field: string; op: string; value: unknown }[];
+  orderBy: string | null;
+  limit: number | null;
+  startAfter: string | null;
+}
+
+let recorded: RecordedQuery;
+let rows: { id: string; data: Record<string, unknown> }[] = [];
+let cursorExists = true;
+
+function queryStub(): Record<string, unknown> {
+  const self = {
+    where: (field: string, op: string, value: unknown) => {
+      recorded.wheres.push({ field, op, value });
+      return self;
+    },
+    orderBy: (field: string) => {
+      recorded.orderBy = field;
+      return self;
+    },
+    limit: (n: number) => {
+      recorded.limit = n;
+      return self;
+    },
+    startAfter: (doc: { id: string }) => {
+      recorded.startAfter = doc.id;
+      return self;
+    },
+    get: async () => ({
+      docs: rows.map((r) => ({ id: r.id, data: () => r.data })),
+    }),
+  };
+  return self as unknown as Record<string, unknown>;
+}
+
+vi.mock("firebase-admin", () => ({
+  firestore: () => ({
+    collection: () => ({
+      ...queryStub(),
+      doc: (id: string) => ({
+        get: async () => ({ exists: cursorExists, id }),
+      }),
+    }),
+  }),
+}));
+
+vi.mock("firebase-functions", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { listAudit } from "./audit";
+
+interface ResMock extends Response {
+  __status: number | undefined;
+  __body:
+    | {
+        success?: boolean;
+        error?: string;
+        data?: { entries?: unknown[]; nextCursor?: string | null };
+      }
+    | undefined;
+}
+
+function buildRes(): ResMock {
+  const res: Partial<ResMock> = {};
+  res.status = vi.fn(function (this: ResMock, code: number) {
+    this.__status = code;
+    return this;
+  }) as ResMock["status"];
+  res.json = vi.fn(function (this: ResMock, body: unknown) {
+    this.__body = body as ResMock["__body"];
+    return this;
+  }) as ResMock["json"];
+  return res as ResMock;
+}
+
+function buildReq(query: Record<string, string> = {}): Request {
+  return { query } as unknown as Request;
+}
+
+function seed(n: number) {
+  rows = Array.from({ length: n }, (_, i) => ({
+    id: `e${i}`,
+    data: { action: "event.create", performedBy: "u1" },
+  }));
+}
+
+beforeEach(() => {
+  recorded = { wheres: [], orderBy: null, limit: null, startAfter: null };
+  cursorExists = true;
+  seed(3);
+});
+
+describe("orden y forma", () => {
+  // El registro se lee como una cronología: cualquier otro orden lo vuelve
+  // ilegible para lo que se usa.
+  it("ordena por timestamp descendente", async () => {
+    await listAudit(buildReq(), buildRes());
+    expect(recorded.orderBy).toBe("timestamp");
+  });
+
+  it("devuelve las entradas con su id", async () => {
+    const res = buildRes();
+    await listAudit(buildReq(), res);
+    expect(res.__body?.data?.entries).toHaveLength(3);
+    expect(res.__body?.success).toBe(true);
+  });
+});
+
+describe("filtros", () => {
+  it.each([
+    "action",
+    "performedBy",
+    "targetId",
+    "category",
+    "severity",
+    "outcome",
+    "context.ipPrefix",
+  ])("admite el filtro %s", async (field) => {
+    await listAudit(buildReq({ [field]: "x" }), buildRes());
+    expect(recorded.wheres).toEqual([{ field, op: "==", value: "x" }]);
+  });
+
+  // Cada combinación exigiría su propio índice compuesto: permitir dos
+  // multiplicaría los índices para comprar una comodidad que nadie pidió.
+  it("rechaza dos filtros a la vez", async () => {
+    const res = buildRes();
+    await listAudit(
+      buildReq({ action: "event.create", performedBy: "u1" }),
+      res
+    );
+    expect(res.__status).toBe(400);
+    expect(res.__body?.error).toContain("at most one filter");
+    expect(recorded.wheres).toEqual([]);
+  });
+
+  it("sin filtro no añade ningún where", async () => {
+    await listAudit(buildReq(), buildRes());
+    expect(recorded.wheres).toEqual([]);
+  });
+
+  it("ignora un filtro vacío", async () => {
+    await listAudit(buildReq({ action: "" }), buildRes());
+    expect(recorded.wheres).toEqual([]);
+  });
+
+  // Se resuelve con un `in` sobre el campo que ya tiene índice. Una desigualdad
+  // `severity >= "warning"` obligaría a que el primer orderBy fuese `severity`,
+  // y entonces el registro dejaría de estar ordenado por fecha.
+  it("severity=notable se traduce a un `in`", async () => {
+    await listAudit(buildReq({ severity: "notable" }), buildRes());
+    expect(recorded.wheres).toEqual([
+      { field: "severity", op: "in", value: ["warning", "critical"] },
+    ]);
+    expect(recorded.orderBy).toBe("timestamp");
+  });
+
+  it("una severidad concreta sigue siendo igualdad", async () => {
+    await listAudit(buildReq({ severity: "critical" }), buildRes());
+    expect(recorded.wheres).toEqual([
+      { field: "severity", op: "==", value: "critical" },
+    ]);
+  });
+
+  // El prefijo de red es lo único que se guarda; la dirección completa vive
+  // solo en Cloud Logging.
+  it("filtra por prefijo de red", async () => {
+    await listAudit(
+      buildReq({ "context.ipPrefix": "181.65.42.0/24" }),
+      buildRes()
+    );
+    expect(recorded.wheres[0]).toMatchObject({
+      field: "context.ipPrefix",
+      value: "181.65.42.0/24",
+    });
+  });
+});
+
+describe("paginación", () => {
+  it("por defecto pide 50 más uno", async () => {
+    await listAudit(buildReq(), buildRes());
+    expect(recorded.limit).toBe(51);
+  });
+
+  it("acota el límite a 200", async () => {
+    await listAudit(buildReq({ limit: "5000" }), buildRes());
+    expect(recorded.limit).toBe(201);
+  });
+
+  it("ignora un límite absurdo", async () => {
+    await listAudit(buildReq({ limit: "-3" }), buildRes());
+    expect(recorded.limit).toBe(51);
+  });
+
+  // Se pide uno de más para saber si hay página siguiente sin contar la
+  // colección entera.
+  it("no devuelve el de más y expone el cursor", async () => {
+    seed(51);
+    const res = buildRes();
+    await listAudit(buildReq(), res);
+    expect(res.__body?.data?.entries).toHaveLength(50);
+    expect(res.__body?.data?.nextCursor).toBe("e49");
+  });
+
+  it("sin más páginas el cursor es null", async () => {
+    seed(10);
+    const res = buildRes();
+    await listAudit(buildReq(), res);
+    expect(res.__body?.data?.nextCursor).toBeNull();
+  });
+
+  // Cursor por documento y no por fecha: varias entradas pueden compartir
+  // `timestamp` (una operación que escribe varias filas), y paginar por valor
+  // se saltaría entradas o las repetiría.
+  it("pagina con el documento del cursor", async () => {
+    await listAudit(buildReq({ cursor: "e7" }), buildRes());
+    expect(recorded.startAfter).toBe("e7");
+  });
+
+  it("rechaza un cursor inexistente", async () => {
+    cursorExists = false;
+    const res = buildRes();
+    await listAudit(buildReq({ cursor: "fantasma" }), res);
+    expect(res.__status).toBe(400);
+    expect(res.__body?.error).toBe("Invalid cursor");
+  });
+});

--- a/functions/src/handlers/audit.ts
+++ b/functions/src/handlers/audit.ts
@@ -11,8 +11,32 @@ const MAX_LIMIT = 200;
  * y solo se admite UN filtro a la vez: combinarlos multiplicaría los índices
  * sin que nadie los esté pidiendo.
  */
-const FILTERABLE = ["action", "performedBy", "targetId"] as const;
+const FILTERABLE = [
+  "action",
+  "performedBy",
+  "targetId",
+  // Categoría: es la única forma de pedir "solo lo de seguridad". Firestore no
+  // filtra por prefijo de cadena, así que sin un campo propio esa pregunta no
+  // se puede hacer.
+  "category",
+  "severity",
+  "outcome",
+  // Respuesta a incidentes: "qué más hizo esta red". Solo el prefijo, nunca la
+  // dirección completa — esa vive únicamente en Cloud Logging.
+  "context.ipPrefix",
+] as const;
 type Filterable = (typeof FILTERABLE)[number];
+
+/**
+ * Severidades que alguien querría revisar de una sentada.
+ *
+ * Se resuelve con un `in` sobre el mismo campo que ya tiene índice. La
+ * alternativa —una desigualdad `severity >= "warning"`— no sirve: Firestore
+ * exige que el primer `orderBy` sea el campo de la desigualdad, y aquí el orden
+ * tiene que ser por `timestamp` o el registro deja de leerse como una
+ * cronología.
+ */
+const NOTABLE_SEVERITIES = ["warning", "critical"];
 
 function readLimit(raw: unknown): number {
   const parsed = typeof raw === "string" ? parseInt(raw, 10) : NaN;
@@ -47,7 +71,13 @@ export async function listAudit(req: Request, res: Response) {
 
     if (active.length === 1) {
       const field = active[0] as Filterable;
-      query = query.where(field, "==", req.query[field] as string);
+      const value = req.query[field] as string;
+
+      if (field === "severity" && value === "notable") {
+        query = query.where("severity", "in", NOTABLE_SEVERITIES);
+      } else {
+        query = query.where(field, "==", value);
+      }
     }
 
     const limit = readLimit(req.query.limit);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,7 +9,7 @@ import { requirePermission, requireAuth } from "./middleware/auth";
 import { isAllowedOrigin, rejectDisallowedOrigin } from "./middleware/cors";
 import { safeError, validateParamId } from "./middleware/validate";
 import { verifyAppCheck } from "./middleware/appCheck";
-import { auditContext } from "./middleware/auditContext";
+import { auditContext, auditedRead } from "./middleware/auditContext";
 import { recordSecurityEvent } from "./utils/securityAudit";
 import { validateBody } from "./middleware/validateBody";
 import {
@@ -394,7 +394,15 @@ app.put(
 );
 
 // Users
-app.get("/api/users", requirePermission("users:read"), users.listUsers);
+// Devuelve los docs completos, con correo, grants y revocaciones. Agrupado por
+// hora: el panel lo pide en cada montaje y en cada foco de pestaña, así que una
+// fila por llamada sería una fila por vista de página.
+app.get(
+  "/api/users",
+  requirePermission("users:read"),
+  auditedRead("read.users", "user_list", { dedupe: true }),
+  users.listUsers
+);
 app.patch(
   "/api/users/:uid/role",
   requirePermission("users:role:write"),
@@ -418,7 +426,15 @@ app.put(
 );
 
 // Audit log — de solo lectura, y solo para quien tenga `audit:read`.
-app.get("/api/audit", requirePermission("audit:read"), audit.listAudit);
+// Quién leyó el registro es justo el tipo de cosa que un registro de auditoría
+// debería contar, y hasta ahora era la única pantalla que no dejaba rastro de
+// sus propios lectores.
+app.get(
+  "/api/audit",
+  requirePermission("audit:read"),
+  auditedRead("read.audit_log", "audit_log", { dedupe: true }),
+  audit.listAudit
+);
 
 // Access — solicitudes e invitaciones.
 //
@@ -578,10 +594,14 @@ app.delete(
   writeLimiter,
   forms.deleteForm
 );
+// Por llamada, SIN agrupar: es una exportación masiva de datos personales de
+// quien respondió, se usa poco y a propósito. Aquí cada lectura es un hecho
+// distinto que hay que poder fechar, no ruido de tener el panel abierto.
 app.get(
   "/api/forms/:id/responses",
   requirePermission("forms:responses:read"),
   vid,
+  auditedRead("read.form_responses", "form", { targetIdParam: "id" }),
   forms.getFormResponses
 );
 

--- a/functions/src/middleware/auditContext.test.ts
+++ b/functions/src/middleware/auditContext.test.ts
@@ -27,7 +27,12 @@ vi.mock("firebase-admin/firestore", () => ({
   FieldValue: { serverTimestamp: () => "__TS__" },
 }));
 
-import { auditContext, truncateIp } from "./auditContext";
+import {
+  auditContext,
+  auditedRead,
+  truncateIp,
+  __resetReadDedupeState,
+} from "./auditContext";
 
 /** Simula el ciclo de vida: entra la petición, responde, se dispara `finish`. */
 function run(opts: {
@@ -245,5 +250,126 @@ describe("red de seguridad", () => {
     run({ method: "POST", routePath: "/api/x" });
     await flush();
     expect(written[0]).toMatchObject({ performedBy: "unknown" });
+  });
+});
+
+/**
+ * Lecturas sensibles.
+ *
+ * Las lecturas no se auditan en general y eso es deliberado: una fila por GET
+ * daría una por vista de página, y un registro donde el 99% de las filas son
+ * "alguien abrió una pantalla" no sirve para encontrar el 1% que importa.
+ */
+describe("auditedRead", () => {
+  function runRead(opts: {
+    status?: number;
+    uid?: string;
+    params?: Record<string, string>;
+    action?: string;
+    dedupe?: boolean;
+    targetIdParam?: string;
+  }) {
+    const handlers: (() => void)[] = [];
+    const req = {
+      method: "GET",
+      path: "/api/forms/f1/responses",
+      baseUrl: "",
+      params: opts.params ?? {},
+      get: () => undefined,
+      ...(opts.uid ? { user: { uid: opts.uid } } : {}),
+    } as unknown as Request;
+    const res = {
+      statusCode: opts.status ?? 200,
+      setHeader: () => {},
+      on: (event: string, cb: () => void) => {
+        if (event === "finish") handlers.push(cb);
+      },
+    } as unknown as Response;
+
+    const next = vi.fn();
+    auditedRead((opts.action ?? "read.form_responses") as never, "form", {
+      dedupe: opts.dedupe,
+      targetIdParam: opts.targetIdParam,
+    })(req, res, next);
+    handlers.forEach((h) => h());
+    return { next };
+  }
+
+  beforeEach(() => {
+    __resetReadDedupeState();
+  });
+
+  it("registra la lectura con su categoría y llama a next()", async () => {
+    const { next } = runRead({ uid: "u1" });
+    await flush();
+    expect(next).toHaveBeenCalledOnce();
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatchObject({
+      action: "read.form_responses",
+      performedBy: "u1",
+      targetType: "form",
+      category: "read",
+    });
+  });
+
+  it("guarda qué se leyó cuando la ruta lo identifica", async () => {
+    runRead({ uid: "u1", params: { id: "f42" }, targetIdParam: "id" });
+    await flush();
+    expect(written[0]).toMatchObject({ targetId: "f42" });
+  });
+
+  // Un 403 no leyó nada, y además ya queda registrado como evento de seguridad
+  // por su cuenta: una fila de lectura ahí diría que alguien vio datos que no vio.
+  it.each([403, 404, 500])("no registra nada con un %i", async (status) => {
+    written.length = 0;
+    runRead({ status, uid: "u1" });
+    await flush();
+    expect(written).toHaveLength(0);
+  });
+
+  // La exportación masiva de respuestas se usa poco y a propósito: cada lectura
+  // es un hecho distinto que hay que poder fechar.
+  it("sin dedupe, cinco lecturas dejan cinco filas", async () => {
+    for (let i = 0; i < 5; i++) runRead({ uid: "u1" });
+    await flush();
+    expect(written).toHaveLength(5);
+  });
+
+  // El panel pide /api/users en cada montaje y en cada foco de pestaña.
+  it("con dedupe, veinte lecturas dejan una fila", async () => {
+    for (let i = 0; i < 20; i++) {
+      runRead({ uid: "u1", action: "read.users", dedupe: true });
+    }
+    await flush();
+    expect(written).toHaveLength(1);
+    expect(written[0].details).toMatchObject({ deduped: true });
+  });
+
+  it("el dedupe es por persona, no global", async () => {
+    runRead({ uid: "u1", action: "read.users", dedupe: true });
+    runRead({ uid: "u2", action: "read.users", dedupe: true });
+    await flush();
+    expect(written).toHaveLength(2);
+  });
+
+  it("el dedupe es por acción: leer usuarios y leer el log son dos filas", async () => {
+    runRead({ uid: "u1", action: "read.users", dedupe: true });
+    runRead({ uid: "u1", action: "read.audit_log", dedupe: true });
+    await flush();
+    expect(written).toHaveLength(2);
+  });
+
+  it("pasada la hora, vuelve a registrar", async () => {
+    vi.useFakeTimers();
+    try {
+      runRead({ uid: "u1", action: "read.users", dedupe: true });
+      runRead({ uid: "u1", action: "read.users", dedupe: true });
+      vi.advanceTimersByTime(60 * 60 * 1000 + 1000);
+      runRead({ uid: "u1", action: "read.users", dedupe: true });
+    } finally {
+      vi.useRealTimers();
+    }
+    await flush();
+    expect(written).toHaveLength(2);
   });
 });

--- a/functions/src/middleware/auditContext.ts
+++ b/functions/src/middleware/auditContext.ts
@@ -63,6 +63,85 @@ function routePattern(req: Request): string {
 }
 
 /**
+ * Ventana de agrupación de las lecturas repetidas. Una hora: lo bastante para
+ * que abrir el panel treinta veces en una mañana deje una fila, y lo bastante
+ * corto para que "entró por la tarde" y "entró por la noche" se distingan.
+ */
+const READ_DEDUPE_MS = 60 * 60 * 1000;
+
+/** Última vez que se registró cada (uid, acción). */
+const lastRead = new Map<string, number>();
+
+/** Solo para los tests: reinicia el estado en memoria. */
+export function __resetReadDedupeState(): void {
+  lastRead.clear();
+}
+
+export interface AuditedReadOptions {
+  /**
+   * Agrupa a una fila por hora y por persona. Para las lecturas que el panel
+   * repite solo por estar abierto.
+   */
+  dedupe?: boolean;
+  /** Parámetro de ruta que identifica lo leído (p. ej. `"id"`). */
+  targetIdParam?: string;
+}
+
+/**
+ * Registra una lectura sensible.
+ *
+ * Las lecturas no se auditan en general, y eso es deliberado: una fila por GET
+ * daría una por vista de página, y un registro donde el 99% de las filas son
+ * "alguien abrió una pantalla" no sirve para encontrar el 1% que importa. Se
+ * audita la lista corta de lecturas que exponen datos personales o el propio
+ * registro — quién leyó el log de auditoría es exactamente el tipo de cosa que
+ * un log de auditoría debería contar.
+ *
+ * Se engancha en `finish` y solo cuando la respuesta fue 2xx: un 403 no leyó
+ * nada, y ya queda registrado como evento de seguridad por su cuenta.
+ */
+export function auditedRead(
+  action: AuditAction,
+  targetType: string,
+  options: AuditedReadOptions = {}
+) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    res.on("finish", () => {
+      if (res.statusCode < 200 || res.statusCode >= 300) return;
+
+      const uid = (req as { user?: { uid?: string } }).user?.uid ?? "unknown";
+      const targetId = options.targetIdParam
+        ? (req.params[options.targetIdParam] as string | undefined)
+        : undefined;
+
+      if (options.dedupe) {
+        const key = `${uid}:${action}:${targetId ?? "-"}`;
+        const now = Date.now();
+        const previous = lastRead.get(key);
+        if (previous !== undefined && now - previous < READ_DEDUPE_MS) return;
+        lastRead.set(key, now);
+      }
+
+      void writeAuditLog(
+        {
+          action,
+          performedBy: uid,
+          ...(targetId ? { targetId } : {}),
+          targetType,
+          details: options.dedupe ? { deduped: true } : {},
+          category: "read",
+        },
+        req
+      ).catch(() => {
+        // La petición ya terminó; no hay nada que devolver.
+      });
+    });
+
+    next();
+  };
+}
+
+/**
  * Captura el contexto de la petición y deja una red de seguridad.
  *
  * Va registrado ANTES del limitador de perímetro, para que un 429 también

--- a/functions/src/utils/auditActions.ts
+++ b/functions/src/utils/auditActions.ts
@@ -79,6 +79,18 @@ export const AUDIT_ACTIONS = [
   "credential.reconcile",
   "credential_email.drain",
 
+  // Lecturas sensibles. Son las ÚNICAS lecturas que se auditan: un GET normal
+  // no deja fila, porque una por vista de página ahoga el registro y el visor
+  // solo admite un filtro a la vez.
+  //
+  // Falta a propósito el roster de asistentes y las credenciales con datos
+  // personales: el panel los lee DIRECTAMENTE de Firestore, acotado por las
+  // reglas, sin pasar por la API. No hay endpoint donde engancharse, así que
+  // cubrirlos exigiría instrumentar el lado de Firestore.
+  "read.audit_log",
+  "read.users",
+  "read.form_responses",
+
   // Minijuegos
   "minigame_template.create",
   "minigame_template.update",

--- a/src/components/react/admin/audit/AuditLog.tsx
+++ b/src/components/react/admin/audit/AuditLog.tsx
@@ -9,6 +9,18 @@ interface AuditEntry {
   targetType?: string;
   details?: Record<string, unknown>;
   timestamp?: { _seconds: number };
+  outcome?: "success" | "denied" | "failure";
+  severity?: "info" | "notice" | "warning" | "critical";
+  category?: string;
+  actor?: { email?: string | null; role?: string | null; scope?: string };
+  context?: {
+    requestId?: string;
+    route?: string;
+    ipPrefix?: string | null;
+    method?: string;
+  };
+  /** La escribió la red de seguridad porque ningún handler dijo qué pasó. */
+  synthesized?: boolean;
 }
 
 interface AuditPage {
@@ -21,31 +33,114 @@ const FILTERS = [
   { key: "action", label: "Acción", placeholder: "user.role.change" },
   { key: "performedBy", label: "Autor (uid)", placeholder: "uid del actor" },
   { key: "targetId", label: "Objetivo", placeholder: "uid o id del recurso" },
+  { key: "category", label: "Categoría", placeholder: "security, access…" },
+  { key: "severity", label: "Severidad", placeholder: "notable, critical…" },
+  { key: "outcome", label: "Resultado", placeholder: "denied, failure…" },
+  {
+    key: "context.ipPrefix",
+    label: "Red (prefijo)",
+    placeholder: "181.65.42.0/24",
+  },
 ] as const;
 
 type FilterKey = (typeof FILTERS)[number]["key"];
 
-/** Acciones que tocan el control de acceso: se resaltan al revisar. */
-const ACCESS_ACTIONS = new Set([
-  "user.role.change",
-  "user.status.change",
-  "user.grants.change",
-]);
+const FILTER_KEYS = FILTERS.map((f) => f.key) as readonly string[];
+
+/**
+ * Atajos: las dos preguntas que de verdad se hacen al abrir esta pantalla, sin
+ * tener que recordar qué valor va en qué campo.
+ */
+const PRESETS = [
+  { label: "Todo", params: {} as Record<string, string> },
+  { label: "Seguridad", params: { category: "security" } },
+  { label: "Notable", params: { severity: "notable" } },
+  { label: "Accesos", params: { category: "access" } },
+  { label: "Denegado", params: { outcome: "denied" } },
+];
+
+/**
+ * Color por severidad, no por una lista de acciones a mano.
+ *
+ * Antes era un `Set` con tres nombres de acción escritos a mano. Esa lista se
+ * desincroniza en cuanto se añade una acción —y se añadieron muchas—, así que
+ * el resaltado dejaba de marcar justo lo nuevo. Derivarlo del campo hace que
+ * cualquier acción futura entre con el color que le toca sin tocar nada aquí.
+ */
+const SEVERITY_STYLE: Record<string, string> = {
+  critical: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
+  warning:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+  notice: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  info: "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300",
+};
+
+const OUTCOME_LABEL: Record<string, string> = {
+  success: "OK",
+  denied: "Denegado",
+  failure: "Fallo",
+};
+
+const OUTCOME_STYLE: Record<string, string> = {
+  success: "text-green-700 dark:text-green-400",
+  denied: "text-amber-700 dark:text-amber-400",
+  failure: "text-red-700 dark:text-red-400",
+};
 
 function formatDate(ts: AuditEntry["timestamp"]): string {
   if (!ts?._seconds) return "—";
   return new Date(ts._seconds * 1000).toLocaleString("es-PE");
 }
 
+/** Lee el filtro de la URL, para que un hallazgo se pueda enlazar. */
+function paramsFromUrl(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  const search = new URLSearchParams(window.location.search);
+  for (const key of FILTER_KEYS) {
+    const value = search.get(key);
+    if (value) return { [key]: value };
+  }
+  return {};
+}
+
+function syncUrl(params: Record<string, string>) {
+  if (typeof window === "undefined") return;
+  const search = new URLSearchParams(window.location.search);
+  for (const key of FILTER_KEYS) search.delete(key);
+  for (const [key, value] of Object.entries(params)) search.set(key, value);
+  const query = search.toString();
+  window.history.replaceState(
+    null,
+    "",
+    query ? `${window.location.pathname}?${query}` : window.location.pathname
+  );
+}
+
+const COLUMNS = [
+  "Fecha",
+  "Acción",
+  "Resultado",
+  "Autor",
+  "Objetivo",
+  "Red",
+  "Detalle",
+];
+
 export function AuditLog() {
+  // Se lee UNA vez al montar, no en cada render: es el estado inicial que trae
+  // la URL, y recalcularlo continuamente además dejaría el efecto de abajo con
+  // una dependencia que cambia de identidad en cada pasada.
+  const [initial] = useState(paramsFromUrl);
+  const initialKey = (Object.keys(initial)[0] ?? "action") as FilterKey;
+
   const [entries, setEntries] = useState<AuditEntry[]>([]);
   const [cursor, setCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [filterKey, setFilterKey] = useState<FilterKey>("action");
-  const [filterValue, setFilterValue] = useState("");
-  const [applied, setApplied] = useState<Record<string, string>>({});
+  const [filterKey, setFilterKey] = useState<FilterKey>(initialKey);
+  const [filterValue, setFilterValue] = useState(initial[initialKey] ?? "");
+  const [applied, setApplied] = useState<Record<string, string>>(initial);
 
   const load = useCallback(
     async (params: Record<string, string>, append: boolean) => {
@@ -71,20 +166,30 @@ export function AuditLog() {
   );
 
   useEffect(() => {
-    load({}, false);
-  }, [load]);
+    load(initial, false);
+  }, [load, initial]);
+
+  function apply(params: Record<string, string>) {
+    setApplied(params);
+    syncUrl(params);
+    load(params, false);
+  }
 
   function applyFilter(e: React.FormEvent) {
     e.preventDefault();
-    const next = filterValue.trim() ? { [filterKey]: filterValue.trim() } : {};
-    setApplied(next);
-    load(next, false);
+    apply(filterValue.trim() ? { [filterKey]: filterValue.trim() } : {});
+  }
+
+  function applyPreset(params: Record<string, string>) {
+    const key = (Object.keys(params)[0] ?? "action") as FilterKey;
+    setFilterKey(key);
+    setFilterValue(params[key] ?? "");
+    apply(params);
   }
 
   function clearFilter() {
     setFilterValue("");
-    setApplied({});
-    load({}, false);
+    apply({});
   }
 
   if (loading) {
@@ -98,9 +203,31 @@ export function AuditLog() {
   return (
     <div>
       <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
-        Registro de todas las operaciones de escritura. Es de solo lectura:
-        nadie, ni un administrador, puede editarlo ni borrarlo desde el panel.
+        Registro de todas las operaciones de escritura, los intentos denegados y
+        las lecturas de datos sensibles. Es de solo lectura: nadie, ni un
+        administrador, puede editarlo ni borrarlo desde el panel.
       </p>
+
+      <div className="mb-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => {
+          const active =
+            JSON.stringify(preset.params) === JSON.stringify(applied);
+          return (
+            <button
+              key={preset.label}
+              type="button"
+              onClick={() => applyPreset(preset.params)}
+              className={`rounded-full px-3 py-1 text-xs font-medium ${
+                active
+                  ? "bg-blue-600 text-white"
+                  : "border border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+              }`}
+            >
+              {preset.label}
+            </button>
+          );
+        })}
+      </div>
 
       <form onSubmit={applyFilter} className="mb-6 flex flex-wrap gap-2">
         <select
@@ -153,25 +280,31 @@ export function AuditLog() {
           <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
             <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                {["Fecha", "Acción", "Autor", "Objetivo", "Detalle"].map(
-                  (h) => (
-                    <th
-                      key={h}
-                      className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      {h}
-                    </th>
-                  )
-                )}
+                {COLUMNS.map((h) => (
+                  <th
+                    key={h}
+                    className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
+                  >
+                    {h}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
               {entries.map((entry) => {
                 const reason = entry.details?.reason;
+                const severity = entry.severity ?? "info";
+                const outcome = entry.outcome ?? "success";
                 return (
                   <tr
                     key={entry.id}
-                    className="align-top hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    className={`align-top hover:bg-gray-50 dark:hover:bg-gray-700/50 ${
+                      // Una fila sintética significa que hay código mutando sin
+                      // decir qué. Se marca para que incomode, no para que pase.
+                      entry.synthesized
+                        ? "border-l-4 border-l-amber-500 bg-amber-50/40 dark:bg-amber-900/10"
+                        : ""
+                    }`}
                   >
                     <td className="px-4 py-3 whitespace-nowrap text-gray-500 dark:text-gray-400">
                       {formatDate(entry.timestamp)}
@@ -179,19 +312,50 @@ export function AuditLog() {
                     <td className="px-4 py-3">
                       <span
                         className={`rounded-full px-2 py-0.5 font-mono text-xs font-medium ${
-                          ACCESS_ACTIONS.has(entry.action)
-                            ? "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
-                            : "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+                          SEVERITY_STYLE[severity] ?? SEVERITY_STYLE.info
                         }`}
                       >
                         {entry.action}
                       </span>
+                      {entry.synthesized && (
+                        <span
+                          className="ml-2 text-xs text-amber-700 dark:text-amber-400"
+                          title="Ningún handler declaró esta operación: la registró la red de seguridad."
+                        >
+                          sin declarar
+                        </span>
+                      )}
+                      {entry.category && (
+                        <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                          {entry.category}
+                        </p>
+                      )}
+                    </td>
+                    <td
+                      className={`px-4 py-3 text-xs font-medium whitespace-nowrap ${
+                        OUTCOME_STYLE[outcome] ?? ""
+                      }`}
+                    >
+                      {OUTCOME_LABEL[outcome] ?? outcome}
                     </td>
                     <td className="px-4 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
                       {entry.performedBy}
+                      {entry.actor?.role && (
+                        <p className="mt-1 font-sans text-gray-400 dark:text-gray-500">
+                          {entry.actor.role}
+                        </p>
+                      )}
                     </td>
                     <td className="px-4 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
                       {entry.targetId || "—"}
+                      {entry.targetType && (
+                        <p className="mt-1 font-sans text-gray-400 dark:text-gray-500">
+                          {entry.targetType}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs whitespace-nowrap text-gray-500 dark:text-gray-500">
+                      {entry.context?.ipPrefix || "—"}
                     </td>
                     <td className="px-4 py-3 text-gray-600 dark:text-gray-400">
                       {typeof reason === "string" && (
@@ -208,6 +372,14 @@ export function AuditLog() {
                           )
                         )}
                       </code>
+                      {entry.context?.requestId && (
+                        <p
+                          className="mt-1 font-mono text-xs text-gray-400 dark:text-gray-600"
+                          title="Id de correlación: sirve para cruzar esta fila con Cloud Logging."
+                        >
+                          {entry.context.requestId}
+                        </p>
+                      )}
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## What changed

**Three sensitive reads are now recorded** via a declarative `auditedRead()` middleware:

| Route | Mode |
| --- | --- |
| `GET /api/audit` | one row per person per hour |
| `GET /api/users` | one row per person per hour |
| `GET /api/forms/:id/responses` | every call |

**Four new composite indexes** (`category`, `severity`, `outcome`, `context.ipPrefix`, each with `timestamp DESC`) and the matching filters on the endpoint. `severity=notable` maps to an `in` over warning+critical.

**Viewer rework** (`AuditLog.tsx`): new Outcome / Network columns, `targetType` finally rendered, the correlation id shown under the detail, `synthesized` rows flagged "sin declarar", five preset shortcuts, and filter state moved into the query string.

## Why

Reads were not audited at all. That is right as a rule — a row per GET means a row per page view, and a log where 99% of rows are "someone opened a screen" is no use for finding the 1% that matters. But it left out three cases that do matter, and **who read the audit log is exactly the kind of thing an audit log should record**. It was the only screen with no trace of its own readers.

The two panel-driven reads are grouped hourly because the panel requests them on every mount and every tab focus. The form-responses export is not grouped: it is a bulk export of respondents' personal data, used rarely and deliberately, so each read is a distinct fact worth dating.

On the viewer: the amber highlight was driven by a hand-written `Set` of three action names. That list desynchronised the moment actions were added — and many were — so the highlight stopped marking precisely what was new. Deriving the colour from `severity` means any future action arrives with the right colour without touching the component.

## One finding that narrows the scope

**The attendee roster and the credentials carrying personal data do not go through the API.** The panel reads them straight from Firestore, bounded by the rules (`canOnEvent('roster:read', slug)`), so there is no endpoint to hook and covering them would mean instrumenting the Firestore side. The plan listed them as auditable and they are not. This is annotated in `auditActions.ts` so nobody assumes that read is covered — it is the kind of assumption discovered exactly when the data is needed.

## Why `notable` is an `in` and not an inequality

`severity >= "warning"` would have been the obvious way. Firestore requires the first `orderBy` to be the inequality's field, so that would force ordering by `severity` — and the record stops being ordered by date, which is the only thing that makes it readable as a chronology.

## How to test

```bash
cd functions && pnpm build && pnpm test   # 672 tests at this commit
```

Then, from `/admin/audit`:

1. Open the page twice within the hour → exactly one `read.audit_log` row.
2. Export form responses twice → two `read.form_responses` rows, each with the form id.
3. Click the **Seguridad** preset → URL gains `?category=security`; paste that URL in a new tab and confirm the filter is already applied.
4. Trigger a 403 on a read → no read row (nothing was read), but the security event is there.

`firebase deploy --only firestore:indexes` is needed before the new filters work against production.

## Notes for the reviewer

- The read dedupe window is in-memory and per instance, same caveat as everything else in this series.
- `handlers/audit.ts` had no tests at all before this; it now covers the seven filters, the two-filter rejection, the `notable` translation, the 200 limit cap and the document cursor.