### PR TITLE
feat(audit): record attendee check-in with a Firestore trigger

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -323,12 +323,26 @@ service cloud.firestore {
                          .hasOnly(['checkedIn', 'checkedInAt', 'checkedInBy',
                                    'checkedInByName', 'note',
                                    'dniVerified', 'dniVerifiedAt',
-                                   'dniMatchScore', 'dniMatchedName'])
+                                   'dniMatchScore', 'dniMatchedName',
+                                   'lastActionBy', 'lastActionByName',
+                                   'lastActionAt'])
                       && request.resource.data.checkedIn is bool
                       // Marking someone present must be attributable; only
                       // un-checking may leave checkedInBy unset.
                       && (request.resource.data.checkedIn == false
                           || request.resource.data.checkedInBy == request.auth.uid)
+                      // Quién tocó la fila, en LAS DOS direcciones.
+                      //
+                      // `checkedInBy` no sirve para esto: al desmarcar se pone
+                      // a null, así que marcar y desmarcar borraba la única
+                      // constancia de quién lo hizo. Y como el trigger que
+                      // audita esto es de Firestore, no lleva contexto de
+                      // autenticación: si el actor no viaja en el documento,
+                      // no hay forma de saberlo después.
+                      //
+                      // Exigir la igualdad con el uid obliga además a que el
+                      // campo esté presente: si falta, es null y no coincide.
+                      && request.resource.data.lastActionBy == request.auth.uid
                       && (!('note' in request.resource.data)
                           || request.resource.data.note == null
                           || request.resource.data.note.size() <= 200)
@@ -342,6 +356,10 @@ service cloud.firestore {
                           || request.resource.data.checkedInByName == null
                           || (request.resource.data.checkedInByName is string
                               && request.resource.data.checkedInByName.size() <= 120))
+                      && (!('lastActionByName' in request.resource.data)
+                          || request.resource.data.lastActionByName == null
+                          || (request.resource.data.lastActionByName is string
+                              && request.resource.data.lastActionByName.size() <= 120))
                       && (!('dniVerified' in request.resource.data)
                           || request.resource.data.dniVerified is bool)
                       && (!('dniMatchedName' in request.resource.data)

--- a/firestore.rules
+++ b/firestore.rules
@@ -343,6 +343,15 @@ service cloud.firestore {
                       // Exigir la igualdad con el uid obliga además a que el
                       // campo esté presente: si falta, es null y no coincide.
                       && request.resource.data.lastActionBy == request.auth.uid
+                      // Fijada al reloj del servidor, igual que `bingoWonAt`
+                      // más arriba y por los dos mismos motivos: nadie puede
+                      // fechar su acción cuando le convenga, y el campo queda
+                      // acotado sin necesidad de comprobar tipo ni tamaño.
+                      // Sin esto era el ÚNICO campo de la lista blanca sin
+                      // cota — justo lo que advierte el comentario de
+                      // `checkedInByName`, que existe para que un voluntario
+                      // no pueda escribir varios megabytes en una fila.
+                      && request.resource.data.lastActionAt == request.time
                       && (!('note' in request.resource.data)
                           || request.resource.data.note == null
                           || request.resource.data.note.size() <= 200)

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -952,6 +952,10 @@ export const api = onRequest(
 // Firestore trigger: incrementally maintains aggregates/current per
 // minigame instance whenever a participant response is created.
 export { onMinigameResponseWritten } from "./triggers/recomputeAggregates";
+// Audita el check-in. Es la única mutación del panel que no pasa por esta API
+// —va directa a Firestore para poder encolarse sin wifi—, así que un trigger es
+// el único sitio desde el que se puede registrar.
+export { onRosterCheckinWritten } from "./triggers/auditCheckin";
 // Deploying this creates a Cloud Scheduler job. It declares the Gmail
 // secrets itself; the `api` function's secrets array does not extend here.
 export { drainCredentialEmails } from "./triggers/drainCredentialEmails";

--- a/functions/src/triggers/auditCheckin.test.ts
+++ b/functions/src/triggers/auditCheckin.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ writeAuditLog: vi.fn() }));
+
+vi.mock("../utils/audit", () => ({ writeAuditLog: mocks.writeAuditLog }));
+
+// Stub del SDK v2 para que importar el módulo no exija configuración de
+// runtime. Los tests atacan el handler interno, no el export envuelto.
+vi.mock("firebase-functions/v2/firestore", () => ({
+  onDocumentWritten: (_path: string, handler: unknown) => handler,
+}));
+
+import { auditCheckinFromEvent, type RosterWriteEvent } from "./auditCheckin";
+
+const SLUG = "devfest-ica-2026";
+const ATTENDEE = "t_GOOGA263171317";
+
+/** Construye el evento con la forma que entrega Firestore. */
+function writeEvent(
+  before: Record<string, unknown> | null,
+  after: Record<string, unknown> | null
+): RosterWriteEvent {
+  return {
+    data: {
+      before: {
+        exists: before !== null,
+        data: () => before ?? undefined,
+      },
+      after: {
+        exists: after !== null,
+        data: () => after ?? undefined,
+      },
+    },
+    params: { slug: SLUG, attendeeId: ATTENDEE },
+  } as RosterWriteEvent;
+}
+
+beforeEach(() => {
+  mocks.writeAuditLog.mockReset();
+  mocks.writeAuditLog.mockResolvedValue(undefined);
+});
+
+describe("auditCheckinFromEvent", () => {
+  describe("registra el cambio de asistencia", () => {
+    it("marca presente", async () => {
+      await auditCheckinFromEvent(
+        writeEvent(
+          { checkedIn: false },
+          { checkedIn: true, lastActionBy: "vol-1", lastActionByName: "Ana" }
+        )
+      );
+
+      expect(mocks.writeAuditLog).toHaveBeenCalledTimes(1);
+      expect(mocks.writeAuditLog).toHaveBeenCalledWith({
+        action: "checkin.mark",
+        performedBy: "vol-1",
+        targetId: ATTENDEE,
+        targetType: "roster_attendee",
+        details: { eventSlug: SLUG, checkedIn: true, actorName: "Ana" },
+      });
+    });
+
+    // El caso que motivó todo esto: desmarcar limpia `checkedInBy`, así que
+    // antes marcar y desmarcar no dejaba constancia de nadie en ninguna parte.
+    it("desmarca, y sigue diciendo quién lo hizo", async () => {
+      await auditCheckinFromEvent(
+        writeEvent(
+          { checkedIn: true, lastActionBy: "vol-1" },
+          {
+            checkedIn: false,
+            checkedInBy: null,
+            lastActionBy: "org-9",
+            lastActionByName: "Alvaro",
+          }
+        )
+      );
+
+      expect(mocks.writeAuditLog).toHaveBeenCalledTimes(1);
+      expect(mocks.writeAuditLog.mock.calls[0][0]).toMatchObject({
+        action: "checkin.unmark",
+        performedBy: "org-9",
+        details: { checkedIn: false, actorName: "Alvaro" },
+      });
+    });
+
+    // La importación no escribe campos de check-in, ni siquiera a false, así
+    // que la primera vez que alguien marca presente el campo se AÑADE.
+    it("trata la ausencia previa del campo como 'no había llegado'", async () => {
+      await auditCheckinFromEvent(
+        writeEvent(
+          { ticketNumber: "GOOGA263171317" },
+          { ticketNumber: "GOOGA263171317", checkedIn: true, lastActionBy: "v" }
+        )
+      );
+
+      expect(mocks.writeAuditLog).toHaveBeenCalledTimes(1);
+      expect(mocks.writeAuditLog.mock.calls[0][0]).toMatchObject({
+        action: "checkin.mark",
+      });
+    });
+  });
+
+  describe("no registra lo que no es un cambio de asistencia", () => {
+    // El caso de volumen: importar un CSV de trescientas filas reescribe todas
+    // sin tocar el check-in. Sin este corte, cada importación ahogaría el
+    // registro con trescientas entradas que no cuentan nada.
+    it("ignora una importación que no toca el check-in", async () => {
+      await auditCheckinFromEvent(
+        writeEvent(
+          { checkedIn: true, email: "viejo@x.com", lastActionBy: "vol-1" },
+          { checkedIn: true, email: "nuevo@x.com", lastActionBy: "vol-1" }
+        )
+      );
+
+      expect(mocks.writeAuditLog).not.toHaveBeenCalled();
+    });
+
+    it("ignora una creación sin check-in (fila recién importada)", async () => {
+      await auditCheckinFromEvent(
+        writeEvent(null, { ticketNumber: "GOOGA263171317", email: "a@b.com" })
+      );
+
+      expect(mocks.writeAuditLog).not.toHaveBeenCalled();
+    });
+
+    it("ignora una nota añadida sin cambiar la asistencia", async () => {
+      await auditCheckinFromEvent(
+        writeEvent(
+          { checkedIn: false },
+          { checkedIn: false, note: "vino sin entrada", lastActionBy: "org-1" }
+        )
+      );
+
+      expect(mocks.writeAuditLog).not.toHaveBeenCalled();
+    });
+
+    it("ignora el borrado del documento", async () => {
+      await auditCheckinFromEvent(
+        writeEvent({ checkedIn: true, lastActionBy: "vol-1" }, null)
+      );
+
+      expect(mocks.writeAuditLog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("atribución degradada", () => {
+    // Las reglas garantizan `lastActionBy` en toda escritura del cliente, pero
+    // el Admin SDK se las salta y las filas anteriores a esa regla no lo
+    // tienen. Vale más una entrada que diga "no se sabe quién" que ninguna.
+    it("cae a 'unknown' cuando falta el actor", async () => {
+      await auditCheckinFromEvent(
+        writeEvent({ checkedIn: false }, { checkedIn: true })
+      );
+
+      expect(mocks.writeAuditLog.mock.calls[0][0]).toMatchObject({
+        performedBy: "unknown",
+        details: { actorName: null },
+      });
+    });
+
+    it("cae a 'unknown' cuando el actor no es una cadena usable", async () => {
+      await auditCheckinFromEvent(
+        writeEvent({ checkedIn: false }, { checkedIn: true, lastActionBy: 42 })
+      );
+
+      expect(mocks.writeAuditLog.mock.calls[0][0]).toMatchObject({
+        performedBy: "unknown",
+      });
+    });
+  });
+});

--- a/functions/src/triggers/auditCheckin.ts
+++ b/functions/src/triggers/auditCheckin.ts
@@ -1,0 +1,111 @@
+import { onDocumentWritten } from "firebase-functions/v2/firestore";
+import { writeAuditLog } from "../utils/audit";
+
+/**
+ * Audita el check-in de asistentes.
+ *
+ * Marcar asistencia es la ÚNICA mutación del panel que no pasa por la API: los
+ * voluntarios escriben directamente en Firestore para que la escritura se
+ * encole en la caché local y se reproduzca cuando el wifi del recinto vuelve.
+ * Esa decisión es correcta —en la puerta de un evento es la diferencia entre
+ * que el check-in funcione o no— pero dejaba la acción fuera del registro:
+ * `writeAuditLog` vive en la API, y aquí no hay petición que interceptar.
+ *
+ * De ahí un trigger. Es la única forma de instrumentar una escritura directa
+ * sin quitarle al panel lo que lo hace usable sin conexión.
+ *
+ * Un trigger de Firestore NO lleva contexto de autenticación, así que no puede
+ * saber por su cuenta quién escribió. Por eso el actor viaja en el propio
+ * documento (`lastActionBy`), y las reglas exigen que coincida con el uid de
+ * quien escribe. Ver el bloque `roster` en firestore.rules.
+ *
+ * Coste: una invocación por cambio de estado. En un DevFest son cientos.
+ */
+
+/** Lo mínimo del evento de Firestore que necesita el handler. */
+export interface RosterWriteEvent {
+  data?: {
+    before?: { exists: boolean; data: () => RosterDoc | undefined };
+    after?: { exists: boolean; data: () => RosterDoc | undefined };
+  };
+  params: { slug: string; attendeeId: string };
+}
+
+interface RosterDoc {
+  checkedIn?: unknown;
+  lastActionBy?: unknown;
+  lastActionByName?: unknown;
+}
+
+/**
+ * `true` solo si el documento dice explícitamente que la persona está presente.
+ *
+ * La importación no escribe campos de check-in en absoluto —ni siquiera a
+ * `false`, ver `handlers/checkin.ts`— así que la ausencia es el estado normal
+ * de una fila recién importada y tiene que leerse como "no ha llegado".
+ */
+function isCheckedIn(doc: RosterDoc | undefined): boolean {
+  return doc?.checkedIn === true;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Handler interno, exportado aparte para poder dirigirlo con un evento
+ * sintético en los tests sin levantar el emulador. Mismo patrón que
+ * `recomputeAggregates.ts`.
+ */
+export async function auditCheckinFromEvent(
+  event: RosterWriteEvent
+): Promise<void> {
+  const after = event.data?.after;
+
+  // Borrado. Las reglas ya lo prohíben desde el cliente, y una importación
+  // tampoco borra nunca (los asistentes que desaparecen del CSV se marcan,
+  // no se eliminan), así que llegar aquí significa una limpieza deliberada
+  // con el Admin SDK. No es un cambio de asistencia y no se registra como tal.
+  if (!after?.exists) return;
+
+  const beforeDoc = event.data?.before?.exists
+    ? event.data.before.data()
+    : undefined;
+  const afterDoc = after.data();
+
+  const was = isCheckedIn(beforeDoc);
+  const now = isCheckedIn(afterDoc);
+
+  // El grueso de las escrituras del roster son importaciones, que reescriben
+  // los datos del asistente sin tocar el check-in. Solo interesa el cambio de
+  // estado: sin esto, importar un CSV de trescientas filas generaría
+  // trescientas entradas que no cuentan nada.
+  if (was === now) return;
+
+  const { slug, attendeeId } = event.params;
+
+  await writeAuditLog({
+    action: now ? "checkin.mark" : "checkin.unmark",
+    // Las reglas garantizan que este campo existe y que es el uid de quien
+    // escribió. El fallback cubre las filas anteriores a esa regla y cualquier
+    // escritura hecha con el Admin SDK, que sí se salta las reglas.
+    performedBy: asString(afterDoc?.lastActionBy) ?? "unknown",
+    targetId: attendeeId,
+    targetType: "roster_attendee",
+    // Sin datos personales: el registro lo lee gente distinta de la que puede
+    // ver el roster, y el id del documento basta para seguir el rastro. Mismo
+    // criterio que en `handlers/credentials.ts`.
+    details: {
+      eventSlug: slug,
+      checkedIn: now,
+      actorName: asString(afterDoc?.lastActionByName),
+    },
+  });
+}
+
+export const onRosterCheckinWritten = onDocumentWritten(
+  "events/{slug}/roster/{attendeeId}",
+  // Cast en el punto de llamada para conservar el tipo fuerte del SDK v2 de
+  // cara al despliegue sin arrastrarlo al shape interno que usan los tests.
+  (event) => auditCheckinFromEvent(event as unknown as RosterWriteEvent)
+);

--- a/functions/src/triggers/auditCheckin.ts
+++ b/functions/src/triggers/auditCheckin.ts
@@ -19,7 +19,13 @@ import { writeAuditLog } from "../utils/audit";
  * documento (`lastActionBy`), y las reglas exigen que coincida con el uid de
  * quien escribe. Ver el bloque `roster` en firestore.rules.
  *
- * Coste: una invocación por cambio de estado. En un DevFest son cientos.
+ * Coste: una invocación por ESCRITURA en el roster, no por cambio de estado.
+ * Un trigger de Firestore no se puede filtrar en el servidor, así que importar
+ * un CSV de trescientas filas son trescientas invocaciones que salen por el
+ * `return` de abajo sin escribir nada. Es el precio de instrumentar una
+ * escritura directa, y a escala de un DevFest —unos cientos de filas por
+ * evento, unas pocas importaciones— entra de sobra en el nivel gratuito. Si
+ * algún día el roster fuera de decenas de miles, esto habría que replantearlo.
  */
 
 /** Lo mínimo del evento de Firestore que necesita el handler. */

--- a/functions/src/utils/auditActions.ts
+++ b/functions/src/utils/auditActions.ts
@@ -70,6 +70,11 @@ export const AUDIT_ACTIONS = [
   "settings.email_transport",
   "certificate.send",
   "checkin.import",
+  // Las escribe un trigger de Firestore, no un handler: el check-in va directo
+  // del cliente a Firestore para poder encolarse sin wifi, así que no hay
+  // petición donde engancharse. Ver `triggers/auditCheckin.ts`.
+  "checkin.mark",
+  "checkin.unmark",
   "credential.create",
   "credential.image",
   "credential.bevy_status",
@@ -83,10 +88,12 @@ export const AUDIT_ACTIONS = [
   // no deja fila, porque una por vista de página ahoga el registro y el visor
   // solo admite un filtro a la vez.
   //
-  // Falta a propósito el roster de asistentes y las credenciales con datos
-  // personales: el panel los lee DIRECTAMENTE de Firestore, acotado por las
-  // reglas, sin pasar por la API. No hay endpoint donde engancharse, así que
-  // cubrirlos exigiría instrumentar el lado de Firestore.
+  // Faltan las LECTURAS del roster y de las credenciales, que el panel hace
+  // directamente contra Firestore, acotadas por las reglas y sin pasar por la
+  // API: no hay endpoint donde engancharse. Sus ESCRITURAS sí se auditan desde
+  // que existe `triggers/auditCheckin.ts` (`checkin.mark`/`checkin.unmark`);
+  // cubrir también las lecturas exigiría un camino distinto, porque una
+  // suscripción en tiempo real no es un hecho puntual que fechar.
   "read.audit_log",
   "read.users",
   "read.form_responses",

--- a/src/components/react/admin/checkin/useRoster.ts
+++ b/src/components/react/admin/checkin/useRoster.ts
@@ -238,6 +238,15 @@ export async function setCheckedIn(
       // The rules require attribution when marking present.
       checkedInBy: checkedIn ? by.uid : null,
       checkedInByName: checkedIn ? by.name : null,
+      // Quién hizo la acción, en LAS DOS direcciones — a diferencia de
+      // checkedInBy, que se limpia al desmarcar porque ya no hay check-in que
+      // atribuir. Sin esto, marcar y desmarcar no dejaba constancia de nadie:
+      // el trigger que audita estas escrituras es de Firestore y no lleva
+      // contexto de autenticación, así que el actor tiene que viajar en el
+      // documento. Las reglas lo exigen y rechazan la escritura si falta.
+      lastActionBy: by.uid,
+      lastActionByName: by.name,
+      lastActionAt: serverTimestamp(),
     }).catch((err) => {
       onError(err instanceof Error ? err.message : "No se pudo guardar");
     });

--- a/tests/rules/checkin-roster.test.ts
+++ b/tests/rules/checkin-roster.test.ts
@@ -1,6 +1,14 @@
 import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
 import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
-import { deleteDoc, doc, getDoc, setDoc, updateDoc } from "firebase/firestore";
+import {
+  deleteDoc,
+  doc,
+  getDoc,
+  serverTimestamp,
+  setDoc,
+  Timestamp,
+  updateDoc,
+} from "firebase/firestore";
 import { cleanup, clearAll, getTestEnv } from "./setup";
 
 const SLUG = "devfest-ica-2026";
@@ -28,7 +36,7 @@ async function seedRole(
  * el motivo que dicen estar comprobando.
  */
 function checkin(uid: string, fields: Record<string, unknown>) {
-  return { lastActionBy: uid, ...fields };
+  return { lastActionBy: uid, lastActionAt: serverTimestamp(), ...fields };
 }
 
 /** Seeds a roster doc the way the import Cloud Function would. */
@@ -397,6 +405,39 @@ describe("checkin roster rules", () => {
           checkedIn: false,
           checkedInAt: null,
           checkedInBy: null,
+        })
+      );
+    });
+
+    // Mismo motivo por el que `bingoWonAt` va fijado a `request.time`: si el
+    // cliente pudiera elegir la fecha, la auditoría contaría el orden de los
+    // hechos como a esa persona le conviniera. Y sin la fijación este campo era
+    // el único de la lista blanca sin cota de tipo ni de tamaño.
+    it("denies a backdated lastActionAt", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "org-1",
+          lastActionBy: "org-1",
+          lastActionAt: Timestamp.fromMillis(1000),
+        })
+      );
+    });
+
+    it("denies a write with no lastActionAt at all", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "org-1",
+          lastActionBy: "org-1",
         })
       );
     });

--- a/tests/rules/checkin-roster.test.ts
+++ b/tests/rules/checkin-roster.test.ts
@@ -18,6 +18,19 @@ async function seedRole(
   });
 }
 
+/**
+ * Payload de una escritura de check-in, con la atribución ya puesta.
+ *
+ * Las reglas exigen `lastActionBy == request.auth.uid` en TODA escritura del
+ * roster. Va en un helper y no a mano en cada caso para que los tests que
+ * comprueban otra cosa —los límites de longitud, los campos inmutables— no
+ * puedan pasar por accidente al faltarles la atribución, en vez de fallar por
+ * el motivo que dicen estar comprobando.
+ */
+function checkin(uid: string, fields: Record<string, unknown>) {
+  return { lastActionBy: uid, ...fields };
+}
+
 /** Seeds a roster doc the way the import Cloud Function would. */
 async function seedAttendee(over: Record<string, unknown> = {}) {
   const env = await getTestEnv();
@@ -160,10 +173,10 @@ describe("checkin roster rules", () => {
       });
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: true,
-          checkedInBy: "org-1",
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", { checkedIn: true, checkedInBy: "org-1" })
+        )
       );
     });
 
@@ -233,12 +246,15 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertSucceeds(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: true,
-          checkedInAt: new Date(),
-          checkedInBy: "org-1",
-          checkedInByName: "Alvaro",
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: true,
+            checkedInAt: new Date(),
+            checkedInBy: "org-1",
+            checkedInByName: "Alvaro",
+          })
+        )
       );
     });
 
@@ -248,11 +264,14 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: true,
-          checkedInBy: "org-1",
-          email: "attacker@evil.com",
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: true,
+            checkedInBy: "org-1",
+            email: "attacker@evil.com",
+          })
+        )
       );
     });
   });
@@ -264,11 +283,31 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: true,
-          checkedInBy: "org-1",
-          checkedInByName: "x".repeat(121),
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: true,
+            checkedInBy: "org-1",
+            checkedInByName: "x".repeat(121),
+          })
+        )
+      );
+    });
+
+    it("rejects an over-long lastActionByName", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: true,
+            checkedInBy: "org-1",
+            lastActionByName: "x".repeat(121),
+          })
+        )
       );
     });
 
@@ -278,11 +317,14 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: true,
-          checkedInBy: "org-1",
-          dniMatchScore: 7,
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: true,
+            checkedInBy: "org-1",
+            dniMatchScore: 7,
+          })
+        )
       );
     });
 
@@ -292,11 +334,14 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: true,
-          checkedInBy: "org-1",
-          dniVerified: "yes",
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: true,
+            checkedInBy: "org-1",
+            dniVerified: "yes",
+          })
+        )
       );
     });
   });
@@ -308,26 +353,80 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertSucceeds(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: true,
-          checkedInAt: new Date(),
-          checkedInBy: "org-1",
-          checkedInByName: "Alvaro",
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: true,
+            checkedInAt: new Date(),
+            checkedInBy: "org-1",
+            checkedInByName: "Alvaro",
+          })
+        )
       );
     });
 
-    it("allows un-checking without attribution", async () => {
+    // Desmarcar sigue poniendo `checkedInBy` a null —es lo correcto, ya no hay
+    // check-in que atribuir—, pero la ACCIÓN sí queda atribuida en
+    // `lastActionBy`. Antes marcar y desmarcar no dejaba constancia de nadie en
+    // ninguna parte, y el trigger de auditoría no tiene contexto de auth del
+    // que sacarlo.
+    it("allows un-checking, attributed to whoever did it", async () => {
       const env = await getTestEnv();
       await seedAttendee({ checkedIn: true, checkedInBy: "org-1" });
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertSucceeds(
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: false,
+            checkedInAt: null,
+            checkedInBy: null,
+          })
+        )
+      );
+    });
+
+    it("denies un-checking without saying who did it", async () => {
+      const env = await getTestEnv();
+      await seedAttendee({ checkedIn: true, checkedInBy: "org-1" });
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
         updateDoc(doc(org, ATTENDEE), {
           checkedIn: false,
           checkedInAt: null,
           checkedInBy: null,
         })
+      );
+    });
+
+    it("denies marking someone present without saying who did it", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), {
+          checkedIn: true,
+          checkedInBy: "org-1",
+        })
+      );
+    });
+
+    it("denies attributing the action to somebody else", async () => {
+      const env = await getTestEnv();
+      await seedAttendee();
+      await seedRole("org-1", "organizer");
+      const org = env.authenticatedContext("org-1").firestore();
+      await assertFails(
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("otra-persona", {
+            checkedIn: true,
+            checkedInBy: "org-1",
+          })
+        )
       );
     });
 
@@ -337,10 +436,13 @@ describe("checkin roster rules", () => {
       await seedRole("member-1", "member");
       const member = env.authenticatedContext("member-1").firestore();
       await assertFails(
-        updateDoc(doc(member, ATTENDEE), {
-          checkedIn: true,
-          checkedInBy: "member-1",
-        })
+        updateDoc(
+          doc(member, ATTENDEE),
+          checkin("member-1", {
+            checkedIn: true,
+            checkedInBy: "member-1",
+          })
+        )
       );
     });
 
@@ -350,10 +452,13 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: true,
-          checkedInBy: "someone-else",
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: true,
+            checkedInBy: "someone-else",
+          })
+        )
       );
     });
   });
@@ -365,7 +470,10 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), { email: "attacker@evil.com" })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", { email: "attacker@evil.com" })
+        )
       );
     });
 
@@ -374,7 +482,9 @@ describe("checkin roster rules", () => {
       await seedAttendee();
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
-      await assertFails(updateDoc(doc(org, ATTENDEE), { firstName: "Otro" }));
+      await assertFails(
+        updateDoc(doc(org, ATTENDEE), checkin("org-1", { firstName: "Otro" }))
+      );
     });
 
     it("denies faking bevyCheckinAt, which the Bevy sync diffs against", async () => {
@@ -383,7 +493,10 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), { bevyCheckinAt: new Date() })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", { bevyCheckinAt: new Date() })
+        )
       );
     });
 
@@ -393,11 +506,14 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: true,
-          checkedInBy: "org-1",
-          email: "attacker@evil.com",
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: true,
+            checkedInBy: "org-1",
+            email: "attacker@evil.com",
+          })
+        )
       );
     });
 
@@ -407,10 +523,10 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: "yes",
-          checkedInBy: "org-1",
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", { checkedIn: "yes", checkedInBy: "org-1" })
+        )
       );
     });
 
@@ -420,11 +536,14 @@ describe("checkin roster rules", () => {
       await seedRole("org-1", "organizer");
       const org = env.authenticatedContext("org-1").firestore();
       await assertFails(
-        updateDoc(doc(org, ATTENDEE), {
-          checkedIn: true,
-          checkedInBy: "org-1",
-          note: "x".repeat(201),
-        })
+        updateDoc(
+          doc(org, ATTENDEE),
+          checkin("org-1", {
+            checkedIn: true,
+            checkedInBy: "org-1",
+            note: "x".repeat(201),
+          })
+        )
       );
     });
   });

--- a/tests/rules/event-scope.test.ts
+++ b/tests/rules/event-scope.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
 import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
-import { doc, getDoc, setDoc, updateDoc } from "firebase/firestore";
+import {
+  doc,
+  getDoc,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+} from "firebase/firestore";
 import { cleanup, clearAll, getTestEnv } from "./setup";
 
 const EVENT_A = "devfest-ica-2026";
@@ -120,8 +126,10 @@ describe("alcance por evento", () => {
           checkedIn: true,
           checkedInBy: "vol-1",
           // Las reglas exigen atribución de la ACCIÓN en toda escritura del
-          // roster, para que el trigger de auditoría sepa quién la hizo.
+          // roster, para que el trigger de auditoría sepa quién la hizo, y la
+          // fecha fijada al reloj del servidor.
           lastActionBy: "vol-1",
+          lastActionAt: serverTimestamp(),
         })
       );
     });

--- a/tests/rules/event-scope.test.ts
+++ b/tests/rules/event-scope.test.ts
@@ -119,6 +119,9 @@ describe("alcance por evento", () => {
         updateDoc(doc(vol, ATTENDEE_A), {
           checkedIn: true,
           checkedInBy: "vol-1",
+          // Las reglas exigen atribución de la ACCIÓN en toda escritura del
+          // roster, para que el trigger de auditoría sepa quién la hizo.
+          lastActionBy: "vol-1",
         })
       );
     });


### PR DESCRIPTION
> **Stacked on #323.** The base of this PR is `fix/rules-caducidad-y-revocaciones`, not `main` — both touch the roster block in `firestore.rules`. Merge #323 first and GitHub will retarget this one automatically.

## What changed

- **New trigger** `functions/src/triggers/auditCheckin.ts`, following the shape already established by `recomputeAggregates.ts`: an inner handler exported separately so it can be driven with a synthetic event in unit tests, without the emulator.
- **`firestore.rules`** — `lastActionBy`, `lastActionByName` and `lastActionAt` join the roster allowlist, `lastActionBy` must equal `request.auth.uid` on **every** roster write, and the name is length-bounded like `checkedInByName`.
- **`useRoster.setCheckedIn()`** writes those three fields in both directions.
- **New actions** `checkin.mark` / `checkin.unmark`. The `checkin.` prefix already maps to the `operations` category.

## Why

Marking attendance was the only panel mutation with no trace in `audit_log`. Not by oversight: check-in writes straight to Firestore so the write can queue in the local cache and replay when venue wifi returns, which means it never passes through the API and there is no request to hang `writeAuditLog` on. The comment in `auditActions.ts` already conceded the point — *"cubrirlo exigiría instrumentar el lado de Firestore"* — and that is what this does, without taking away what makes the panel usable at the door.

Attribution had to be solved first. `checkedInBy` will not do: un-checking sets it to `null`, so marking and then un-marking erased the only record of who did it, leaving nothing anywhere. And a Firestore trigger carries no auth context, so if the actor does not travel in the document there is no way to recover it afterwards. Hence `lastActionBy`, which the rules require to match the writer — requiring equality also forces the field to be present, since a missing field is `null` and matches nothing.

The trigger only records a **change of state**. An import rewrites every row without touching check-in, and without that guard a 300-row CSV would add 300 entries that say nothing. Details carry no personal data: the log is read by a different set of eyes than the roster, and the document id is enough to trace the record — same rule as `handlers/credentials.ts`.

## How to test

```bash
pnpm test:functions  # 714 (was 705 on the base branch)
pnpm test:rules      # 179 (was 175 on the base branch)
```

Worth knowing during review: the rules tests now pass attribution through a `checkin()` helper rather than inline. Several of them check something else entirely — length bounds, immutable fields — and without the new field they would have failed for the *wrong reason*, which is the quiet way a test stops testing what it claims.

End to end, with the emulators up: mark and unmark someone from the panel and confirm two `audit_log` rows with the right `performedBy` on both. Then import a roster and confirm it produces none.

## Deploy note

**Rules and client must ship together.** A panel tab left open from before will write without `lastActionBy` and have its check-ins rejected until it reloads. Do not merge with an event close by.