### PR TITLE
fix(audit): drop undefined values before writing to Firestore

### DIFF
--- a/functions/src/utils/audit.test.ts
+++ b/functions/src/utils/audit.test.ts
@@ -349,3 +349,69 @@ describe("commitWithAuditLog", () => {
     expect(loggerMock.info).not.toHaveBeenCalled();
   });
 });
+
+describe("valores undefined", () => {
+  it("elimina claves undefined de details", () => {
+    const entry = buildAuditEntry({
+      action: "security.invitation.redeem_failed",
+      performedBy: "u1",
+      details: { reason: "no_match", email: "a@b.c", invitationId: undefined },
+    });
+    const details = entry.details as Record<string, unknown>;
+    expect("invitationId" in details).toBe(false);
+    expect(details).toEqual({ reason: "no_match", email: "a@b.c" });
+  });
+
+  it("conserva null, cero y cadena vacía", () => {
+    const entry = buildAuditEntry({
+      action: "event.update",
+      performedBy: "u1",
+      details: { previousRole: null, count: 0, note: "", gone: undefined },
+    });
+    expect(entry.details).toEqual({ previousRole: null, count: 0, note: "" });
+  });
+
+  it("limpia también dentro de objetos anidados y arrays", () => {
+    const entry = buildAuditEntry({
+      action: "user.grants.change",
+      performedBy: "u1",
+      details: {
+        grants: [
+          { permission: "audit:read", scope: "*", expiresAt: undefined },
+        ],
+        nested: { a: 1, b: undefined },
+      },
+    });
+    const d = entry.details as Record<string, unknown>;
+    expect((d.grants as Record<string, unknown>[])[0]).toEqual({
+      permission: "audit:read",
+      scope: "*",
+    });
+    expect(d.nested).toEqual({ a: 1 });
+  });
+
+  it("no destruye el sentinel de timestamp", () => {
+    const entry = buildAuditEntry({ action: "event.create", performedBy: "u" });
+    expect(entry.timestamp).toBe("__TS__");
+  });
+
+  it("conserva instancias de Date", () => {
+    const when = new Date("2026-07-30T00:00:00Z");
+    const entry = buildAuditEntry({
+      action: "event.create",
+      performedBy: "u",
+      details: { when },
+    });
+    expect((entry.details as Record<string, unknown>).when).toBe(when);
+  });
+
+  it("escribe en Firestore una entrada que traía undefined", async () => {
+    await writeAuditLog({
+      action: "security.invitation.redeem_failed",
+      performedBy: "u1",
+      details: { reason: "no_match", invitationId: undefined },
+    });
+    expect(written).toHaveLength(1);
+    expect(JSON.stringify(written[0].data)).not.toContain("invitationId");
+  });
+});

--- a/functions/src/utils/audit.ts
+++ b/functions/src/utils/audit.ts
@@ -50,6 +50,21 @@ function readActor(req: Request | undefined): AuditActor | undefined {
  * escriben su entrada dentro de una transacción y necesitan el documento, no
  * la escritura.
  */
+function stripUndefined<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => stripUndefined(v)) as unknown as T;
+  }
+  if (value === null || typeof value !== "object") return value;
+  if (Object.getPrototypeOf(value) !== Object.prototype) return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    if (val === undefined) continue;
+    out[key] = stripUndefined(val);
+  }
+  return out as T;
+}
+
 export function buildAuditEntry(
   entry: AuditEntry,
   req?: Request
@@ -59,18 +74,15 @@ export function buildAuditEntry(
   const actor = entry.actor ?? readActor(req);
   const context = entry.context ?? req?.auditContext;
 
-  return {
+  return stripUndefined({
     ...entry,
     timestamp: entry.timestamp ?? FieldValue.serverTimestamp(),
     outcome,
     category,
     severity: entry.severity ?? deriveSeverity(category, outcome),
-    // Se omiten en vez de guardarse como `undefined`: Firestore rechaza
-    // `undefined` por defecto, así que dejarlos pasar convertiría una entrada
-    // sin contexto en una escritura fallida.
     ...(actor ? { actor } : {}),
     ...(context ? { context } : {}),
-  };
+  });
 }
 
 /**


### PR DESCRIPTION
## What changed

`buildAuditEntry` now strips `undefined` values recursively before the entry reaches Firestore.

## Why

Found in production while testing the invitation tripwire. The `security.invitation.redeem_failed` event reached Cloud Logging but its Firestore write failed, so the row never appeared in the panel:

```
Error: Failed to write audit log
  at writeAuditLog (/workspace/lib/utils/audit.js:210)
  at recordSecurityEvent (/workspace/lib/utils/securityAudit.js:167)
  at invalid (/workspace/lib/handlers/access.js:532)
  at redeemInvitation (/workspace/lib/handlers/access.js:544)
```

The cause is in `handlers/access.ts`: `invalid(reason, invitationId?)` builds `details: { reason, email, invitationId }`, and the no-match branch calls it without the second argument. That leaves `invitationId: undefined` in the object, and Firestore rejects `undefined` as a value.

**Why this one matters more than a normal dropped row.** The failing path is a redemption attempt with a made-up token — exactly the pattern of somebody probing stolen invitation links. It never reached `audit_log`, so it was invisible in the viewer and, worse, **never triggered the alert email**, because that scheduled function queries Firestore and not Cloud Logging. The tripwire worked at half strength and did so silently, since `writeAuditLog` swallows its errors by design.

## Fixed in the writer, not the call site

A one-line fix at `invalid()` would close this instance and leave the next one open — every current and future call site can pass an optional field the same way. Sanitising centrally means no caller can reintroduce it.

The sanitiser deliberately keeps `null`, `0` and `""` — those are data, not absence — and does not recurse into non-plain objects, so the `serverTimestamp()` sentinel and `Date` instances survive untouched.

## How to test

```bash
cd functions && pnpm build && pnpm test   # 703 tests
```

Six new cases: the exact production shape, preservation of null/0/"", nested objects and arrays, the timestamp sentinel, `Date` instances, and an end-to-end write. Verified the suite catches the regression — reverting the fix makes the `invitationId: undefined` case fail.

## After merging

Repeat the tripwire test to confirm the row now lands:

1. Open `/admin/invitacion?token=inventado` and submit.
2. In `/admin/audit`, the **Seguridad** preset should show `security.invitation.redeem_failed` with `reason: no_match`.

Before this fix that row existed only in Cloud Logging.