### PR TITLE
fix(functions): resolve the real client IP behind Firebase Hosting

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -60,10 +60,9 @@ import * as emailSettings from "./handlers/emailSettings";
 admin.initializeApp();
 
 const app = express();
-// Firebase Hosting + Cloud Functions sits behind exactly one Google
-// Frontend hop, so trust a single proxy. Setting `true` would let
-// callers spoof X-Forwarded-For and bypass IP-based rate limiting.
-app.set("trust proxy", 1);
+
+const TRUSTED_PROXY_HOPS = 2;
+app.set("trust proxy", TRUSTED_PROXY_HOPS);
 
 // Registered BEFORE cors(), which answers OPTIONS itself and never calls
 // next() — anything after it would be dead code for preflight. See the

--- a/functions/src/middleware/auditContext.test.ts
+++ b/functions/src/middleware/auditContext.test.ts
@@ -32,6 +32,7 @@ import {
   auditedRead,
   truncateIp,
   __resetReadDedupeState,
+  __resetProxyChainLog,
 } from "./auditContext";
 
 /** Simula el ciclo de vida: entra la petición, responde, se dispara `finish`. */
@@ -371,5 +372,76 @@ describe("auditedRead", () => {
     }
     await flush();
     expect(written).toHaveLength(2);
+  });
+});
+
+describe("logProxyChainOnce", () => {
+  beforeEach(() => __resetProxyChainLog());
+
+  function runWithHeaders(xff?: string, ip = "38.250.154.63") {
+    const handlers: (() => void)[] = [];
+    const req = {
+      method: "GET",
+      path: "/api/x",
+      baseUrl: "",
+      ip,
+      headers: xff === undefined ? {} : { "x-forwarded-for": xff },
+      get: () => undefined,
+    } as unknown as Request;
+    const res = {
+      statusCode: 200,
+      setHeader: () => {},
+      on: (e: string, cb: () => void) => {
+        if (e === "finish") handlers.push(cb);
+      },
+    } as unknown as Response;
+    auditContext()(req, res, vi.fn());
+    handlers.forEach((h) => h());
+  }
+
+  it("no revienta cuando la petición no trae headers", () => {
+    expect(() => {
+      const req = {
+        method: "GET",
+        path: "/x",
+        baseUrl: "",
+        get: () => undefined,
+      } as unknown as Request;
+      const res = {
+        statusCode: 200,
+        setHeader: () => {},
+        on: () => {},
+      } as unknown as Response;
+      auditContext()(req, res, vi.fn());
+    }).not.toThrow();
+  });
+  it("marca coincidencia cuando req.ip es la primera entrada de la cadena", () => {
+    runWithHeaders("38.250.154.63, 74.125.209.32", "38.250.154.63");
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "proxy.chain",
+      expect.objectContaining({
+        entryCount: 2,
+        firstEntry: "38.250.154.63",
+        lastEntry: "74.125.209.32",
+        resolvedIp: "38.250.154.63",
+        matchesFirstEntry: true,
+      })
+    );
+  });
+  it("marca DESAJUSTE cuando req.ip es la última entrada", () => {
+    runWithHeaders("38.250.154.63, 74.125.209.32", "74.125.209.32");
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "proxy.chain",
+      expect.objectContaining({ matchesFirstEntry: false })
+    );
+  });
+  it("solo emite una vez por arranque", () => {
+    runWithHeaders("1.2.3.4");
+    runWithHeaders("1.2.3.4");
+    runWithHeaders("1.2.3.4");
+    const calls = loggerMock.info.mock.calls.filter(
+      (c) => c[0] === "proxy.chain"
+    );
+    expect(calls).toHaveLength(1);
   });
 });

--- a/functions/src/middleware/auditContext.ts
+++ b/functions/src/middleware/auditContext.ts
@@ -44,6 +44,33 @@ export function truncateIp(ip: string | undefined): string | null {
 /** Métodos que cambian estado. Los demás no generan fila de respaldo. */
 const MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
+let loggedProxyChain = false;
+
+export function __resetProxyChainLog(): void {
+  loggedProxyChain = false;
+}
+
+function logProxyChainOnce(req: Request): void {
+  if (loggedProxyChain) return;
+  loggedProxyChain = true;
+
+  const raw = req.headers?.["x-forwarded-for"];
+  const chain = Array.isArray(raw) ? raw.join(", ") : (raw ?? "");
+  const entries = chain
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  logger.info("proxy.chain", {
+    xForwardedFor: chain,
+    entryCount: entries.length,
+    firstEntry: entries[0] ?? null,
+    lastEntry: entries[entries.length - 1] ?? null,
+    resolvedIp: req.ip ?? null,
+    matchesFirstEntry: entries.length > 0 && entries[0] === req.ip,
+  });
+}
+
 /**
  * Patrón de la ruta, no la ruta concreta.
  *
@@ -159,6 +186,7 @@ export function auditContext() {
       userAgent: singleLineHeader(req.get("user-agent")) || null,
     };
     req.auditContext = context;
+    logProxyChainOnce(req);
 
     // Útil para que quien reporte un fallo pueda pegar el id, y para cruzar la
     // respuesta con su línea de Cloud Logging.


### PR DESCRIPTION
## What changed

`app.set("trust proxy", 1)` → `2`, plus a once-per-cold-start diagnostic that logs the raw `X-Forwarded-For` chain.

## Why

The old value carried a comment claiming "exactly one Google Frontend hop". That premise is false. Probing production:

```
Real caller IP:                38.250.154.63
Recorded by the function:      74.125.209.32   (Google)
Next consecutive request:      66.249.84.132   (Google, different)
```

`httpRequest.remoteIp` in Cloud Logging shows the same. The real chain is client → Firebase Hosting → Cloud Run, i.e. **two** hops. Express resolves `req.ip` by walking `[peer, ...XFF reversed]` and returning the first untrusted address: with `1` it returned the last `X-Forwarded-For` entry (Hosting's), with `2` it returns the client's.

**This is not an audit-only problem.** Seven places key on `req.ip` — the perimeter limiter plus join, bingo, claim, credential and access. With a frontend IP that also rotates, different callers shared buckets and anyone wanting past a limit got a fresh allowance as the IP rotated. That means the 5/hour ceiling I relied on to argue that failed invitation redemptions were naturally bounded **was not real**. Fixing the hop count corrects all seven at once.

Not `true`: that would trust the whole chain and let a caller inject their own `X-Forwarded-For` to forge the IP at will.

## The diagnostic, and why it is in this PR

The number 2 cannot be derived by reading the code, and getting it wrong is **silent** — you record a plausible address that belongs to nobody. So this ships with one log line per cold start carrying the raw chain, its first and last entry, the resolved IP, and whether they match.

After deploy, one request is enough to confirm:

```bash
gcloud logging read 'jsonPayload.message="proxy.chain"' \
  --project=appgdgica --freshness=1h --limit=3 \
  --format="value(jsonPayload.xForwardedFor,jsonPayload.resolvedIp,jsonPayload.matchesFirstEntry)"
```

`matchesFirstEntry=true` confirms the value. If it is `false`, the chain in the same line says exactly what to change it to — no second round of guessing.

## How to test

```bash
cd functions && pnpm build && pnpm test   # 697 tests
```

New tests cover the match case, the mismatch case (the bug this fixes), the once-per-instance latch, and that a request with no headers cannot make the diagnostic throw — a diagnostic must never take down the request it observes.

## Notes for the reviewer

- Pre-existing bug: `trust proxy 1` predates the audit work. The audit series did not cause it, but it built `ipPrefix` on top and made it visible.
- Until this merges, `context.ipPrefix` in `audit_log` records Google's network rather than the caller's, so the "what else did this network do" query in `docs/auditoria.md` does not work.