### PR TITLE
fix(audit): alert on notable events, not just critical ones

### DIFF
--- a/docs/auditoria.md
+++ b/docs/auditoria.md
@@ -112,9 +112,28 @@ que ninguna petición pase el middleware — y cada intento posterior queda como
 
 ## Alertas
 
-`functions/src/triggers/auditAlerts.ts` corre cada hora, busca lo `critical`
-desde su marca de agua (`settings/auditAlerts`) y manda un correo a la dirección
-de contacto. Un solo correo con todo lo acumulado, no uno por evento.
+`functions/src/triggers/auditAlerts.ts` corre cada hora, busca lo **notable**
+(`warning` y `critical`) desde su marca de agua (`settings/auditAlerts`) y manda
+un correo a la dirección de contacto. Un solo correo con todo lo acumulado, no
+uno por evento.
+
+Mira los dos niveles y no solo `critical` por una razón concreta: a `critical`
+solo llegan dos cosas —una cuenta suspendida que sigue intentando operar y el
+propio registro estrangulándose—, mientras que `security.permission.denied`, que
+es lo que delata a alguien probando qué puede tocar, es `warning`. Igual que las
+filas `synthesized`, que significan "hay código mutando cosas sin decir qué".
+Avisando solo de lo crítico, una tarde entera de sondeo no generaba ni un correo.
+
+Los dos niveles se tratan distinto para que ampliarlo no convierta el aviso en
+ruido: lo crítico se detalla evento a evento y los `warning` van **agregados por
+acción** con su cuenta. Provocar un `warning` es barato —basta con tantear un
+endpoint—, así que detallarlos dejaría que quien sondea decidiera la longitud
+del correo.
+
+Si el correo dice **"al menos N"**, la consulta llegó a su techo de 200 filas y
+hubo más de las que cuenta. La marca de agua avanza igual, así que lo que quedó
+fuera no se avisa nunca: el panel es la fuente completa. El enlace del correo ya
+va filtrado por `?severity=notable`, que es exactamente lo que el aviso cubre.
 
 Si las alertas dejan de llegar, el fallo está en Cloud Logging:
 

--- a/functions/src/handlers/audit.ts
+++ b/functions/src/handlers/audit.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import * as admin from "firebase-admin";
 import { safeError } from "../middleware/validate";
+import { NOTABLE_SEVERITIES } from "../utils/auditTypes";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
@@ -27,16 +28,8 @@ const FILTERABLE = [
 ] as const;
 type Filterable = (typeof FILTERABLE)[number];
 
-/**
- * Severidades que alguien querría revisar de una sentada.
- *
- * Se resuelve con un `in` sobre el mismo campo que ya tiene índice. La
- * alternativa —una desigualdad `severity >= "warning"`— no sirve: Firestore
- * exige que el primer `orderBy` sea el campo de la desigualdad, y aquí el orden
- * tiene que ser por `timestamp` o el registro deja de leerse como una
- * cronología.
- */
-const NOTABLE_SEVERITIES = ["warning", "critical"];
+// Compartida con las alertas por correo: el visor y el aviso tienen que
+// resaltar exactamente lo mismo. Ver `utils/auditTypes.ts`.
 
 function readLimit(raw: unknown): number {
   const parsed = typeof raw === "string" ? parseInt(raw, 10) : NaN;

--- a/functions/src/services/email.ts
+++ b/functions/src/services/email.ts
@@ -214,11 +214,28 @@ export async function sendAuditAlertEmail(mail: {
     ipPrefix?: string | null;
     at?: Date | null;
   }[];
+  /**
+   * `warning` agregados por acción. Provocarlos es barato, así que se cuentan
+   * en vez de detallarse: quien tantea endpoints no debe poder decidir la
+   * longitud del correo.
+   */
+  warningSummary?: { action: string; count: number }[];
+  /** Cuántos `warning` hubo en total, aunque el resumen recorte acciones. */
+  warningTotal?: number;
   /** Total real: puede superar `events.length` si se recortó la lista. */
   total: number;
+  /**
+   * La consulta llegó a su techo, así que `total` es un suelo y no un total.
+   * Se dice en voz alta: la marca de agua avanza igual y lo que quedó fuera no
+   * se avisa nunca.
+   */
+  truncated?: boolean;
   panelUrl: string;
 }): Promise<void> {
   const desde = mail.since.toLocaleString("es-PE");
+  const cuantos = mail.truncated
+    ? `al menos ${mail.total}`
+    : String(mail.total);
   const rows = mail.events
     .map((e) => {
       const cuando = e.at ? e.at.toLocaleString("es-PE") : "—";
@@ -231,9 +248,27 @@ export async function sendAuditAlertEmail(mail: {
     })
     .join("");
 
-  const recortado =
-    mail.total > mail.events.length
-      ? `<p>Se muestran ${mail.events.length} de <strong>${mail.total}</strong>. ` +
+  const summary = mail.warningSummary ?? [];
+  const warningTotal = mail.warningTotal ?? 0;
+
+  const summaryRows = summary
+    .map(
+      (s) =>
+        `<li><code>${htmlEscape(singleLine(s.action))}</code> × ${s.count}</li>`
+    )
+    .join("");
+
+  const resumen = summary.length
+    ? `<p>Además, <strong>${warningTotal}</strong> evento(s) de nivel aviso, ` +
+      `agrupados por acción:</p><ul>${summaryRows}</ul>`
+    : "";
+
+  const recortado = mail.truncated
+    ? `<p>La consulta llegó a su límite, así que hubo <strong>al menos</strong> ` +
+      `esos eventos — pueden haber sido más. Míralo en el panel.</p>`
+    : mail.events.length < mail.total - warningTotal
+      ? `<p>Se detallan ${mail.events.length} de ` +
+        `<strong>${mail.total - warningTotal}</strong> críticos. ` +
         `El resto está en el panel.</p>`
       : "";
 
@@ -245,18 +280,30 @@ export async function sendAuditAlertEmail(mail: {
     )
     .join("\n");
 
+  const textSummary = summary
+    .map((s) => `- ${singleLine(s.action)} x ${s.count}`)
+    .join("\n");
+
   await sendPlain(
     mail.to,
-    `[GDG ICA] ${mail.total} evento(s) de auditoría que revisar`,
-    `<p>Hay <strong>${mail.total}</strong> evento(s) registrados desde ` +
+    `[GDG ICA] ${cuantos} evento(s) de auditoría que revisar`,
+    `<p>Hay <strong>${cuantos}</strong> evento(s) registrados desde ` +
       `${htmlEscape(desde)} que conviene revisar.</p>` +
-      `<ul>${rows}</ul>${recortado}` +
+      (rows ? `<ul>${rows}</ul>` : "") +
+      `${resumen}${recortado}` +
       `<p><a href="${htmlEscape(mail.panelUrl)}">Abrir el registro de auditoría</a></p>` +
       `<p>Si no reconoces alguna de estas acciones, revisa los roles y los ` +
       `permisos en /admin/users antes que nada.</p>` +
       `<p>Comunidad GDG ICA</p>`,
-    `Hay ${mail.total} evento(s) de auditoría desde ${desde} que conviene ` +
-      `revisar.\n\n${textRows}\n\n${mail.panelUrl}\n\n` +
+    `Hay ${cuantos} evento(s) de auditoría desde ${desde} que conviene ` +
+      `revisar.\n\n${textRows}\n\n` +
+      (textSummary
+        ? `Avisos por acción (${warningTotal}):\n${textSummary}\n\n`
+        : "") +
+      (mail.truncated
+        ? `La consulta llegó a su límite: pudo haber más.\n\n`
+        : "") +
+      `${mail.panelUrl}\n\n` +
       `Si no reconoces alguna de estas acciones, revisa los roles y permisos ` +
       `en /admin/users antes que nada.\n\nComunidad GDG ICA`
   );

--- a/functions/src/services/email.ts
+++ b/functions/src/services/email.ts
@@ -222,6 +222,11 @@ export async function sendAuditAlertEmail(mail: {
   warningSummary?: { action: string; count: number }[];
   /** Cuántos `warning` hubo en total, aunque el resumen recorte acciones. */
   warningTotal?: number;
+  /**
+   * Cuántas acciones distintas hubo. Si supera las filas del resumen, el correo
+   * lo dice: recortar está bien, ocultar que se recortó no.
+   */
+  warningActionCount?: number;
   /** Total real: puede superar `events.length` si se recortó la lista. */
   total: number;
   /**
@@ -258,9 +263,19 @@ export async function sendAuditAlertEmail(mail: {
     )
     .join("");
 
+  // Recortar el resumen está bien; callar que se recortó, no — es el mismo
+  // fallo que este cambio corrige en el total de eventos.
+  const accionesOmitidas = Math.max(
+    0,
+    (mail.warningActionCount ?? summary.length) - summary.length
+  );
+
   const resumen = summary.length
     ? `<p>Además, <strong>${warningTotal}</strong> evento(s) de nivel aviso, ` +
-      `agrupados por acción:</p><ul>${summaryRows}</ul>`
+      `agrupados por acción:</p><ul>${summaryRows}</ul>` +
+      (accionesOmitidas > 0
+        ? `<p>Y ${accionesOmitidas} acción(es) más, en el panel.</p>`
+        : "")
     : "";
 
   const recortado = mail.truncated
@@ -280,9 +295,11 @@ export async function sendAuditAlertEmail(mail: {
     )
     .join("\n");
 
-  const textSummary = summary
-    .map((s) => `- ${singleLine(s.action)} x ${s.count}`)
-    .join("\n");
+  const textSummary =
+    summary.map((s) => `- ${singleLine(s.action)} x ${s.count}`).join("\n") +
+    (accionesOmitidas > 0
+      ? `\n- y ${accionesOmitidas} acción(es) más, en el panel`
+      : "");
 
   await sendPlain(
     mail.to,

--- a/functions/src/triggers/auditAlerts.test.ts
+++ b/functions/src/triggers/auditAlerts.test.ts
@@ -195,6 +195,32 @@ describe("aviso", () => {
     expect(alert.warningTotal).toBe(2);
   });
 
+  // El resumen se recorta a 15 acciones. Callar que se recortó sería el mismo
+  // fallo que este cambio corrige en el total.
+  it("dice cuántas acciones deja fuera del resumen", async () => {
+    rows = Array.from({ length: 20 }, (_, i) =>
+      warning({ action: `security.accion.${i}` })
+    );
+    await run();
+    const alert = sentAlerts[0] as {
+      warningSummary: unknown[];
+      warningActionCount: number;
+    };
+    expect(alert.warningSummary).toHaveLength(15);
+    expect(alert.warningActionCount).toBe(20);
+  });
+
+  it("no deja nada fuera cuando caben todas", async () => {
+    rows = [warning(), warning({ action: "security.ratelimit.exceeded" })];
+    await run();
+    const alert = sentAlerts[0] as {
+      warningSummary: unknown[];
+      warningActionCount: number;
+    };
+    expect(alert.warningSummary).toHaveLength(2);
+    expect(alert.warningActionCount).toBe(2);
+  });
+
   // La marca de agua avanza igual, así que lo que el límite dejó fuera no se
   // avisa nunca. Dar ese recuento como total sería mentir justo en la ráfaga,
   // que es cuando el número real es el dato que hace falta.

--- a/functions/src/triggers/auditAlerts.test.ts
+++ b/functions/src/triggers/auditAlerts.test.ts
@@ -91,6 +91,22 @@ function critical(over: Record<string, unknown> = {}, agoMs = 60_000) {
   };
 }
 
+/**
+ * Fila de nivel aviso. Es la severidad de `security.permission.denied`, que es
+ * la señal de alguien tanteando qué puede tocar — y la que antes no disparaba
+ * ningún correo.
+ */
+function warning(over: Record<string, unknown> = {}, agoMs = 60_000) {
+  return critical(
+    {
+      action: "security.permission.denied",
+      severity: "warning",
+      ...over,
+    },
+    agoMs
+  );
+}
+
 beforeEach(() => {
   docs.clear();
   rows = [];
@@ -136,17 +152,90 @@ describe("aviso", () => {
     expect(alert.events).toHaveLength(25);
   });
 
+  // El caso que motivó ampliar la consulta: `security.permission.denied` es la
+  // señal principal de alguien probando qué alcanza, y es `warning`. Mirando
+  // solo lo crítico, una tarde entera de sondeo no generaba ni un correo.
+  it("avisa también de lo que es solo aviso", async () => {
+    rows = [warning()];
+    await run();
+    expect(sentAlerts).toHaveLength(1);
+    expect(sentAlerts[0]).toMatchObject({ total: 1, warningTotal: 1 });
+  });
+
+  // Detallarlos uno a uno dejaría que quien sondea decidiera la longitud del
+  // correo, y un correo larguísimo se lee como spam.
+  it("agrupa los avisos por acción en vez de detallarlos", async () => {
+    rows = [
+      warning(),
+      warning({ performedBy: "actor-2" }),
+      warning({ action: "security.ratelimit.exceeded" }),
+    ];
+    await run();
+    const alert = sentAlerts[0] as {
+      events: unknown[];
+      warningSummary: { action: string; count: number }[];
+    };
+    expect(alert.events).toHaveLength(0);
+    expect(alert.warningSummary).toEqual([
+      { action: "security.permission.denied", count: 2 },
+      { action: "security.ratelimit.exceeded", count: 1 },
+    ]);
+  });
+
+  it("detalla lo crítico y resume lo demás en el mismo correo", async () => {
+    rows = [critical(), warning(), warning()];
+    await run();
+    const alert = sentAlerts[0] as {
+      total: number;
+      events: unknown[];
+      warningTotal: number;
+    };
+    expect(alert.total).toBe(3);
+    expect(alert.events).toHaveLength(1);
+    expect(alert.warningTotal).toBe(2);
+  });
+
+  // La marca de agua avanza igual, así que lo que el límite dejó fuera no se
+  // avisa nunca. Dar ese recuento como total sería mentir justo en la ráfaga,
+  // que es cuando el número real es el dato que hace falta.
+  it("avisa de que el recuento es un suelo cuando la consulta topa", async () => {
+    rows = Array.from({ length: 200 }, () => critical());
+    await run();
+    expect(sentAlerts[0]).toMatchObject({ truncated: true, total: 200 });
+  });
+
+  it("no lo marca como truncado si la ventana cabía entera", async () => {
+    // 199 filas: la consulta no llegó a su techo, así que se trajo todo.
+    rows = Array.from({ length: 199 }, () => critical());
+    await run();
+    expect(sentAlerts[0]).toMatchObject({ truncated: false });
+  });
+
+  // Aunque la consulta tope, si parte de lo traído queda fuera de la ventana
+  // sabemos que la ventana entera cabía y el total es exacto.
+  it("no lo marca como truncado si parte de lo traído es antiguo", async () => {
+    rows = [
+      ...Array.from({ length: 199 }, () => critical()),
+      critical({}, 5 * 60 * 60 * 1000),
+    ];
+    await run();
+    expect(sentAlerts[0]).toMatchObject({ truncated: false, total: 199 });
+  });
+
   it("incluye el prefijo de red, no la dirección", async () => {
     rows = [critical()];
     await run();
     expect(JSON.stringify(sentAlerts[0])).toContain("181.65.42.0/24");
   });
 
-  it("enlaza al panel ya filtrado", async () => {
-    rows = [critical()];
+  // `notable`, no `critical`: el enlace tiene que enseñar lo mismo de lo que
+  // avisa el correo. Filtrando por crítico, quien siguiera el enlace tras un
+  // aviso de sondeo no encontraría ninguna de las filas que lo motivaron.
+  it("enlaza al panel filtrado por lo mismo que avisa", async () => {
+    rows = [warning()];
     await run();
     expect(sentAlerts[0]).toMatchObject({
-      panelUrl: "https://gdgica.com/admin/audit?severity=critical",
+      panelUrl: "https://gdgica.com/admin/audit?severity=notable",
     });
   });
 });

--- a/functions/src/triggers/auditAlerts.ts
+++ b/functions/src/triggers/auditAlerts.ts
@@ -174,6 +174,11 @@ export const auditAlerts = onSchedule(
         events,
         warningSummary,
         warningTotal: warnings.length,
+        // Cuántas acciones DISTINTAS hubo, no cuántas se enseñan. El resumen
+        // se recorta a `MAX_SUMMARY_ROWS`, y sin este número el correo callaba
+        // que había recortado — la misma omisión silenciosa que este cambio
+        // corrige en el total.
+        warningActionCount: byAction.size,
         total: fresh.length,
         truncated,
         // `notable` y no `critical`: el enlace tiene que enseñar lo mismo de lo

--- a/functions/src/triggers/auditAlerts.ts
+++ b/functions/src/triggers/auditAlerts.ts
@@ -10,6 +10,7 @@ import {
   SITE_ORIGIN,
 } from "../config";
 import { sendAuditAlertEmail } from "../services/email";
+import { NOTABLE_SEVERITIES } from "../utils/auditTypes";
 
 /**
  * A quién se avisa. La misma dirección de contacto del resto de la plataforma:
@@ -29,6 +30,12 @@ const MAX_DETAILED = 25;
 
 /** Techo de la consulta, para que una ráfaga no traiga la colección entera. */
 const QUERY_LIMIT = 200;
+
+/**
+ * Cuántas acciones distintas se resumen. Los `warning` van agregados por
+ * acción, así que esto acota la tabla del resumen, no cuántos eventos cuenta.
+ */
+const MAX_SUMMARY_ROWS = 15;
 
 /**
  * Primera ejecución: sin marca de agua, se mira solo la última hora en vez de
@@ -54,8 +61,21 @@ interface AuditRow {
  * la auditoría en una defensa es que te busque a ti y no al contrario.
  *
  * Se apoya en `severity`, no en una lista de acciones. Cualquier acción futura
- * que se marque como `critical` entra en las alertas sin tocar este archivo — y
- * al revés, subir algo a `critical` es una decisión con consecuencia visible.
+ * que se marque como notable entra en las alertas sin tocar este archivo — y al
+ * revés, subir la severidad de algo es una decisión con consecuencia visible.
+ *
+ * Mira `warning` además de `critical`, y esa es la razón de ser de este
+ * diseño. Solo dos cosas llegan a `critical`: una cuenta suspendida que sigue
+ * intentando operar, y el propio registro estrangulándose. Lo que de verdad
+ * delata a alguien probando qué puede tocar —`security.permission.denied`— es
+ * `warning`, igual que las filas `synthesized` que significan "aquí hay código
+ * mutando cosas sin decir qué". Avisando solo de lo crítico, una tarde entera
+ * de sondeo no generaba ni un correo.
+ *
+ * Para que ampliarlo no convierta el aviso en ruido, los dos niveles se tratan
+ * distinto: lo crítico se detalla evento a evento, y los `warning` van
+ * agregados por acción con su cuenta. Un correo de doscientas líneas se lee
+ * como spam y se empieza a ignorar justo cuando importa.
  */
 export const auditAlerts = onSchedule(
   {
@@ -85,7 +105,7 @@ export const auditAlerts = onSchedule(
 
     const snapshot = await db
       .collection("audit_log")
-      .where("severity", "==", "critical")
+      .where("severity", "in", NOTABLE_SEVERITIES)
       .orderBy("timestamp", "desc")
       .limit(QUERY_LIMIT)
       .get();
@@ -101,6 +121,18 @@ export const auditAlerts = onSchedule(
         return at > since && at <= windowEnd;
       });
 
+    // Si la consulta llegó al techo Y todo lo que trajo cae dentro de la
+    // ventana, es que había más por debajo que el `limit` cortó: no sabemos
+    // cuántos eventos hubo, solo que fueron al menos estos.
+    //
+    // Decirlo importa porque la marca de agua avanza igual, así que lo que se
+    // quedó fuera no se avisa nunca. Antes el correo daba ese recuento como si
+    // fuera el total, que es precisamente mentir en la ráfaga — el momento en
+    // que el número real es el dato que hace falta.
+    const truncated =
+      snapshot.docs.length === QUERY_LIMIT &&
+      fresh.length === snapshot.docs.length;
+
     // La marca de agua avanza SIEMPRE, incluso sin nada que avisar. Si solo
     // avanzara al mandar correo, una hora tranquila dejaría la ventana abierta
     // y la siguiente ejecución volvería a mirar lo mismo.
@@ -111,7 +143,13 @@ export const auditAlerts = onSchedule(
 
     if (fresh.length === 0) return;
 
-    const events = fresh.slice(0, MAX_DETAILED).map((row) => ({
+    // Lo crítico se detalla; los `warning` se agregan. Provocar un `warning` es
+    // barato —basta con tantear un endpoint— así que detallarlos uno a uno
+    // dejaría que quien sondea decidiera la longitud del correo.
+    const criticals = fresh.filter((row) => row.severity === "critical");
+    const warnings = fresh.filter((row) => row.severity !== "critical");
+
+    const events = criticals.slice(0, MAX_DETAILED).map((row) => ({
       action: row.action ?? "(sin acción)",
       severity: row.severity ?? "critical",
       performedBy: row.performedBy ?? "(desconocido)",
@@ -119,16 +157,36 @@ export const auditAlerts = onSchedule(
       at: row.timestamp?.toDate?.() ?? null,
     }));
 
+    const byAction = new Map<string, number>();
+    for (const row of warnings) {
+      const action = row.action ?? "(sin acción)";
+      byAction.set(action, (byAction.get(action) ?? 0) + 1);
+    }
+    const warningSummary = [...byAction.entries()]
+      .map(([action, count]) => ({ action, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, MAX_SUMMARY_ROWS);
+
     try {
       await sendAuditAlertEmail({
         to: ALERT_TO,
         since,
         events,
+        warningSummary,
+        warningTotal: warnings.length,
         total: fresh.length,
-        panelUrl: `${SITE_ORIGIN}/admin/audit?severity=critical`,
+        truncated,
+        // `notable` y no `critical`: el enlace tiene que enseñar lo mismo de lo
+        // que avisa el correo. Filtrando por crítico, quien siguiera el enlace
+        // tras un aviso de sondeo no encontraría ninguna de las filas que lo
+        // habían motivado.
+        panelUrl: `${SITE_ORIGIN}/admin/audit?severity=notable`,
       });
       logger.info("audit.alert.sent", {
         total: fresh.length,
+        criticals: criticals.length,
+        warnings: warnings.length,
+        truncated,
         since: since.toISOString(),
       });
     } catch (err) {

--- a/functions/src/utils/auditTypes.ts
+++ b/functions/src/utils/auditTypes.ts
@@ -25,6 +25,25 @@ export type AuditOutcome = "success" | "denied" | "failure";
 export type AuditSeverity = "info" | "notice" | "warning" | "critical";
 
 /**
+ * Lo que alguien querría revisar de una sentada: el filtro `notable` del visor
+ * y lo que dispara un aviso por correo.
+ *
+ * Vive aquí y no en `handlers/audit.ts` porque el visor y las alertas tienen
+ * que coincidir. Si el correo avisara de menos de lo que el panel resalta, el
+ * enlace del propio correo llevaría a una lista más larga que la que anuncia.
+ *
+ * Se resuelve con un `in` sobre el campo que ya tiene índice compuesto con
+ * `timestamp`. La alternativa —una desigualdad `severity >= "warning"`— no
+ * sirve: Firestore exige que el primer `orderBy` sea el campo de la
+ * desigualdad, y aquí el orden tiene que ser por `timestamp` o el registro
+ * deja de leerse como una cronología.
+ */
+export const NOTABLE_SEVERITIES: readonly AuditSeverity[] = [
+  "warning",
+  "critical",
+];
+
+/**
  * Agrupación de primer nivel. Existe porque Firestore no sabe filtrar por
  * prefijo de cadena: sin un campo propio, "enséñame solo lo de seguridad" no
  * se puede consultar, y el visor solo admite un filtro a la vez porque cada


### PR DESCRIPTION
## What changed

- `auditAlerts` now queries `severity in ["critical", "warning"]`. `NOTABLE_SEVERITIES` moves to `utils/auditTypes.ts` and is shared with the viewer, so the two cannot drift.
- Criticals are still detailed event by event; **warnings are aggregated by action** with a count.
- The email link points at `?severity=notable` instead of `?severity=critical`.
- When the query hits its 200-row ceiling the email says **"al menos N"** instead of presenting that number as the total.
- `docs/auditoria.md` updated.

## Why

Only two things ever reach `critical`: a suspended account still trying to operate, and the log throttling itself. What actually gives away someone probing what they can touch is `security.permission.denied`, which is `warning` — as are the `synthesized` rows that mean "code is mutating things without saying what". An entire afternoon of probing produced **no email at all**, with the whole instrumentation working and the panel highlighting it.

Widening it naively would have turned the alert into noise, so the two levels are treated differently. Triggering a `warning` is cheap — poke an endpoint — so detailing them one by one would let whoever is probing decide the length of the email.

The link changed for the same reason the query did: pointing at `critical`, anyone following it after a probing alert would find none of the rows that caused it. The viewer already reads `?severity=` from the query string and already has a **Notable** quick filter with exactly this value, so the link works end to end.

Separately, the email stopped lying during a burst. The query is capped at 200 rows and `total` came from there, despite the comment promising the real total is always stated. Since the watermark advances regardless, whatever fell outside is never alerted — worth making obvious.

No new index: the existing `severity` + `timestamp` composite already serves an `in` query.

## How to test

```bash
pnpm test:functions  # 709 (was 703)
```

New cases cover: a `warning` triggers an alert; warnings are grouped by action; criticals and warnings share one email; the truncated case reports a floor; and a window that fit entirely is *not* marked truncated.