### PR TITLE
feat(audit): email alerts, monthly export, App Check cache and the runbook

### DIFF
--- a/docs/auditoria.md
+++ b/docs/auditoria.md
@@ -1,0 +1,246 @@
+# Runbook: el registro de auditoría
+
+Qué se registra, cómo investigar un incidente con él, y los tres pasos manuales
+que el código no puede dar por su cuenta.
+
+## Qué contiene
+
+La colección `audit_log` guarda una fila por operación. Cada fila lleva:
+
+| Campo                     | Qué es                                                            |
+| ------------------------- | ----------------------------------------------------------------- |
+| `action`                  | del registro cerrado de `functions/src/utils/auditActions.ts`     |
+| `performedBy` · `actor`   | uid, correo, rol con el que se actuó y alcance                    |
+| `targetId` · `targetType` | sobre qué se actuó                                                |
+| `outcome`                 | `success`, `denied` o `failure`                                   |
+| `severity`                | `info`, `notice`, `warning`, `critical`                           |
+| `category`                | `content`, `access`, `operations`, `minigame`, `read`, `security` |
+| `context`                 | `requestId`, `method`, patrón de ruta, prefijo de red, user-agent |
+| `details`                 | libre, propio de cada acción                                      |
+| `synthesized`             | `true` si la escribió la red de seguridad, no un handler          |
+
+**Lo que NO contiene**: la dirección IP completa (solo el prefijo /24 o /48), ni
+DNI, nombre o correo de asistentes. Los plazos y el motivo están en
+[retención de datos](./retencion-de-datos.md).
+
+### Tres cosas que conviene saber antes de fiarse del registro
+
+1. **Los cambios de acceso son atómicos; el resto, no.** Rol, estado, grants,
+   staff por evento, alta de cuenta y canje de invitación escriben su fila en el
+   mismo batch o transacción que la mutación: o quedan las dos o no queda
+   ninguna. Las demás acciones usan `writeAuditLog`, que registra el fallo y
+   deja seguir — una fila perdida ahí es posible, aunque quede en Cloud Logging.
+
+2. **Cloud Logging tiene MÁS que Firestore, no menos.** Cada fila se espeja allí
+   con la IP completa, y los eventos de seguridad de nivel `log-only` (token
+   inválido, App Check ausente) **solo** existen ahí. Si el panel no explica algo,
+   el siguiente sitio donde mirar es Cloud Logging, no la conclusión de que no
+   pasó.
+
+3. **Los contadores son por instancia.** El presupuesto de escrituras de
+   seguridad (30/min) y la agrupación de lecturas repetidas (1/hora) viven en
+   memoria, igual que los rate limiters. Con varias instancias activas el
+   número real de filas puede ser mayor que el nominal. No es un fallo: un
+   contador compartido costaría una lectura y una escritura por denegación.
+
+## Investigar un incidente
+
+### 1. Empieza por lo notable
+
+En `/admin/audit`, el atajo **Notable** (`?severity=notable`) trae todo lo
+`warning` y `critical`. **Seguridad** (`?category=security`) trae solo
+denegaciones, canjes fallidos y throttling.
+
+Señales por orden de gravedad:
+
+- `security.account.suspended_access` — una cuenta suspendida con un token
+  todavía vivo intentando operar. Es la señal más limpia de una cuenta
+  comprometida o de alguien que ya no debería estar.
+- `security.invitation.redeem_failed` — con `details.reason`. Un `no_match`
+  repetido desde la misma red es alguien probando tokens; un `race_already_used`
+  es un enlace compartido.
+- `user.role.change` / `user.grants.change` que no reconozcas.
+- Filas con `synthesized: true` — hay código mutando sin declarar qué. No es un
+  ataque: es un hueco de instrumentación que hay que cerrar.
+- `security.audit.throttled` — se está suprimiendo registro. Lo que falta está
+  en Cloud Logging.
+
+### 2. Sigue el hilo por la red y por la persona
+
+El prefijo de red contesta "qué más hizo esta red":
+
+```
+/admin/audit?context.ipPrefix=181.65.42.0/24
+```
+
+Y por persona: `?performedBy=<uid>`. Solo se admite **un filtro a la vez** —
+cada uno cuesta un índice compuesto, y la categoría sola ya da la vista que
+hace falta.
+
+### 3. Cruza con Cloud Logging por el `requestId`
+
+Cada fila lleva un `requestId`, visible bajo el detalle en el panel y devuelto
+en la cabecera `X-Request-Id` de cada respuesta. Con él:
+
+```bash
+gcloud logging read \
+  'jsonPayload.requestId="<request-id>"' \
+  --project=appgdgica --limit=50 --freshness=30d
+```
+
+Eso trae la IP completa, los eventos `log-only` de esa misma petición, y
+cualquier error no capturado.
+
+Para ver todo el espejo de auditoría de un periodo:
+
+```bash
+gcloud logging read \
+  'jsonPayload.message="audit" AND jsonPayload.severity="critical"' \
+  --project=appgdgica --limit=100 --freshness=7d
+```
+
+### 4. Si hay que cortar
+
+`PATCH /api/users/:uid/status` con `status: "suspended"` desde `/admin/users`.
+La suspensión corta todos los permisos de golpe y surte efecto en la siguiente
+petición, porque el doc de usuario se lee en cada una. **No** hace falta deshacer
+rol y grants uno a uno.
+
+Ojo: suspender no invalida el ID token, que vive hasta una hora. Lo que hace es
+que ninguna petición pase el middleware — y cada intento posterior queda como
+`security.account.suspended_access`, que es justamente la señal que se quiere.
+
+## Alertas
+
+`functions/src/triggers/auditAlerts.ts` corre cada hora, busca lo `critical`
+desde su marca de agua (`settings/auditAlerts`) y manda un correo a la dirección
+de contacto. Un solo correo con todo lo acumulado, no uno por evento.
+
+Si las alertas dejan de llegar, el fallo está en Cloud Logging:
+
+```bash
+gcloud logging read 'jsonPayload.message="audit.alert.failed"' \
+  --project=appgdgica --limit=20 --freshness=7d
+```
+
+La marca de agua avanza aunque el correo falle. Es deliberado: reintentar
+dejando la ventana abierta significaría que un problema persistente de SMTP
+acumula filas y manda un correo enorme al arreglarse. El registro sigue
+completo en el panel.
+
+## Copias
+
+`functions/src/triggers/exportAudit.ts` exporta `audit_log` a GCS el día 1 de
+cada mes. Existe porque las reglas cierran la colección a los clientes pero el
+Admin SDK las salta: quien comprometa el panel puede borrar filas.
+
+**Requiere dos pasos manuales una vez.** Sin ellos el export falla con un 403
+que queda en el log:
+
+```bash
+# 1. El bucket destino
+gcloud storage buckets create gs://appgdgica-audit-backups \
+  --project=appgdgica --location=southamerica-west1
+
+# 2. Permiso de export para la cuenta de servicio de las funciones
+gcloud projects add-iam-policy-binding appgdgica \
+  --member="serviceAccount:appgdgica@appspot.gserviceaccount.com" \
+  --role="roles/datastore.importExportAdmin"
+```
+
+Comprobar que salió:
+
+```bash
+gcloud logging read 'jsonPayload.message="audit.export.started"' \
+  --project=appgdgica --limit=5 --freshness=40d
+```
+
+---
+
+## Los tres pasos manuales
+
+### 1. Log bucket bloqueado — IRREVERSIBLE
+
+Es el control de inmutabilidad **real**, y el único que resiste el escenario que
+motiva tener uno: una cuenta comprometida con permisos de administración.
+
+La cuenta de servicio de la función no puede borrar sus propios logs, y eso ya
+es útil. Pero un **owner** del proyecto sí puede (`gcloud logging logs delete`,
+o borrando el bucket). Lo que cierra eso es un bucket con retención bloqueada:
+una vez bloqueado **no se puede desbloquear, ni acortar el plazo, ni borrar el
+bucket** — ni tú, ni un owner, ni el soporte de Google.
+
+> **Leer antes de ejecutar:** el bloqueo es permanente. Vas a pagar el
+> almacenamiento de esos logs durante todo el plazo que fijes, sin poder
+> cancelarlo. Empieza con un plazo que estés dispuesto a sostener; 400 días
+> cubre el año fiscal y algo de margen.
+
+```bash
+# Crear el bucket de logs con retención
+gcloud logging buckets create audit-locked \
+  --location=global --retention-days=400 \
+  --description="Espejo de auditoría, retención bloqueada" \
+  --project=appgdgica
+
+# Enrutar solo el espejo de auditoría y los eventos de seguridad
+gcloud logging sinks create audit-mirror \
+  logging.googleapis.com/projects/appgdgica/locations/global/buckets/audit-locked \
+  --log-filter='jsonPayload.message="audit" OR jsonPayload.message=~"^security\."' \
+  --project=appgdgica
+
+# Y SOLO cuando lo anterior esté verificado y funcionando:
+gcloud logging buckets update audit-locked \
+  --location=global --locked --project=appgdgica
+```
+
+Verifica que el sink recibe datos **antes** de bloquear. Un bucket bloqueado y
+vacío no se puede borrar, y habrías fijado un plazo irrevocable sobre nada.
+
+### 2. Activar App Check — solo después de mirar los logs
+
+`settings/appcheck.enforce` está en `false`. Activarlo cierra los endpoints
+públicos de credenciales a quien no traiga un token válido de App Check.
+
+**Primero comprueba que los clientes reales lo mandan.** `src/lib/api.ts` omite
+la cabecera en silencio cuando `getAppCheckToken()` devuelve `null`, así que si
+reCAPTCHA no funciona para tus asistentes, activarlo los deja fuera sin aviso —
+y descubrirlo en mitad de un evento es el peor momento posible.
+
+```bash
+gcloud logging read 'jsonPayload.message="security.appcheck.missing"' \
+  --project=appgdgica --limit=100 --freshness=7d
+```
+
+Lo que buscas es que ese recuento sea **bajo y estable** en un periodo con
+tráfico real de un evento. Si es alto, hay clientes legítimos sin cabecera y
+activarlo los rechazaría.
+
+Cuando el número convenza, poner `enforce: true` en el documento
+`settings/appcheck` desde la consola de Firebase.
+
+**Interruptor de emergencia:** volver a poner `enforce: false` desde la consola.
+Surte efecto sin desplegar. Está escrito aquí porque es la razón por la que
+activarlo es aceptable — pero ojo con el punto siguiente.
+
+> Desde el arreglo de la caché, un error transitorio de lectura de Firestore
+> **conserva** el último valor conocido en vez de abrir el paso. Eso solo afecta
+> a peticiones que ya llegaban sin token válido —un token válido no lee el
+> ajuste—, así que no toca a los clientes legítimos. Pero significa que el
+> interruptor de emergencia necesita que Firestore sea legible; si no lo es, el
+> flujo de credenciales está roto de todas formas, porque también escribe ahí.
+
+### 3. Enviar las invitaciones
+
+Este runbook existe para poder mandarlas con red debajo. Antes de la primera:
+
+- [ ] `pnpm test` en `functions/` y `pnpm test:rules` en la raíz, en verde.
+- [ ] Un cambio de rol de prueba aparece en `/admin/audit` con `requestId`,
+      `ipPrefix` y `actor.role`.
+- [ ] Un canje con un token inventado deja `security.invitation.redeem_failed`
+      con el motivo real, mientras la respuesta sigue siendo el mensaje opaco.
+- [ ] El correo de alerta llega tras un cambio de rol de prueba.
+- [ ] Los pasos 1 y 2 hechos, o decididos a conciencia para más tarde.
+
+Los permisos de una invitación no son reversibles hacia atrás en el tiempo: lo
+que alguien vea mientras tiene acceso, ya lo vio. El registro sirve para saber
+qué pasó, no para deshacerlo.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -25,6 +25,38 @@
       ]
     },
     {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "severity", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "outcome", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "context.ipPrefix", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "minigames",
       "queryScope": "COLLECTION",
       "fields": [

--- a/functions/src/handlers/audit.test.ts
+++ b/functions/src/handlers/audit.test.ts
@@ -1,0 +1,232 @@
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Consultas construidas, para poder afirmar sobre lo que se pidió a Firestore. */
+interface RecordedQuery {
+  wheres: { field: string; op: string; value: unknown }[];
+  orderBy: string | null;
+  limit: number | null;
+  startAfter: string | null;
+}
+
+let recorded: RecordedQuery;
+let rows: { id: string; data: Record<string, unknown> }[] = [];
+let cursorExists = true;
+
+function queryStub(): Record<string, unknown> {
+  const self = {
+    where: (field: string, op: string, value: unknown) => {
+      recorded.wheres.push({ field, op, value });
+      return self;
+    },
+    orderBy: (field: string) => {
+      recorded.orderBy = field;
+      return self;
+    },
+    limit: (n: number) => {
+      recorded.limit = n;
+      return self;
+    },
+    startAfter: (doc: { id: string }) => {
+      recorded.startAfter = doc.id;
+      return self;
+    },
+    get: async () => ({
+      docs: rows.map((r) => ({ id: r.id, data: () => r.data })),
+    }),
+  };
+  return self as unknown as Record<string, unknown>;
+}
+
+vi.mock("firebase-admin", () => ({
+  firestore: () => ({
+    collection: () => ({
+      ...queryStub(),
+      doc: (id: string) => ({
+        get: async () => ({ exists: cursorExists, id }),
+      }),
+    }),
+  }),
+}));
+
+vi.mock("firebase-functions", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { listAudit } from "./audit";
+
+interface ResMock extends Response {
+  __status: number | undefined;
+  __body:
+    | {
+        success?: boolean;
+        error?: string;
+        data?: { entries?: unknown[]; nextCursor?: string | null };
+      }
+    | undefined;
+}
+
+function buildRes(): ResMock {
+  const res: Partial<ResMock> = {};
+  res.status = vi.fn(function (this: ResMock, code: number) {
+    this.__status = code;
+    return this;
+  }) as ResMock["status"];
+  res.json = vi.fn(function (this: ResMock, body: unknown) {
+    this.__body = body as ResMock["__body"];
+    return this;
+  }) as ResMock["json"];
+  return res as ResMock;
+}
+
+function buildReq(query: Record<string, string> = {}): Request {
+  return { query } as unknown as Request;
+}
+
+function seed(n: number) {
+  rows = Array.from({ length: n }, (_, i) => ({
+    id: `e${i}`,
+    data: { action: "event.create", performedBy: "u1" },
+  }));
+}
+
+beforeEach(() => {
+  recorded = { wheres: [], orderBy: null, limit: null, startAfter: null };
+  cursorExists = true;
+  seed(3);
+});
+
+describe("orden y forma", () => {
+  // El registro se lee como una cronología: cualquier otro orden lo vuelve
+  // ilegible para lo que se usa.
+  it("ordena por timestamp descendente", async () => {
+    await listAudit(buildReq(), buildRes());
+    expect(recorded.orderBy).toBe("timestamp");
+  });
+
+  it("devuelve las entradas con su id", async () => {
+    const res = buildRes();
+    await listAudit(buildReq(), res);
+    expect(res.__body?.data?.entries).toHaveLength(3);
+    expect(res.__body?.success).toBe(true);
+  });
+});
+
+describe("filtros", () => {
+  it.each([
+    "action",
+    "performedBy",
+    "targetId",
+    "category",
+    "severity",
+    "outcome",
+    "context.ipPrefix",
+  ])("admite el filtro %s", async (field) => {
+    await listAudit(buildReq({ [field]: "x" }), buildRes());
+    expect(recorded.wheres).toEqual([{ field, op: "==", value: "x" }]);
+  });
+
+  // Cada combinación exigiría su propio índice compuesto: permitir dos
+  // multiplicaría los índices para comprar una comodidad que nadie pidió.
+  it("rechaza dos filtros a la vez", async () => {
+    const res = buildRes();
+    await listAudit(
+      buildReq({ action: "event.create", performedBy: "u1" }),
+      res
+    );
+    expect(res.__status).toBe(400);
+    expect(res.__body?.error).toContain("at most one filter");
+    expect(recorded.wheres).toEqual([]);
+  });
+
+  it("sin filtro no añade ningún where", async () => {
+    await listAudit(buildReq(), buildRes());
+    expect(recorded.wheres).toEqual([]);
+  });
+
+  it("ignora un filtro vacío", async () => {
+    await listAudit(buildReq({ action: "" }), buildRes());
+    expect(recorded.wheres).toEqual([]);
+  });
+
+  // Se resuelve con un `in` sobre el campo que ya tiene índice. Una desigualdad
+  // `severity >= "warning"` obligaría a que el primer orderBy fuese `severity`,
+  // y entonces el registro dejaría de estar ordenado por fecha.
+  it("severity=notable se traduce a un `in`", async () => {
+    await listAudit(buildReq({ severity: "notable" }), buildRes());
+    expect(recorded.wheres).toEqual([
+      { field: "severity", op: "in", value: ["warning", "critical"] },
+    ]);
+    expect(recorded.orderBy).toBe("timestamp");
+  });
+
+  it("una severidad concreta sigue siendo igualdad", async () => {
+    await listAudit(buildReq({ severity: "critical" }), buildRes());
+    expect(recorded.wheres).toEqual([
+      { field: "severity", op: "==", value: "critical" },
+    ]);
+  });
+
+  // El prefijo de red es lo único que se guarda; la dirección completa vive
+  // solo en Cloud Logging.
+  it("filtra por prefijo de red", async () => {
+    await listAudit(
+      buildReq({ "context.ipPrefix": "181.65.42.0/24" }),
+      buildRes()
+    );
+    expect(recorded.wheres[0]).toMatchObject({
+      field: "context.ipPrefix",
+      value: "181.65.42.0/24",
+    });
+  });
+});
+
+describe("paginación", () => {
+  it("por defecto pide 50 más uno", async () => {
+    await listAudit(buildReq(), buildRes());
+    expect(recorded.limit).toBe(51);
+  });
+
+  it("acota el límite a 200", async () => {
+    await listAudit(buildReq({ limit: "5000" }), buildRes());
+    expect(recorded.limit).toBe(201);
+  });
+
+  it("ignora un límite absurdo", async () => {
+    await listAudit(buildReq({ limit: "-3" }), buildRes());
+    expect(recorded.limit).toBe(51);
+  });
+
+  // Se pide uno de más para saber si hay página siguiente sin contar la
+  // colección entera.
+  it("no devuelve el de más y expone el cursor", async () => {
+    seed(51);
+    const res = buildRes();
+    await listAudit(buildReq(), res);
+    expect(res.__body?.data?.entries).toHaveLength(50);
+    expect(res.__body?.data?.nextCursor).toBe("e49");
+  });
+
+  it("sin más páginas el cursor es null", async () => {
+    seed(10);
+    const res = buildRes();
+    await listAudit(buildReq(), res);
+    expect(res.__body?.data?.nextCursor).toBeNull();
+  });
+
+  // Cursor por documento y no por fecha: varias entradas pueden compartir
+  // `timestamp` (una operación que escribe varias filas), y paginar por valor
+  // se saltaría entradas o las repetiría.
+  it("pagina con el documento del cursor", async () => {
+    await listAudit(buildReq({ cursor: "e7" }), buildRes());
+    expect(recorded.startAfter).toBe("e7");
+  });
+
+  it("rechaza un cursor inexistente", async () => {
+    cursorExists = false;
+    const res = buildRes();
+    await listAudit(buildReq({ cursor: "fantasma" }), res);
+    expect(res.__status).toBe(400);
+    expect(res.__body?.error).toBe("Invalid cursor");
+  });
+});

--- a/functions/src/handlers/audit.ts
+++ b/functions/src/handlers/audit.ts
@@ -11,8 +11,32 @@ const MAX_LIMIT = 200;
  * y solo se admite UN filtro a la vez: combinarlos multiplicaría los índices
  * sin que nadie los esté pidiendo.
  */
-const FILTERABLE = ["action", "performedBy", "targetId"] as const;
+const FILTERABLE = [
+  "action",
+  "performedBy",
+  "targetId",
+  // Categoría: es la única forma de pedir "solo lo de seguridad". Firestore no
+  // filtra por prefijo de cadena, así que sin un campo propio esa pregunta no
+  // se puede hacer.
+  "category",
+  "severity",
+  "outcome",
+  // Respuesta a incidentes: "qué más hizo esta red". Solo el prefijo, nunca la
+  // dirección completa — esa vive únicamente en Cloud Logging.
+  "context.ipPrefix",
+] as const;
 type Filterable = (typeof FILTERABLE)[number];
+
+/**
+ * Severidades que alguien querría revisar de una sentada.
+ *
+ * Se resuelve con un `in` sobre el mismo campo que ya tiene índice. La
+ * alternativa —una desigualdad `severity >= "warning"`— no sirve: Firestore
+ * exige que el primer `orderBy` sea el campo de la desigualdad, y aquí el orden
+ * tiene que ser por `timestamp` o el registro deja de leerse como una
+ * cronología.
+ */
+const NOTABLE_SEVERITIES = ["warning", "critical"];
 
 function readLimit(raw: unknown): number {
   const parsed = typeof raw === "string" ? parseInt(raw, 10) : NaN;
@@ -47,7 +71,13 @@ export async function listAudit(req: Request, res: Response) {
 
     if (active.length === 1) {
       const field = active[0] as Filterable;
-      query = query.where(field, "==", req.query[field] as string);
+      const value = req.query[field] as string;
+
+      if (field === "severity" && value === "notable") {
+        query = query.where("severity", "in", NOTABLE_SEVERITIES);
+      } else {
+        query = query.where(field, "==", value);
+      }
     }
 
     const limit = readLimit(req.query.limit);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,7 +9,7 @@ import { requirePermission, requireAuth } from "./middleware/auth";
 import { isAllowedOrigin, rejectDisallowedOrigin } from "./middleware/cors";
 import { safeError, validateParamId } from "./middleware/validate";
 import { verifyAppCheck } from "./middleware/appCheck";
-import { auditContext } from "./middleware/auditContext";
+import { auditContext, auditedRead } from "./middleware/auditContext";
 import { recordSecurityEvent } from "./utils/securityAudit";
 import { validateBody } from "./middleware/validateBody";
 import {
@@ -394,7 +394,15 @@ app.put(
 );
 
 // Users
-app.get("/api/users", requirePermission("users:read"), users.listUsers);
+// Devuelve los docs completos, con correo, grants y revocaciones. Agrupado por
+// hora: el panel lo pide en cada montaje y en cada foco de pestaña, así que una
+// fila por llamada sería una fila por vista de página.
+app.get(
+  "/api/users",
+  requirePermission("users:read"),
+  auditedRead("read.users", "user_list", { dedupe: true }),
+  users.listUsers
+);
 app.patch(
   "/api/users/:uid/role",
   requirePermission("users:role:write"),
@@ -418,7 +426,15 @@ app.put(
 );
 
 // Audit log — de solo lectura, y solo para quien tenga `audit:read`.
-app.get("/api/audit", requirePermission("audit:read"), audit.listAudit);
+// Quién leyó el registro es justo el tipo de cosa que un registro de auditoría
+// debería contar, y hasta ahora era la única pantalla que no dejaba rastro de
+// sus propios lectores.
+app.get(
+  "/api/audit",
+  requirePermission("audit:read"),
+  auditedRead("read.audit_log", "audit_log", { dedupe: true }),
+  audit.listAudit
+);
 
 // Access — solicitudes e invitaciones.
 //
@@ -578,10 +594,14 @@ app.delete(
   writeLimiter,
   forms.deleteForm
 );
+// Por llamada, SIN agrupar: es una exportación masiva de datos personales de
+// quien respondió, se usa poco y a propósito. Aquí cada lectura es un hecho
+// distinto que hay que poder fechar, no ruido de tener el panel abierto.
 app.get(
   "/api/forms/:id/responses",
   requirePermission("forms:responses:read"),
   vid,
+  auditedRead("read.form_responses", "form", { targetIdParam: "id" }),
   forms.getFormResponses
 );
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -956,3 +956,8 @@ export { onMinigameResponseWritten } from "./triggers/recomputeAggregates";
 // Deploying this creates a Cloud Scheduler job. It declares the Gmail
 // secrets itself; the `api` function's secrets array does not extend here.
 export { drainCredentialEmails } from "./triggers/drainCredentialEmails";
+// Aviso por correo de lo que hay que revisar en el registro: sin esto, toda la
+// instrumentación solo sirve si alguien se acuerda de abrir el panel.
+export { auditAlerts } from "./triggers/auditAlerts";
+// Copia mensual de audit_log fuera de Firestore, donde el Admin SDK no llega.
+export { exportAudit } from "./triggers/exportAudit";

--- a/functions/src/middleware/appCheck.test.ts
+++ b/functions/src/middleware/appCheck.test.ts
@@ -13,7 +13,11 @@ vi.mock("firebase-admin", () => ({
   }),
 }));
 
-import { verifyAppCheck } from "./appCheck";
+import {
+  verifyAppCheck,
+  readAppCheckEnforcement,
+  __resetAppCheckCache,
+} from "./appCheck";
 
 function buildReq(token?: string): Request {
   return {
@@ -52,6 +56,9 @@ function enforcement(enforce: boolean | undefined | "error") {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // El valor cacheado vive en el módulo, así que sin esto un test que activa la
+  // exigencia se la deja puesta al siguiente.
+  __resetAppCheckCache();
 });
 
 describe("verifyAppCheck", () => {
@@ -117,9 +124,10 @@ describe("verifyAppCheck", () => {
     expect(body.error).toMatch(/recarga la página/i);
   });
 
-  it("fails open when the setting cannot be read", async () => {
-    // A Firestore hiccup must not close public registration. The endpoint
-    // still has its per-IP limit and its per-event cap.
+  it("fails open when the setting cannot be read and nothing is cached", async () => {
+    // With no known value there is nothing to fall back on, so a Firestore
+    // hiccup must not close public registration. The endpoint still has its
+    // per-IP limit and its per-event cap.
     mocks.verifyToken.mockRejectedValue(new Error("bad"));
     enforcement("error");
     const next = vi.fn();
@@ -130,11 +138,82 @@ describe("verifyAppCheck", () => {
     expect(res.__status).toBeUndefined();
   });
 
+  // This replaces the older blanket "a hiccup always fails open". That was a
+  // hole: a Firestore blink silently switched App Check off and back on, so it
+  // neither protected nor said it wasn't protecting.
+  //
+  // Keeping the last known value is safe because a VALID token never reads the
+  // setting at all (see the first test). So this only affects requests that
+  // already arrived without a usable App Check token — exactly the ones
+  // enforcement exists to reject. Legitimate clients are untouched.
+  it("keeps enforcing through a hiccup once the setting was read as on", async () => {
+    enforcement(true);
+    expect(await readAppCheckEnforcement()).toBe(true);
+
+    mocks.verifyToken.mockRejectedValue(new Error("bad"));
+    enforcement("error");
+    const next = vi.fn();
+    const res = buildRes();
+    await verifyAppCheck()(buildReq("bad-token"), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.__status).toBe(403);
+  });
+
   it("treats a missing enforce field as unenforced", async () => {
     mocks.verifyToken.mockRejectedValue(new Error("bad"));
     enforcement(undefined);
     const next = vi.fn();
     await verifyAppCheck()(buildReq("bad-token"), buildRes(), next);
     expect(next).toHaveBeenCalledOnce();
+  });
+});
+
+/**
+ * La caché del interruptor.
+ *
+ * La bandera vive en Firestore para poder apagarla sin desplegar si reCAPTCHA se
+ * cae en mitad de un evento. Eso sigue funcionando; lo que cambia es qué pasa
+ * cuando la LECTURA falla.
+ */
+describe("readAppCheckEnforcement", () => {
+  it("reads the flag", async () => {
+    enforcement(true);
+    expect(await readAppCheckEnforcement()).toBe(true);
+    enforcement(false);
+    expect(await readAppCheckEnforcement()).toBe(false);
+  });
+
+  // Solo `true` exacto: un "true" de cadena en el documento no activa nada.
+  it("only an exact boolean true enforces", async () => {
+    mocks.settingsGet.mockResolvedValue({ data: () => ({ enforce: "true" }) });
+    expect(await readAppCheckEnforcement()).toBe(false);
+  });
+
+  it("survives several consecutive read failures", async () => {
+    enforcement(true);
+    await readAppCheckEnforcement();
+    enforcement("error");
+    expect(await readAppCheckEnforcement()).toBe(true);
+    expect(await readAppCheckEnforcement()).toBe(true);
+    expect(await readAppCheckEnforcement()).toBe(true);
+  });
+
+  it("caches a known false too", async () => {
+    enforcement(false);
+    expect(await readAppCheckEnforcement()).toBe(false);
+    enforcement("error");
+    expect(await readAppCheckEnforcement()).toBe(false);
+  });
+
+  // El interruptor de emergencia sigue siendo inmediato: en cuanto la lectura
+  // vuelve, manda el valor real y no el cacheado.
+  it("returns to the real value once reads recover", async () => {
+    enforcement(true);
+    await readAppCheckEnforcement();
+    enforcement("error");
+    expect(await readAppCheckEnforcement()).toBe(true);
+    enforcement(false);
+    expect(await readAppCheckEnforcement()).toBe(false);
   });
 });

--- a/functions/src/middleware/appCheck.ts
+++ b/functions/src/middleware/appCheck.ts
@@ -25,6 +25,27 @@ const HEADER = "x-firebase-appcheck";
  * way to disable it would be worse than the abuse it prevents. Start
  * unenforced, watch the logs, then turn it on.
  */
+/**
+ * Último valor leído con éxito, por instancia.
+ *
+ * Existe porque caer a `false` ante un error de lectura desactiva App Check en
+ * silencio: un parpadeo de Firestore bastaba para que la protección se apagara
+ * sin que nada lo dijera, y volviera sola cuando la lectura funcionase otra vez.
+ * Eso es lo peor de los dos mundos — ni protege ni avisa de que no protege.
+ *
+ * Con la caché, un error transitorio conserva la última decisión conocida. La
+ * primera lectura de una instancia sigue cayendo a `false` si falla, y eso se
+ * mantiene a propósito: sin ningún valor conocido, cerrar el paso convertiría un
+ * problema de Firestore en asistentes que no pueden sacar su credencial en
+ * mitad de un evento.
+ */
+let cachedEnforcement: boolean | null = null;
+
+/** Solo para los tests: olvida el valor cacheado. */
+export function __resetAppCheckCache(): void {
+  cachedEnforcement = null;
+}
+
 export async function readAppCheckEnforcement(): Promise<boolean> {
   try {
     const snap = await admin
@@ -32,11 +53,24 @@ export async function readAppCheckEnforcement(): Promise<boolean> {
       .collection("settings")
       .doc("appcheck")
       .get();
-    return snap.data()?.enforce === true;
+    cachedEnforcement = snap.data()?.enforce === true;
+    return cachedEnforcement;
   } catch (err) {
-    // Fail open: a settings read failure must not close public
-    // registration. The endpoint still has its rate limit and its cap.
-    logger.warn("Could not read the App Check enforcement setting", { err });
+    if (cachedEnforcement !== null) {
+      // Se conserva la última decisión conocida en vez de abrir el paso.
+      logger.warn(
+        "Could not read the App Check enforcement setting; keeping the last known value",
+        { err, enforce: cachedEnforcement }
+      );
+      return cachedEnforcement;
+    }
+    // Sin valor previo: se abre, con ruido. La alternativa —cerrar sin saber si
+    // la exigencia estaba activada— rompería el registro público por un fallo
+    // que puede no tener nada que ver.
+    logger.warn(
+      "Could not read the App Check enforcement setting and there is no cached value",
+      { err }
+    );
     return false;
   }
 }

--- a/functions/src/middleware/auditContext.test.ts
+++ b/functions/src/middleware/auditContext.test.ts
@@ -27,7 +27,12 @@ vi.mock("firebase-admin/firestore", () => ({
   FieldValue: { serverTimestamp: () => "__TS__" },
 }));
 
-import { auditContext, truncateIp } from "./auditContext";
+import {
+  auditContext,
+  auditedRead,
+  truncateIp,
+  __resetReadDedupeState,
+} from "./auditContext";
 
 /** Simula el ciclo de vida: entra la petición, responde, se dispara `finish`. */
 function run(opts: {
@@ -245,5 +250,126 @@ describe("red de seguridad", () => {
     run({ method: "POST", routePath: "/api/x" });
     await flush();
     expect(written[0]).toMatchObject({ performedBy: "unknown" });
+  });
+});
+
+/**
+ * Lecturas sensibles.
+ *
+ * Las lecturas no se auditan en general y eso es deliberado: una fila por GET
+ * daría una por vista de página, y un registro donde el 99% de las filas son
+ * "alguien abrió una pantalla" no sirve para encontrar el 1% que importa.
+ */
+describe("auditedRead", () => {
+  function runRead(opts: {
+    status?: number;
+    uid?: string;
+    params?: Record<string, string>;
+    action?: string;
+    dedupe?: boolean;
+    targetIdParam?: string;
+  }) {
+    const handlers: (() => void)[] = [];
+    const req = {
+      method: "GET",
+      path: "/api/forms/f1/responses",
+      baseUrl: "",
+      params: opts.params ?? {},
+      get: () => undefined,
+      ...(opts.uid ? { user: { uid: opts.uid } } : {}),
+    } as unknown as Request;
+    const res = {
+      statusCode: opts.status ?? 200,
+      setHeader: () => {},
+      on: (event: string, cb: () => void) => {
+        if (event === "finish") handlers.push(cb);
+      },
+    } as unknown as Response;
+
+    const next = vi.fn();
+    auditedRead((opts.action ?? "read.form_responses") as never, "form", {
+      dedupe: opts.dedupe,
+      targetIdParam: opts.targetIdParam,
+    })(req, res, next);
+    handlers.forEach((h) => h());
+    return { next };
+  }
+
+  beforeEach(() => {
+    __resetReadDedupeState();
+  });
+
+  it("registra la lectura con su categoría y llama a next()", async () => {
+    const { next } = runRead({ uid: "u1" });
+    await flush();
+    expect(next).toHaveBeenCalledOnce();
+    expect(written).toHaveLength(1);
+    expect(written[0]).toMatchObject({
+      action: "read.form_responses",
+      performedBy: "u1",
+      targetType: "form",
+      category: "read",
+    });
+  });
+
+  it("guarda qué se leyó cuando la ruta lo identifica", async () => {
+    runRead({ uid: "u1", params: { id: "f42" }, targetIdParam: "id" });
+    await flush();
+    expect(written[0]).toMatchObject({ targetId: "f42" });
+  });
+
+  // Un 403 no leyó nada, y además ya queda registrado como evento de seguridad
+  // por su cuenta: una fila de lectura ahí diría que alguien vio datos que no vio.
+  it.each([403, 404, 500])("no registra nada con un %i", async (status) => {
+    written.length = 0;
+    runRead({ status, uid: "u1" });
+    await flush();
+    expect(written).toHaveLength(0);
+  });
+
+  // La exportación masiva de respuestas se usa poco y a propósito: cada lectura
+  // es un hecho distinto que hay que poder fechar.
+  it("sin dedupe, cinco lecturas dejan cinco filas", async () => {
+    for (let i = 0; i < 5; i++) runRead({ uid: "u1" });
+    await flush();
+    expect(written).toHaveLength(5);
+  });
+
+  // El panel pide /api/users en cada montaje y en cada foco de pestaña.
+  it("con dedupe, veinte lecturas dejan una fila", async () => {
+    for (let i = 0; i < 20; i++) {
+      runRead({ uid: "u1", action: "read.users", dedupe: true });
+    }
+    await flush();
+    expect(written).toHaveLength(1);
+    expect(written[0].details).toMatchObject({ deduped: true });
+  });
+
+  it("el dedupe es por persona, no global", async () => {
+    runRead({ uid: "u1", action: "read.users", dedupe: true });
+    runRead({ uid: "u2", action: "read.users", dedupe: true });
+    await flush();
+    expect(written).toHaveLength(2);
+  });
+
+  it("el dedupe es por acción: leer usuarios y leer el log son dos filas", async () => {
+    runRead({ uid: "u1", action: "read.users", dedupe: true });
+    runRead({ uid: "u1", action: "read.audit_log", dedupe: true });
+    await flush();
+    expect(written).toHaveLength(2);
+  });
+
+  it("pasada la hora, vuelve a registrar", async () => {
+    vi.useFakeTimers();
+    try {
+      runRead({ uid: "u1", action: "read.users", dedupe: true });
+      runRead({ uid: "u1", action: "read.users", dedupe: true });
+      vi.advanceTimersByTime(60 * 60 * 1000 + 1000);
+      runRead({ uid: "u1", action: "read.users", dedupe: true });
+    } finally {
+      vi.useRealTimers();
+    }
+    await flush();
+    expect(written).toHaveLength(2);
   });
 });

--- a/functions/src/middleware/auditContext.ts
+++ b/functions/src/middleware/auditContext.ts
@@ -63,6 +63,85 @@ function routePattern(req: Request): string {
 }
 
 /**
+ * Ventana de agrupación de las lecturas repetidas. Una hora: lo bastante para
+ * que abrir el panel treinta veces en una mañana deje una fila, y lo bastante
+ * corto para que "entró por la tarde" y "entró por la noche" se distingan.
+ */
+const READ_DEDUPE_MS = 60 * 60 * 1000;
+
+/** Última vez que se registró cada (uid, acción). */
+const lastRead = new Map<string, number>();
+
+/** Solo para los tests: reinicia el estado en memoria. */
+export function __resetReadDedupeState(): void {
+  lastRead.clear();
+}
+
+export interface AuditedReadOptions {
+  /**
+   * Agrupa a una fila por hora y por persona. Para las lecturas que el panel
+   * repite solo por estar abierto.
+   */
+  dedupe?: boolean;
+  /** Parámetro de ruta que identifica lo leído (p. ej. `"id"`). */
+  targetIdParam?: string;
+}
+
+/**
+ * Registra una lectura sensible.
+ *
+ * Las lecturas no se auditan en general, y eso es deliberado: una fila por GET
+ * daría una por vista de página, y un registro donde el 99% de las filas son
+ * "alguien abrió una pantalla" no sirve para encontrar el 1% que importa. Se
+ * audita la lista corta de lecturas que exponen datos personales o el propio
+ * registro — quién leyó el log de auditoría es exactamente el tipo de cosa que
+ * un log de auditoría debería contar.
+ *
+ * Se engancha en `finish` y solo cuando la respuesta fue 2xx: un 403 no leyó
+ * nada, y ya queda registrado como evento de seguridad por su cuenta.
+ */
+export function auditedRead(
+  action: AuditAction,
+  targetType: string,
+  options: AuditedReadOptions = {}
+) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    res.on("finish", () => {
+      if (res.statusCode < 200 || res.statusCode >= 300) return;
+
+      const uid = (req as { user?: { uid?: string } }).user?.uid ?? "unknown";
+      const targetId = options.targetIdParam
+        ? (req.params[options.targetIdParam] as string | undefined)
+        : undefined;
+
+      if (options.dedupe) {
+        const key = `${uid}:${action}:${targetId ?? "-"}`;
+        const now = Date.now();
+        const previous = lastRead.get(key);
+        if (previous !== undefined && now - previous < READ_DEDUPE_MS) return;
+        lastRead.set(key, now);
+      }
+
+      void writeAuditLog(
+        {
+          action,
+          performedBy: uid,
+          ...(targetId ? { targetId } : {}),
+          targetType,
+          details: options.dedupe ? { deduped: true } : {},
+          category: "read",
+        },
+        req
+      ).catch(() => {
+        // La petición ya terminó; no hay nada que devolver.
+      });
+    });
+
+    next();
+  };
+}
+
+/**
  * Captura el contexto de la petición y deja una red de seguridad.
  *
  * Va registrado ANTES del limitador de perímetro, para que un 429 también

--- a/functions/src/services/email.ts
+++ b/functions/src/services/email.ts
@@ -190,3 +190,74 @@ export async function sendCertificateEmail(
     ],
   });
 }
+
+/**
+ * Aviso de que el registro de auditoría tiene algo que mirar.
+ *
+ * Va a la misma dirección de contacto que el resto: quien recibe esto es quien
+ * administra la plataforma, no una persona de la comunidad. Se manda un solo
+ * correo con todo lo acumulado en la ventana en vez de uno por evento — un
+ * ataque genera decenas de filas, y decenas de correos se leen como spam y se
+ * empiezan a ignorar justo cuando importan.
+ *
+ * El cuerpo NO lleva datos personales de nadie: solo acción, actor, severidad y
+ * prefijo de red. Si hace falta más, el enlace lleva al panel, que ya exige el
+ * permiso `audit:read`. Un correo es la copia menos controlada que existe.
+ */
+export async function sendAuditAlertEmail(mail: {
+  to: string;
+  since: Date;
+  events: {
+    action: string;
+    severity: string;
+    performedBy: string;
+    ipPrefix?: string | null;
+    at?: Date | null;
+  }[];
+  /** Total real: puede superar `events.length` si se recortó la lista. */
+  total: number;
+  panelUrl: string;
+}): Promise<void> {
+  const desde = mail.since.toLocaleString("es-PE");
+  const rows = mail.events
+    .map((e) => {
+      const cuando = e.at ? e.at.toLocaleString("es-PE") : "—";
+      const red = e.ipPrefix ? ` · ${htmlEscape(singleLine(e.ipPrefix))}` : "";
+      return (
+        `<li><code>${htmlEscape(singleLine(e.action))}</code> ` +
+        `(${htmlEscape(singleLine(e.severity))}) — ` +
+        `${htmlEscape(singleLine(e.performedBy))}${red} · ${htmlEscape(cuando)}</li>`
+      );
+    })
+    .join("");
+
+  const recortado =
+    mail.total > mail.events.length
+      ? `<p>Se muestran ${mail.events.length} de <strong>${mail.total}</strong>. ` +
+        `El resto está en el panel.</p>`
+      : "";
+
+  const textRows = mail.events
+    .map(
+      (e) =>
+        `- ${singleLine(e.action)} (${singleLine(e.severity)}) — ` +
+        `${singleLine(e.performedBy)}${e.ipPrefix ? ` · ${singleLine(e.ipPrefix)}` : ""}`
+    )
+    .join("\n");
+
+  await sendPlain(
+    mail.to,
+    `[GDG ICA] ${mail.total} evento(s) de auditoría que revisar`,
+    `<p>Hay <strong>${mail.total}</strong> evento(s) registrados desde ` +
+      `${htmlEscape(desde)} que conviene revisar.</p>` +
+      `<ul>${rows}</ul>${recortado}` +
+      `<p><a href="${htmlEscape(mail.panelUrl)}">Abrir el registro de auditoría</a></p>` +
+      `<p>Si no reconoces alguna de estas acciones, revisa los roles y los ` +
+      `permisos en /admin/users antes que nada.</p>` +
+      `<p>Comunidad GDG ICA</p>`,
+    `Hay ${mail.total} evento(s) de auditoría desde ${desde} que conviene ` +
+      `revisar.\n\n${textRows}\n\n${mail.panelUrl}\n\n` +
+      `Si no reconoces alguna de estas acciones, revisa los roles y permisos ` +
+      `en /admin/users antes que nada.\n\nComunidad GDG ICA`
+  );
+}

--- a/functions/src/triggers/auditAlerts.test.ts
+++ b/functions/src/triggers/auditAlerts.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Estado del emulador en memoria. */
+const docs = new Map<string, Record<string, unknown>>();
+let rows: Record<string, unknown>[] = [];
+let emailFails = false;
+const sentAlerts: Record<string, unknown>[] = [];
+
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("firebase-functions", () => ({ logger: loggerMock }));
+
+/** `onSchedule` devuelve el handler tal cual para poder invocarlo. */
+vi.mock("firebase-functions/v2/scheduler", () => ({
+  onSchedule: (_opts: unknown, handler: () => Promise<void>) => handler,
+}));
+
+// Izado: `vi.mock` corre antes que cualquier declaración normal del archivo.
+const { FakeTimestamp } = vi.hoisted(() => {
+  class FakeTimestamp {
+    constructor(private readonly ms: number) {}
+    toDate() {
+      return new Date(this.ms);
+    }
+    static fromDate(d: Date) {
+      return new FakeTimestamp(d.getTime());
+    }
+  }
+  return { FakeTimestamp };
+});
+
+vi.mock("firebase-admin/firestore", () => ({
+  Timestamp: FakeTimestamp,
+}));
+
+vi.mock("firebase-admin", () => ({
+  firestore: () => ({
+    doc: (path: string) => ({
+      get: async () => ({
+        data: () => docs.get(path),
+        exists: docs.has(path),
+      }),
+      set: async (data: Record<string, unknown>) => {
+        docs.set(path, { ...(docs.get(path) ?? {}), ...data });
+      },
+    }),
+    collection: () => {
+      const chain = {
+        where: () => chain,
+        orderBy: () => chain,
+        limit: () => chain,
+        get: async () => ({ docs: rows.map((r) => ({ data: () => r })) }),
+      };
+      return chain;
+    },
+  }),
+}));
+
+vi.mock("../config", () => ({
+  GMAIL_USER: { value: () => "" },
+  GMAIL_APP_PASSWORD: { value: () => "" },
+  RESEND_API_KEY: { value: () => "" },
+  RESEND_FROM: { value: () => "" },
+  SITE_ORIGIN: "https://gdgica.com",
+}));
+
+vi.mock("../services/email", () => ({
+  sendAuditAlertEmail: async (mail: Record<string, unknown>) => {
+    if (emailFails) throw new Error("smtp down");
+    sentAlerts.push(mail);
+  },
+}));
+
+import { auditAlerts } from "./auditAlerts";
+
+const run = auditAlerts as unknown as () => Promise<void>;
+
+/** Fila crítica con la antigüedad indicada. */
+function critical(over: Record<string, unknown> = {}, agoMs = 60_000) {
+  return {
+    action: "user.role.change",
+    severity: "critical",
+    performedBy: "actor-1",
+    timestamp: new FakeTimestamp(Date.now() - agoMs),
+    context: { ipPrefix: "181.65.42.0/24" },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  docs.clear();
+  rows = [];
+  emailFails = false;
+  sentAlerts.length = 0;
+  loggerMock.info.mockReset();
+  loggerMock.warn.mockReset();
+  loggerMock.error.mockReset();
+});
+
+describe("aviso", () => {
+  it("manda un correo con lo crítico reciente", async () => {
+    rows = [critical()];
+    await run();
+    expect(sentAlerts).toHaveLength(1);
+    expect(sentAlerts[0]).toMatchObject({
+      to: "aalvaropc@gmail.com",
+      total: 1,
+    });
+  });
+
+  it("no manda nada si no hay eventos", async () => {
+    rows = [];
+    await run();
+    expect(sentAlerts).toHaveLength(0);
+  });
+
+  // Decenas de correos se leen como spam y se empiezan a ignorar justo cuando
+  // importan, así que una ráfaga va en un solo aviso.
+  it("agrupa varios eventos en un correo", async () => {
+    rows = [critical(), critical({ performedBy: "actor-2" }), critical()];
+    await run();
+    expect(sentAlerts).toHaveLength(1);
+    expect(sentAlerts[0]).toMatchObject({ total: 3 });
+  });
+
+  // Recortar la lista está bien; ocultar que se recortó, no.
+  it("recorta el detalle pero dice el total real", async () => {
+    rows = Array.from({ length: 40 }, () => critical());
+    await run();
+    const alert = sentAlerts[0] as { total: number; events: unknown[] };
+    expect(alert.total).toBe(40);
+    expect(alert.events).toHaveLength(25);
+  });
+
+  it("incluye el prefijo de red, no la dirección", async () => {
+    rows = [critical()];
+    await run();
+    expect(JSON.stringify(sentAlerts[0])).toContain("181.65.42.0/24");
+  });
+
+  it("enlaza al panel ya filtrado", async () => {
+    rows = [critical()];
+    await run();
+    expect(sentAlerts[0]).toMatchObject({
+      panelUrl: "https://gdgica.com/admin/audit?severity=critical",
+    });
+  });
+});
+
+describe("marca de agua", () => {
+  it("la avanza tras ejecutarse", async () => {
+    rows = [critical()];
+    await run();
+    expect(docs.get("settings/auditAlerts")?.lastCheckedAt).toBeDefined();
+  });
+
+  // Si solo avanzara al mandar correo, una hora tranquila dejaría la ventana
+  // abierta y la siguiente ejecución volvería a mirar lo mismo.
+  it("la avanza incluso sin nada que avisar", async () => {
+    rows = [];
+    await run();
+    expect(docs.get("settings/auditAlerts")?.lastCheckedAt).toBeDefined();
+  });
+
+  // Lo que hace la función idempotente: correr dos veces no avisa dos veces del
+  // mismo evento.
+  it("no repite el aviso en la segunda ejecución", async () => {
+    rows = [critical()];
+    await run();
+    expect(sentAlerts).toHaveLength(1);
+    await run();
+    expect(sentAlerts).toHaveLength(1);
+  });
+
+  it("sí avisa de algo nuevo tras la primera ejecución", async () => {
+    // Hace falta separación temporal real: las dos ejecuciones ocurren en el
+    // mismo milisegundo si no se avanza el reloj, y entonces nada puede caer
+    // entre la marca de agua y el final de la ventana siguiente.
+    vi.useFakeTimers();
+    try {
+      rows = [critical({}, 60_000)];
+      await run();
+      expect(sentAlerts).toHaveLength(1);
+
+      vi.advanceTimersByTime(30 * 60 * 1000);
+      rows = [critical({ performedBy: "actor-nuevo" }, 60_000)];
+      await run();
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(sentAlerts).toHaveLength(2);
+    expect(sentAlerts[1]).toMatchObject({ total: 1 });
+  });
+
+  // La ventana se cierra ANTES de consultar, así que una fila escrita mientras
+  // la función corre pertenece a la ventana siguiente y no se pierde.
+  it("deja para la siguiente ventana lo posterior a su cierre", async () => {
+    rows = [critical({}, -60_000)];
+    await run();
+    expect(sentAlerts).toHaveLength(0);
+  });
+
+  // Arrancar avisando de todo el histórico garantiza que el primer correo se
+  // ignore, así que sin marca de agua solo se mira la última hora.
+  it("la primera ejecución solo mira la última hora", async () => {
+    rows = [critical({}, 5 * 60 * 60 * 1000)];
+    await run();
+    expect(sentAlerts).toHaveLength(0);
+  });
+
+  it("descarta filas sin marca de tiempo", async () => {
+    rows = [critical({ timestamp: undefined })];
+    await run();
+    expect(sentAlerts).toHaveLength(0);
+  });
+});
+
+describe("fallo del correo", () => {
+  // La marca de agua ya avanzó, así que el aviso de esta ventana se pierde. Se
+  // acepta a cambio de la idempotencia, pero tiene que quedar en Cloud Logging:
+  // es donde se mira si las alertas dejan de llegar.
+  it("registra el fallo y no lanza", async () => {
+    emailFails = true;
+    rows = [critical()];
+    await expect(run()).resolves.toBeUndefined();
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      "audit.alert.failed",
+      expect.objectContaining({ total: 1 })
+    );
+  });
+
+  it("aun fallando, la marca de agua avanza", async () => {
+    emailFails = true;
+    rows = [critical()];
+    await run();
+    expect(docs.get("settings/auditAlerts")?.lastCheckedAt).toBeDefined();
+  });
+});

--- a/functions/src/triggers/auditAlerts.ts
+++ b/functions/src/triggers/auditAlerts.ts
@@ -1,0 +1,144 @@
+import * as admin from "firebase-admin";
+import { logger } from "firebase-functions";
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { Timestamp } from "firebase-admin/firestore";
+import {
+  GMAIL_USER,
+  GMAIL_APP_PASSWORD,
+  RESEND_API_KEY,
+  RESEND_FROM,
+  SITE_ORIGIN,
+} from "../config";
+import { sendAuditAlertEmail } from "../services/email";
+
+/**
+ * A quién se avisa. La misma dirección de contacto del resto de la plataforma:
+ * quien recibe esto es quien la administra.
+ */
+const ALERT_TO = "aalvaropc@gmail.com";
+
+/** Documento donde vive la marca de agua. */
+const STATE_DOC = "settings/auditAlerts";
+
+/**
+ * Cuántos eventos se detallan en el correo. El total real siempre se dice,
+ * aunque la lista se recorte: un correo con doscientas líneas no se lee, y uno
+ * que oculta que hubo doscientas miente.
+ */
+const MAX_DETAILED = 25;
+
+/** Techo de la consulta, para que una ráfaga no traiga la colección entera. */
+const QUERY_LIMIT = 200;
+
+/**
+ * Primera ejecución: sin marca de agua, se mira solo la última hora en vez de
+ * todo el histórico. Arrancar avisando de cada cosa que pasó desde el principio
+ * de los tiempos garantiza que el primer correo se ignore.
+ */
+const FIRST_RUN_LOOKBACK_MS = 60 * 60 * 1000;
+
+interface AuditRow {
+  action?: string;
+  severity?: string;
+  performedBy?: string;
+  synthesized?: boolean;
+  timestamp?: Timestamp;
+  context?: { ipPrefix?: string | null };
+}
+
+/**
+ * Avisa por correo de lo que hay que mirar en el registro de auditoría.
+ *
+ * Sin esto, todo el trabajo de instrumentación solo sirve si alguien se acuerda
+ * de abrir el panel. Un registro que nadie lee no detecta nada; lo que convierte
+ * la auditoría en una defensa es que te busque a ti y no al contrario.
+ *
+ * Se apoya en `severity`, no en una lista de acciones. Cualquier acción futura
+ * que se marque como `critical` entra en las alertas sin tocar este archivo — y
+ * al revés, subir algo a `critical` es una decisión con consecuencia visible.
+ */
+export const auditAlerts = onSchedule(
+  {
+    schedule: "0 * * * *",
+    timeZone: "America/Lima",
+    // Una función programada declara sus propios secretos: el array del
+    // `onRequest` de la API no se extiende hasta aquí, y omitirlos falla al
+    // enviar —con una contraseña vacía— en vez de al desplegar.
+    secrets: [GMAIL_USER, GMAIL_APP_PASSWORD, RESEND_API_KEY, RESEND_FROM],
+    timeoutSeconds: 120,
+  },
+  async () => {
+    const db = admin.firestore();
+    const stateRef = db.doc(STATE_DOC);
+    const stateSnap = await stateRef.get();
+
+    const lastChecked = stateSnap.data()?.lastCheckedAt as
+      Timestamp | undefined;
+    const since = lastChecked
+      ? lastChecked.toDate()
+      : new Date(Date.now() - FIRST_RUN_LOOKBACK_MS);
+
+    // La ventana se cierra ANTES de consultar. Si se cerrara después, todo lo
+    // escrito mientras corre la consulta caería en el hueco entre esta ejecución
+    // y la siguiente, y no se avisaría de ello nunca.
+    const windowEnd = new Date();
+
+    const snapshot = await db
+      .collection("audit_log")
+      .where("severity", "==", "critical")
+      .orderBy("timestamp", "desc")
+      .limit(QUERY_LIMIT)
+      .get();
+
+    // El filtro por fecha se aplica en memoria: combinarlo con el `where` de
+    // severidad exigiría otro índice compuesto, y la consulta ya viene ordenada
+    // y acotada a 200.
+    const fresh = snapshot.docs
+      .map((d) => d.data() as AuditRow)
+      .filter((row) => {
+        const at = row.timestamp?.toDate?.();
+        if (!at) return false;
+        return at > since && at <= windowEnd;
+      });
+
+    // La marca de agua avanza SIEMPRE, incluso sin nada que avisar. Si solo
+    // avanzara al mandar correo, una hora tranquila dejaría la ventana abierta
+    // y la siguiente ejecución volvería a mirar lo mismo.
+    await stateRef.set(
+      { lastCheckedAt: Timestamp.fromDate(windowEnd) },
+      { merge: true }
+    );
+
+    if (fresh.length === 0) return;
+
+    const events = fresh.slice(0, MAX_DETAILED).map((row) => ({
+      action: row.action ?? "(sin acción)",
+      severity: row.severity ?? "critical",
+      performedBy: row.performedBy ?? "(desconocido)",
+      ipPrefix: row.context?.ipPrefix ?? null,
+      at: row.timestamp?.toDate?.() ?? null,
+    }));
+
+    try {
+      await sendAuditAlertEmail({
+        to: ALERT_TO,
+        since,
+        events,
+        total: fresh.length,
+        panelUrl: `${SITE_ORIGIN}/admin/audit?severity=critical`,
+      });
+      logger.info("audit.alert.sent", {
+        total: fresh.length,
+        since: since.toISOString(),
+      });
+    } catch (err) {
+      // La marca de agua ya avanzó, así que un fallo de correo pierde el aviso
+      // de esta ventana. Se acepta a cambio de la idempotencia: reintentar
+      // dejando la ventana abierta significaría que un problema persistente de
+      // SMTP acumula filas y manda un correo enorme cuando se arregle. El
+      // registro sigue completo en el panel, y este error queda en Cloud
+      // Logging, que es donde se mira si las alertas dejan de llegar.
+      logger.error("audit.alert.failed", { err, total: fresh.length });
+    }
+  }
+);

--- a/functions/src/triggers/exportAudit.ts
+++ b/functions/src/triggers/exportAudit.ts
@@ -1,0 +1,85 @@
+import { logger } from "firebase-functions";
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { google } from "googleapis";
+
+/**
+ * Copia mensual de `audit_log` fuera de Firestore.
+ *
+ * Para qué sirve exactamente: las reglas cierran la colección a los clientes,
+ * pero el Admin SDK las salta. Cualquiera que comprometa el panel —o la propia
+ * cuenta de servicio— puede borrar filas, y un registro que sus atacantes pueden
+ * editar no prueba nada. Esta copia vive en un bucket distinto, con su propio
+ * control de acceso, así que borrarla exige comprometer también eso.
+ *
+ * NO es el control principal de inmutabilidad. Ese es el log bucket de Cloud
+ * Logging con `--locked`, que ni un owner del proyecto puede acortar ni borrar
+ * (ver docs/auditoria.md). Esto es la segunda copia, y su ventaja sobre la de
+ * Cloud Logging es que se puede reimportar a Firestore tal cual.
+ *
+ * Usa `googleapis`, que ya es dependencia directa, en vez del cliente de
+ * administración de `@google-cloud/firestore`: ese último solo está disponible
+ * como dependencia transitiva de `firebase-admin`, y depender de algo que no
+ * está declarado se rompe el día que firebase-admin cambie de versión mayor.
+ */
+
+/** Se resuelve en tiempo de ejecución: en Cloud Functions siempre está puesta. */
+function projectId(): string {
+  return (
+    process.env.GCLOUD_PROJECT ??
+    process.env.GOOGLE_CLOUD_PROJECT ??
+    "appgdgica"
+  );
+}
+
+/**
+ * Bucket destino. Tiene que existir y la cuenta de servicio de la función
+ * necesita permiso de escritura y el rol de export — los dos pasos están en
+ * docs/auditoria.md, y sin ellos esto falla con un 403 que queda en el log.
+ */
+function bucketUri(): string {
+  return `gs://${projectId()}-audit-backups`;
+}
+
+export const exportAudit = onSchedule(
+  {
+    // Día 1 de cada mes. Mensual y no diario porque el volumen de `audit_log`
+    // es pequeño y cada export cobra por documento leído: la copia existe para
+    // sobrevivir a un borrado, no para reconstruir el estado de ayer.
+    schedule: "0 4 1 * *",
+    timeZone: "America/Lima",
+    timeoutSeconds: 540,
+  },
+  async () => {
+    const project = projectId();
+    const name = `projects/${project}/databases/(default)`;
+
+    try {
+      // La autenticación sale del entorno: la cuenta de servicio de la función.
+      const auth = new google.auth.GoogleAuth({
+        scopes: ["https://www.googleapis.com/auth/datastore"],
+      });
+      const firestore = google.firestore({ version: "v1", auth });
+
+      const response = await firestore.projects.databases.exportDocuments({
+        name,
+        requestBody: {
+          // Solo la colección de auditoría. Exportar la base entera arrastraría
+          // las credenciales con datos personales a un bucket más, que es
+          // exactamente lo contrario de lo que pide la política de retención.
+          collectionIds: ["audit_log"],
+          outputUriPrefix: bucketUri(),
+        },
+      });
+
+      logger.info("audit.export.started", {
+        operation: response.data.name,
+        destination: bucketUri(),
+      });
+    } catch (err) {
+      // No se relanza: un fallo aquí no debe marcar la ejecución programada como
+      // caída y disparar reintentos que acumulen exports a medias. Queda en
+      // Cloud Logging, que es donde se comprueba si las copias siguen saliendo.
+      logger.error("audit.export.failed", { err, destination: bucketUri() });
+    }
+  }
+);

--- a/functions/src/utils/auditActions.ts
+++ b/functions/src/utils/auditActions.ts
@@ -79,6 +79,18 @@ export const AUDIT_ACTIONS = [
   "credential.reconcile",
   "credential_email.drain",
 
+  // Lecturas sensibles. Son las ÚNICAS lecturas que se auditan: un GET normal
+  // no deja fila, porque una por vista de página ahoga el registro y el visor
+  // solo admite un filtro a la vez.
+  //
+  // Falta a propósito el roster de asistentes y las credenciales con datos
+  // personales: el panel los lee DIRECTAMENTE de Firestore, acotado por las
+  // reglas, sin pasar por la API. No hay endpoint donde engancharse, así que
+  // cubrirlos exigiría instrumentar el lado de Firestore.
+  "read.audit_log",
+  "read.users",
+  "read.form_responses",
+
   // Minijuegos
   "minigame_template.create",
   "minigame_template.update",

--- a/src/components/react/admin/audit/AuditLog.tsx
+++ b/src/components/react/admin/audit/AuditLog.tsx
@@ -9,6 +9,18 @@ interface AuditEntry {
   targetType?: string;
   details?: Record<string, unknown>;
   timestamp?: { _seconds: number };
+  outcome?: "success" | "denied" | "failure";
+  severity?: "info" | "notice" | "warning" | "critical";
+  category?: string;
+  actor?: { email?: string | null; role?: string | null; scope?: string };
+  context?: {
+    requestId?: string;
+    route?: string;
+    ipPrefix?: string | null;
+    method?: string;
+  };
+  /** La escribió la red de seguridad porque ningún handler dijo qué pasó. */
+  synthesized?: boolean;
 }
 
 interface AuditPage {
@@ -21,31 +33,114 @@ const FILTERS = [
   { key: "action", label: "Acción", placeholder: "user.role.change" },
   { key: "performedBy", label: "Autor (uid)", placeholder: "uid del actor" },
   { key: "targetId", label: "Objetivo", placeholder: "uid o id del recurso" },
+  { key: "category", label: "Categoría", placeholder: "security, access…" },
+  { key: "severity", label: "Severidad", placeholder: "notable, critical…" },
+  { key: "outcome", label: "Resultado", placeholder: "denied, failure…" },
+  {
+    key: "context.ipPrefix",
+    label: "Red (prefijo)",
+    placeholder: "181.65.42.0/24",
+  },
 ] as const;
 
 type FilterKey = (typeof FILTERS)[number]["key"];
 
-/** Acciones que tocan el control de acceso: se resaltan al revisar. */
-const ACCESS_ACTIONS = new Set([
-  "user.role.change",
-  "user.status.change",
-  "user.grants.change",
-]);
+const FILTER_KEYS = FILTERS.map((f) => f.key) as readonly string[];
+
+/**
+ * Atajos: las dos preguntas que de verdad se hacen al abrir esta pantalla, sin
+ * tener que recordar qué valor va en qué campo.
+ */
+const PRESETS = [
+  { label: "Todo", params: {} as Record<string, string> },
+  { label: "Seguridad", params: { category: "security" } },
+  { label: "Notable", params: { severity: "notable" } },
+  { label: "Accesos", params: { category: "access" } },
+  { label: "Denegado", params: { outcome: "denied" } },
+];
+
+/**
+ * Color por severidad, no por una lista de acciones a mano.
+ *
+ * Antes era un `Set` con tres nombres de acción escritos a mano. Esa lista se
+ * desincroniza en cuanto se añade una acción —y se añadieron muchas—, así que
+ * el resaltado dejaba de marcar justo lo nuevo. Derivarlo del campo hace que
+ * cualquier acción futura entre con el color que le toca sin tocar nada aquí.
+ */
+const SEVERITY_STYLE: Record<string, string> = {
+  critical: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
+  warning:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+  notice: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  info: "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300",
+};
+
+const OUTCOME_LABEL: Record<string, string> = {
+  success: "OK",
+  denied: "Denegado",
+  failure: "Fallo",
+};
+
+const OUTCOME_STYLE: Record<string, string> = {
+  success: "text-green-700 dark:text-green-400",
+  denied: "text-amber-700 dark:text-amber-400",
+  failure: "text-red-700 dark:text-red-400",
+};
 
 function formatDate(ts: AuditEntry["timestamp"]): string {
   if (!ts?._seconds) return "—";
   return new Date(ts._seconds * 1000).toLocaleString("es-PE");
 }
 
+/** Lee el filtro de la URL, para que un hallazgo se pueda enlazar. */
+function paramsFromUrl(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  const search = new URLSearchParams(window.location.search);
+  for (const key of FILTER_KEYS) {
+    const value = search.get(key);
+    if (value) return { [key]: value };
+  }
+  return {};
+}
+
+function syncUrl(params: Record<string, string>) {
+  if (typeof window === "undefined") return;
+  const search = new URLSearchParams(window.location.search);
+  for (const key of FILTER_KEYS) search.delete(key);
+  for (const [key, value] of Object.entries(params)) search.set(key, value);
+  const query = search.toString();
+  window.history.replaceState(
+    null,
+    "",
+    query ? `${window.location.pathname}?${query}` : window.location.pathname
+  );
+}
+
+const COLUMNS = [
+  "Fecha",
+  "Acción",
+  "Resultado",
+  "Autor",
+  "Objetivo",
+  "Red",
+  "Detalle",
+];
+
 export function AuditLog() {
+  // Se lee UNA vez al montar, no en cada render: es el estado inicial que trae
+  // la URL, y recalcularlo continuamente además dejaría el efecto de abajo con
+  // una dependencia que cambia de identidad en cada pasada.
+  const [initial] = useState(paramsFromUrl);
+  const initialKey = (Object.keys(initial)[0] ?? "action") as FilterKey;
+
   const [entries, setEntries] = useState<AuditEntry[]>([]);
   const [cursor, setCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [filterKey, setFilterKey] = useState<FilterKey>("action");
-  const [filterValue, setFilterValue] = useState("");
-  const [applied, setApplied] = useState<Record<string, string>>({});
+  const [filterKey, setFilterKey] = useState<FilterKey>(initialKey);
+  const [filterValue, setFilterValue] = useState(initial[initialKey] ?? "");
+  const [applied, setApplied] = useState<Record<string, string>>(initial);
 
   const load = useCallback(
     async (params: Record<string, string>, append: boolean) => {
@@ -71,20 +166,30 @@ export function AuditLog() {
   );
 
   useEffect(() => {
-    load({}, false);
-  }, [load]);
+    load(initial, false);
+  }, [load, initial]);
+
+  function apply(params: Record<string, string>) {
+    setApplied(params);
+    syncUrl(params);
+    load(params, false);
+  }
 
   function applyFilter(e: React.FormEvent) {
     e.preventDefault();
-    const next = filterValue.trim() ? { [filterKey]: filterValue.trim() } : {};
-    setApplied(next);
-    load(next, false);
+    apply(filterValue.trim() ? { [filterKey]: filterValue.trim() } : {});
+  }
+
+  function applyPreset(params: Record<string, string>) {
+    const key = (Object.keys(params)[0] ?? "action") as FilterKey;
+    setFilterKey(key);
+    setFilterValue(params[key] ?? "");
+    apply(params);
   }
 
   function clearFilter() {
     setFilterValue("");
-    setApplied({});
-    load({}, false);
+    apply({});
   }
 
   if (loading) {
@@ -98,9 +203,31 @@ export function AuditLog() {
   return (
     <div>
       <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
-        Registro de todas las operaciones de escritura. Es de solo lectura:
-        nadie, ni un administrador, puede editarlo ni borrarlo desde el panel.
+        Registro de todas las operaciones de escritura, los intentos denegados y
+        las lecturas de datos sensibles. Es de solo lectura: nadie, ni un
+        administrador, puede editarlo ni borrarlo desde el panel.
       </p>
+
+      <div className="mb-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => {
+          const active =
+            JSON.stringify(preset.params) === JSON.stringify(applied);
+          return (
+            <button
+              key={preset.label}
+              type="button"
+              onClick={() => applyPreset(preset.params)}
+              className={`rounded-full px-3 py-1 text-xs font-medium ${
+                active
+                  ? "bg-blue-600 text-white"
+                  : "border border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+              }`}
+            >
+              {preset.label}
+            </button>
+          );
+        })}
+      </div>
 
       <form onSubmit={applyFilter} className="mb-6 flex flex-wrap gap-2">
         <select
@@ -153,25 +280,31 @@ export function AuditLog() {
           <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
             <thead className="bg-gray-50 dark:bg-gray-900">
               <tr>
-                {["Fecha", "Acción", "Autor", "Objetivo", "Detalle"].map(
-                  (h) => (
-                    <th
-                      key={h}
-                      className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
-                    >
-                      {h}
-                    </th>
-                  )
-                )}
+                {COLUMNS.map((h) => (
+                  <th
+                    key={h}
+                    className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400"
+                  >
+                    {h}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
               {entries.map((entry) => {
                 const reason = entry.details?.reason;
+                const severity = entry.severity ?? "info";
+                const outcome = entry.outcome ?? "success";
                 return (
                   <tr
                     key={entry.id}
-                    className="align-top hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    className={`align-top hover:bg-gray-50 dark:hover:bg-gray-700/50 ${
+                      // Una fila sintética significa que hay código mutando sin
+                      // decir qué. Se marca para que incomode, no para que pase.
+                      entry.synthesized
+                        ? "border-l-4 border-l-amber-500 bg-amber-50/40 dark:bg-amber-900/10"
+                        : ""
+                    }`}
                   >
                     <td className="px-4 py-3 whitespace-nowrap text-gray-500 dark:text-gray-400">
                       {formatDate(entry.timestamp)}
@@ -179,19 +312,50 @@ export function AuditLog() {
                     <td className="px-4 py-3">
                       <span
                         className={`rounded-full px-2 py-0.5 font-mono text-xs font-medium ${
-                          ACCESS_ACTIONS.has(entry.action)
-                            ? "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
-                            : "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+                          SEVERITY_STYLE[severity] ?? SEVERITY_STYLE.info
                         }`}
                       >
                         {entry.action}
                       </span>
+                      {entry.synthesized && (
+                        <span
+                          className="ml-2 text-xs text-amber-700 dark:text-amber-400"
+                          title="Ningún handler declaró esta operación: la registró la red de seguridad."
+                        >
+                          sin declarar
+                        </span>
+                      )}
+                      {entry.category && (
+                        <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                          {entry.category}
+                        </p>
+                      )}
+                    </td>
+                    <td
+                      className={`px-4 py-3 text-xs font-medium whitespace-nowrap ${
+                        OUTCOME_STYLE[outcome] ?? ""
+                      }`}
+                    >
+                      {OUTCOME_LABEL[outcome] ?? outcome}
                     </td>
                     <td className="px-4 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
                       {entry.performedBy}
+                      {entry.actor?.role && (
+                        <p className="mt-1 font-sans text-gray-400 dark:text-gray-500">
+                          {entry.actor.role}
+                        </p>
+                      )}
                     </td>
                     <td className="px-4 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
                       {entry.targetId || "—"}
+                      {entry.targetType && (
+                        <p className="mt-1 font-sans text-gray-400 dark:text-gray-500">
+                          {entry.targetType}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs whitespace-nowrap text-gray-500 dark:text-gray-500">
+                      {entry.context?.ipPrefix || "—"}
                     </td>
                     <td className="px-4 py-3 text-gray-600 dark:text-gray-400">
                       {typeof reason === "string" && (
@@ -208,6 +372,14 @@ export function AuditLog() {
                           )
                         )}
                       </code>
+                      {entry.context?.requestId && (
+                        <p
+                          className="mt-1 font-mono text-xs text-gray-400 dark:text-gray-600"
+                          title="Id de correlación: sirve para cruzar esta fila con Cloud Logging."
+                        >
+                          {entry.context.requestId}
+                        </p>
+                      )}
                     </td>
                   </tr>
                 );

--- a/tests/rules/baseline.test.ts
+++ b/tests/rules/baseline.test.ts
@@ -28,6 +28,34 @@ describe("baseline firestore.rules", () => {
     await assertFails(setDoc(doc(anon, "audit_log/x"), { action: "x" }));
   });
 
+  // The rule closes read AND write, but only the write half was covered. The
+  // read half is the one that matters more now: entries carry the actor's email
+  // and the network prefix they acted from, so a client-side read would hand
+  // that to anyone who opened a console.
+  it("denies anonymous reads of audit_log", async () => {
+    const env = await getTestEnv();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "audit_log/seeded"), {
+        action: "user.role.change",
+      });
+    });
+    const anon = env.unauthenticatedContext().firestore();
+    await assertFails(getDoc(doc(anon, "audit_log/seeded")));
+  });
+
+  // Signing in changes nothing: audit_log is reachable only through
+  // GET /api/audit, which checks the `audit:read` permission.
+  it("denies a signed-in user from reading audit_log", async () => {
+    const env = await getTestEnv();
+    await env.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), "audit_log/seeded"), {
+        action: "user.role.change",
+      });
+    });
+    const signedIn = env.authenticatedContext("user-a").firestore();
+    await assertFails(getDoc(doc(signedIn, "audit_log/seeded")));
+  });
+
   it("denies authenticated user from reading another user's profile", async () => {
     const env = await getTestEnv();
     // Seed a user doc bypassing rules so the read target exists.


### PR DESCRIPTION
## What changed

- **`triggers/auditAlerts.ts`** — hourly, finds `critical` entries since a watermark in `settings/auditAlerts`, emails one digest to the contact address.
- **`triggers/exportAudit.ts`** — monthly export of `audit_log` to GCS.
- **`middleware/appCheck.ts`** — the enforcement flag is now cached, so a Firestore read failure keeps the last known value instead of silently opening.
- **`docs/auditoria.md`** — how to investigate an incident, and the manual steps.
- The missing rules test: `audit_log` closes read *and* write, but only write was covered.

## Why

All the instrumentation in the previous four PRs only helps if somebody remembers to open the panel. A record nobody reads detects nothing — what turns auditing into a defence is that it comes looking for you.

Alerts key off `severity`, not a list of actions, so any future action marked `critical` is included without touching the file. One digest per window, not one mail per event: an attack produces dozens of rows, and dozens of mails read as spam and start getting ignored exactly when they matter. If more than 25, it details 25 and states the real total — truncating is fine, hiding that you truncated is not. The body carries no personal data; the link goes to the panel, which already requires `audit:read`. A mail is the least controlled copy that exists.

## The App Check change overrides a documented decision — please read this bit

`readAppCheckEnforcement()` returned `false` when the settings read failed, so a Firestore blink switched App Check off silently and back on when reads recovered. That neither protects nor announces that it isn't protecting.

The reason caching is safe is in the file itself: **a valid token never reads the setting.** The read only happens when the token is missing or invalid, so keeping a cached `true` affects only requests that already arrived without a usable App Check token — exactly the ones enforcement exists to reject. Legitimate clients are untouched. The original fail-open was handing those requests a free pass every time Firestore blinked.

With no cached value it still opens, on purpose: closing without knowing whether enforcement was on would turn a Firestore problem into attendees unable to get their credential.

This changed the premise of an existing test, which is now split in two (no cache → open; cached → keep). The reasoning sits in a comment beside the test rather than arriving as a silent diff.

## Blocking manual steps — these are not optional

**1. The locked log bucket is IRREVERSIBLE.** It is the real immutability control and the only one that survives the scenario that motivates having one: a compromised account with administrative permissions. The function's service account cannot delete its own logs, but a project **owner** can. A bucket with locked retention cannot be unlocked, shortened or deleted — not by you, not by an owner, not by Google support. You will pay storage for the whole period you set, with no way to cancel. **Verify the sink is receiving data before locking**: a locked empty bucket cannot be deleted either.

**2. Do not enable App Check until you have measured.** `src/lib/api.ts` omits the header silently when reCAPTCHA fails, so if it is broken for your attendees, enabling enforcement locks them out with no warning — and finding that out mid-event is the worst possible moment. The command and the number to look for are in the runbook.

**3. The export needs a bucket and an IAM role** before it can work; without them it fails with a 403 that only lands in the log.

## How to test

```bash
cd functions && pnpm build && pnpm test   # 693 tests
pnpm test:rules                           # 158 tests
```

The alert trigger's watermark tests cover idempotency directly: running twice does not alert twice, the watermark advances even with nothing to report and even when the mail fails, and the first run only looks back one hour rather than over all history.

## Notes for the reviewer

- The export uses `googleapis`, already a direct dependency, rather than `@google-cloud/firestore`'s admin client. The latter works because `firebase-admin` pulls it in, but depending on something undeclared breaks on the next firebase-admin major — and CLAUDE.md asks for new dependencies to be discussed first. No new dependencies were added.
- The export covers `audit_log` only. Exporting the whole database would drag the credentials carrying personal data into one more bucket, the opposite of what the retention policy asks for.
- The alert watermark advances even when the mail fails. Deliberate: retrying with the window open means a persistent SMTP problem accumulates rows and sends one enormous mail once fixed. The failure lands in Cloud Logging, which is where you check if alerts stop arriving.