### PR TITLE
feat(admin): make the volunteer role usable from the UI

### DIFF
--- a/src/components/react/admin/AdminApp.tsx
+++ b/src/components/react/admin/AdminApp.tsx
@@ -24,7 +24,11 @@ import { AuditLog } from "./audit/AuditLog";
 import { AccessReview } from "./access/AccessReview";
 import { EventStaffPanel } from "./event-staff/EventStaffPanel";
 import { ProposalsPanel } from "./proposals/ProposalsPanel";
-import { ROLE_BUNDLES, isRole, type Permission } from "@/lib/permissions";
+import {
+  canReachByAssignment,
+  type Permission,
+  type PermissionSubject,
+} from "@/lib/permissions";
 
 interface Props {
   page: string;
@@ -33,6 +37,7 @@ interface Props {
 
 interface Guards {
   can: (permission: Permission) => boolean;
+  profile: PermissionSubject | null;
   role: string | null;
   signOut: () => void;
 }
@@ -68,6 +73,13 @@ const PAGE_PERMISSIONS: Record<string, Permission> = {
   "event-staff": "roster:read",
   certificates: "certificates:send",
   checkin: "roster:read",
+  // Faltaba, y `renderPage` trata la ausencia como "sin requisito": cualquiera
+  // que entrase al panel podía abrir /admin/credentials y recibir la pantalla
+  // en vez del aviso de acceso restringido. No era una fuga —las reglas
+  // deniegan los datos— pero sí justo el agujero que el comentario de arriba
+  // dice que no existe. Mismo permiso que el check-in: una credencial son
+  // datos personales del asistente, y el panel enseña el DNI.
+  credentials: "roster:read",
 };
 
 function pageContent(page: string) {
@@ -128,31 +140,29 @@ function renderPage(page: string, guards: Guards | null) {
   if (!guards) return content;
 
   const required = PAGE_PERMISSIONS[page];
-  // Las páginas acotadas a un evento (check-in, minijuegos) las puede abrir
-  // quien tenga el permiso globalmente O quien pueda alcanzarlo estando
-  // asignado — de ahí que el voluntario pase esta puerta y sea el servidor
-  // quien decida sobre el evento concreto.
+  // Las páginas acotadas a un evento (check-in, credenciales, minijuegos) las
+  // puede abrir quien tenga el permiso globalmente O quien pueda alcanzarlo
+  // estando asignado — de ahí que el voluntario pase esta puerta y sea el
+  // servidor quien decida sobre el evento concreto.
+  //
+  // Ya no hace falta una lista de páginas acotadas: `canReachByAssignment`
+  // pregunta por el PERMISO, y un permiso que el rol no alcanza por asignación
+  // devuelve false igual. La lista era una segunda fuente de verdad que había
+  // que acordarse de ampliar al añadir una página — y a la que ya se le había
+  // olvidado `credentials`.
   if (
     required &&
     !guards.can(required) &&
-    !canReachByAssignment(page, guards)
+    !(guards.profile && canReachByAssignment(guards.profile, required))
   ) {
     return <AccessDenied role={guards.role} signOut={guards.signOut} />;
   }
   return content;
 }
 
-/** Páginas cuyo permiso un rol puede obtener por asignación a un evento. */
-const SCOPED_PAGES = new Set(["checkin", "event-minigames", "event-staff"]);
-
-function canReachByAssignment(page: string, guards: Guards): boolean {
-  if (!SCOPED_PAGES.has(page)) return false;
-  const bundle = ROLE_BUNDLES[isRole(guards.role) ? guards.role : "member"];
-  return bundle.perEvent.length > 0;
-}
-
 function AdminContent({ page, currentPath }: Props) {
-  const { user, role, loading, canAccessPanel, can, signOut } = useAuth();
+  const { user, role, profile, loading, canAccessPanel, can, signOut } =
+    useAuth();
 
   if (loading) {
     return (
@@ -209,7 +219,7 @@ function AdminContent({ page, currentPath }: Props) {
 
   return (
     <AdminShell currentPage={currentPath}>
-      {renderPage(page, { can, role, signOut })}
+      {renderPage(page, { can, profile, role, signOut })}
     </AdminShell>
   );
 }

--- a/src/components/react/admin/AdminShell.tsx
+++ b/src/components/react/admin/AdminShell.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useAuth } from "./AuthProvider";
-import type { Permission } from "@/lib/permissions";
+import { canReachByAssignment, type Permission } from "@/lib/permissions";
 
 /**
  * Cada entrada declara el permiso que la habilita, en vez de la antigua
@@ -119,7 +119,7 @@ interface Props {
 }
 
 export function AdminShell({ currentPage, children }: Props) {
-  const { user, role, signOut, can } = useAuth();
+  const { user, role, profile, signOut, can } = useAuth();
   const [dark, setDark] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -134,8 +134,17 @@ export function AdminShell({ currentPage, children }: Props) {
     localStorage.setItem("admin-theme", next ? "dark" : "light");
   }
 
+  // `can()` evalúa a alcance GLOBAL, y los permisos de un voluntario son todos
+  // `perEvent`: su conjunto global está vacío. Filtrando solo por `can()`, un
+  // voluntario entraba y veía únicamente el dashboard, sin un enlace al
+  // check-in que es su único trabajo — mientras el servidor sí le habría dejado
+  // operar su evento. La segunda condición abre esas entradas a quien pueda
+  // alcanzarlas estando asignado; el evento concreto lo decide el servidor.
   const visibleItems = NAV_ITEMS.filter(
-    (item) => !item.permission || can(item.permission)
+    (item) =>
+      !item.permission ||
+      can(item.permission) ||
+      (profile !== null && canReachByAssignment(profile, item.permission))
   );
 
   const sidebarContent = (

--- a/src/components/react/admin/checkin/CheckinPanel.tsx
+++ b/src/components/react/admin/checkin/CheckinPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { isDevPreview } from "@/lib/api";
 import { useAuth } from "../AuthProvider";
+import { EventPicker } from "../ui/EventPicker";
 import { Toast } from "../ui/Toast";
 import { AttendeeRow } from "./AttendeeRow";
 import { bevyCsvFilename, buildBevyCheckinCsv } from "./buildBevyCsv";
@@ -207,17 +208,7 @@ export function CheckinPanel({ initialSlug }: Props) {
   }
 
   if (!slug) {
-    return (
-      <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
-        <p className="font-medium">Falta indicar el evento.</p>
-        <p className="mt-1 text-sm">
-          Abre esta página como{" "}
-          <code className="rounded bg-amber-100 px-1 dark:bg-amber-900/40">
-            /admin/checkin?slug=devfest-ica-2026
-          </code>
-        </p>
-      </div>
-    );
+    return <EventPicker basePath="/admin/checkin" title="Check-in" />;
   }
 
   if (loading) {

--- a/src/components/react/admin/checkin/__tests__/CheckinPanel.test.tsx
+++ b/src/components/react/admin/checkin/__tests__/CheckinPanel.test.tsx
@@ -7,6 +7,8 @@ const mocks = vi.hoisted(() => ({
   useRoster: vi.fn(),
   setCheckedIn: vi.fn(),
   useAuth: vi.fn(),
+  listEvents: vi.fn(),
+  listMyEvents: vi.fn(),
   isDevPreview: { value: false },
 }));
 
@@ -23,7 +25,11 @@ vi.mock("@/lib/api", () => ({
   get isDevPreview() {
     return mocks.isDevPreview.value;
   },
-  api: { importCheckinRoster: vi.fn() },
+  api: {
+    importCheckinRoster: vi.fn(),
+    listEvents: mocks.listEvents,
+    listMyEvents: mocks.listMyEvents,
+  },
 }));
 
 import { CheckinPanel } from "../CheckinPanel";
@@ -86,7 +92,15 @@ beforeEach(() => {
   mocks.useRoster.mockReturnValue(rosterState());
   mocks.useAuth.mockReturnValue({
     user: { uid: "org-1", displayName: "Alvaro", email: "a@x.com" },
+    // El selector de evento pregunta por `events:read` para decidir si lista
+    // el catálogo entero o solo los eventos asignados a quien mira.
+    can: () => true,
   });
+  mocks.listEvents.mockResolvedValue({
+    success: true,
+    data: [{ id: "devfest-ica-2026", title: "DevFest Ica 2026" }],
+  });
+  mocks.listMyEvents.mockResolvedValue({ success: true, data: [] });
 });
 
 afterEach(() => cleanup());
@@ -100,9 +114,12 @@ describe("CheckinPanel — it renders at all", () => {
     expect(screen.getByText("Alex Alberto Quintanilla Garcia")).toBeVisible();
   });
 
-  it("explains itself when no event was given", () => {
+  // Sin slug ya no se pide escribir la URL a mano: se ofrece elegir el evento.
+  // Era la puerta cerrada para un voluntario, cuyo rol tampoco le da
+  // `events:read` para poder consultar los slugs por su cuenta.
+  it("ofrece elegir evento cuando no se dio ninguno", async () => {
     render(<CheckinPanel />);
-    expect(screen.getByText(/Falta indicar el evento/)).toBeVisible();
+    expect(await screen.findByText(/Elige el evento/)).toBeVisible();
   });
 
   it("does not hit live Firestore in dev preview", () => {

--- a/src/components/react/admin/credentials/CredentialsPanel.tsx
+++ b/src/components/react/admin/credentials/CredentialsPanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { isDevPreview } from "@/lib/api";
 import { useAuth } from "../AuthProvider";
+import { EventPicker } from "../ui/EventPicker";
 import { useCredentials } from "./useCredentials";
 import { BevyQueue } from "./BevyQueue";
 import { PhotoModerationQueue } from "./PhotoModerationQueue";
@@ -78,17 +79,7 @@ export function CredentialsPanel({ initialSlug }: { initialSlug?: string }) {
   };
 
   if (!slug) {
-    return (
-      <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-800">
-        <p className="font-medium">Falta indicar el evento.</p>
-        <p className="mt-1 text-sm">
-          Abre esta página como{" "}
-          <code className="rounded bg-amber-100 px-1">
-            /admin/credentials?slug=devfest-2026
-          </code>
-        </p>
-      </div>
-    );
+    return <EventPicker basePath="/admin/credentials" title="Credenciales" />;
   }
 
   if (loading) {

--- a/src/components/react/admin/event-minigames/EventMinigameManager.tsx
+++ b/src/components/react/admin/event-minigames/EventMinigameManager.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "@/lib/api";
+import { EventPicker } from "../ui/EventPicker";
 import { Toast } from "../ui/Toast";
 import { AttachTemplateModal } from "./AttachTemplateModal";
 import { BingoWinnersPanel } from "./BingoWinnersPanel";
@@ -160,9 +161,7 @@ export function EventMinigameManager({ initialSlug }: Props) {
 
   if (!slug) {
     return (
-      <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-4 text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-400">
-        Falta el parámetro <code>?slug=</code> en la URL.
-      </div>
+      <EventPicker basePath="/admin/events/minigames" title="Mini-juegos" />
     );
   }
 

--- a/src/components/react/admin/event-minigames/__tests__/EventMinigameManager.test.tsx
+++ b/src/components/react/admin/event-minigames/__tests__/EventMinigameManager.test.tsx
@@ -9,6 +9,9 @@ const mocks = vi.hoisted(() => ({
   advanceQuizQuestion: vi.fn(),
   removeMinigameFromEvent: vi.fn(),
   listMinigameTemplates: vi.fn(),
+  listEvents: vi.fn(),
+  listMyEvents: vi.fn(),
+  useAuth: vi.fn(),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -19,7 +22,14 @@ vi.mock("@/lib/api", () => ({
     advanceQuizQuestion: mocks.advanceQuizQuestion,
     removeMinigameFromEvent: mocks.removeMinigameFromEvent,
     listMinigameTemplates: mocks.listMinigameTemplates,
+    listEvents: mocks.listEvents,
+    listMyEvents: mocks.listMyEvents,
   },
+}));
+
+// Lo usa el selector de evento que se pinta cuando no hay slug.
+vi.mock("../../AuthProvider", () => ({
+  useAuth: mocks.useAuth,
 }));
 
 import { EventMinigameManager } from "../EventMinigameManager";
@@ -56,6 +66,12 @@ beforeEach(() => {
     data: SAMPLE_INSTANCES,
   });
   mocks.listMinigameTemplates.mockResolvedValue({ success: true, data: [] });
+  mocks.useAuth.mockReturnValue({ can: () => true });
+  mocks.listEvents.mockResolvedValue({
+    success: true,
+    data: [{ id: "devfest-2025", title: "DevFest 2025" }],
+  });
+  mocks.listMyEvents.mockResolvedValue({ success: true, data: [] });
   mocks.attachMinigameToEvent.mockResolvedValue({
     success: true,
     data: { id: "new", type: "poll" },
@@ -70,9 +86,9 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("EventMinigameManager", () => {
-  it("renders an error if no slug is provided", () => {
+  it("ofrece elegir evento si no se dio slug", async () => {
     render(<EventMinigameManager />);
-    expect(screen.getByText(/Falta el parámetro/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Elige el evento/)).toBeInTheDocument();
     expect(mocks.listEventMinigames).not.toHaveBeenCalled();
   });
 

--- a/src/components/react/admin/ui/EventPicker.tsx
+++ b/src/components/react/admin/ui/EventPicker.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { useAuth } from "../AuthProvider";
+
+/**
+ * Elige el evento cuando la URL no lo trae.
+ *
+ * Las tres pantallas acotadas a un evento —check-in, credenciales y
+ * minijuegos— sacaban el slug exclusivamente de `?slug=` y, si faltaba,
+ * enseñaban un mensaje pidiendo que lo escribieras a mano. Servía a medias para
+ * un organizador, que se sabe los slugs; para un voluntario era una puerta
+ * cerrada, porque su rol tampoco le da `events:read` para consultarlos.
+ *
+ * De ahí las dos fuentes: quien pueda listar eventos los lista, y quien no,
+ * recibe los suyos de `GET /api/me/events` — que devuelve solo las asignaciones
+ * vigentes de quien llama. Ese endpoint existía desde que hay staff por evento
+ * y no lo llamaba ningún componente; es exactamente el hueco que faltaba.
+ */
+
+interface EventOption {
+  slug: string;
+  title: string;
+  /** Solo en los asignados: hasta cuándo dura la asignación. */
+  expiresAt?: string | null;
+}
+
+interface Props {
+  /** Ruta a la que volver con el slug puesto, p. ej. `/admin/checkin`. */
+  basePath: string;
+  /** Qué se va a hacer con el evento, para el encabezado. */
+  title: string;
+}
+
+/** Normaliza la fecha que llega de Firestore por JSON. */
+function toDateLabel(value: unknown): string | null {
+  if (!value) return null;
+  const raw =
+    typeof value === "object" && value !== null && "_seconds" in value
+      ? new Date((value as { _seconds: number })._seconds * 1000)
+      : new Date(value as string);
+  return Number.isNaN(raw.getTime()) ? null : raw.toLocaleDateString("es-PE");
+}
+
+export function EventPicker({ basePath, title }: Props) {
+  const { can } = useAuth();
+  const [options, setOptions] = useState<EventOption[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Quien tiene `events:read` ve el catálogo entero; quien no, solo lo suyo.
+  // No es una optimización: para un voluntario `/api/events` responde 403, así
+  // que pedirlo primero y caer al otro sería un 403 garantizado en cada carga
+  // — y cada 403 escribe un evento de seguridad en el registro.
+  const canListAll = can("events:read");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        if (canListAll) {
+          const res = await api.listEvents();
+          if (cancelled) return;
+          if (!res.success) {
+            setError(res.error || "No se pudieron cargar los eventos");
+            return;
+          }
+          const events = (res.data ?? []) as { id: string; title?: string }[];
+          setOptions(
+            events.map((e) => ({ slug: e.id, title: e.title || e.id }))
+          );
+          return;
+        }
+
+        const res = await api.listMyEvents();
+        if (cancelled) return;
+        if (!res.success) {
+          setError(res.error || "No se pudieron cargar tus eventos");
+          return;
+        }
+        const assignments = (res.data ?? []) as {
+          eventSlug: string;
+          expiresAt?: unknown;
+        }[];
+        setOptions(
+          assignments.map((a) => ({
+            slug: a.eventSlug,
+            // El endpoint devuelve la asignación, no el evento, así que no hay
+            // título que enseñar. El slug es legible y es lo que la persona ve
+            // en la URL de todos modos.
+            title: a.eventSlug,
+            expiresAt: toDateLabel(a.expiresAt),
+          }))
+        );
+      } catch {
+        if (!cancelled) setError("No se pudieron cargar los eventos");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [canListAll]);
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 p-6 text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+        {error}
+      </div>
+    );
+  }
+
+  if (options === null) {
+    return (
+      <p className="py-12 text-center text-sm text-gray-500 dark:text-gray-400">
+        Cargando eventos…
+      </p>
+    );
+  }
+
+  if (options.length === 0) {
+    return (
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+        <p className="font-medium">No tienes eventos asignados.</p>
+        <p className="mt-1 text-sm">
+          {canListAll
+            ? "Todavía no hay eventos creados."
+            : "Pide a un organizador que te asigne al evento que vas a trabajar."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+      <h2 className="font-medium text-gray-900 dark:text-white">{title}</h2>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        Elige el evento.
+      </p>
+      <ul className="mt-4 space-y-2">
+        {options.map((option) => (
+          <li key={option.slug}>
+            <a
+              href={`${basePath}?slug=${encodeURIComponent(option.slug)}`}
+              className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3 text-sm transition-colors hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700"
+            >
+              <span className="font-medium text-gray-900 dark:text-white">
+                {option.title}
+              </span>
+              {option.expiresAt && (
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  hasta el {option.expiresAt}
+                </span>
+              )}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/react/admin/ui/__tests__/EventPicker.test.tsx
+++ b/src/components/react/admin/ui/__tests__/EventPicker.test.tsx
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  listEvents: vi.fn(),
+  listMyEvents: vi.fn(),
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: { listEvents: mocks.listEvents, listMyEvents: mocks.listMyEvents },
+}));
+
+vi.mock("../../AuthProvider", () => ({ useAuth: mocks.useAuth }));
+
+import { EventPicker } from "../EventPicker";
+
+/** Quien tiene o no `events:read`, que es lo que decide la fuente. */
+function signedInWith(permissions: string[]) {
+  mocks.useAuth.mockReturnValue({
+    can: (p: string) => permissions.includes(p),
+  });
+}
+
+beforeEach(() => {
+  mocks.listEvents.mockReset();
+  mocks.listMyEvents.mockReset();
+  mocks.useAuth.mockReset();
+  mocks.listEvents.mockResolvedValue({
+    success: true,
+    data: [{ id: "devfest-2026", title: "DevFest Ica 2026" }],
+  });
+  mocks.listMyEvents.mockResolvedValue({
+    success: true,
+    data: [{ eventSlug: "devfest-2026", role: "volunteer", expiresAt: null }],
+  });
+});
+
+afterEach(() => cleanup());
+
+describe("EventPicker", () => {
+  it("lista el catálogo cuando se puede leer eventos", async () => {
+    signedInWith(["events:read", "roster:read"]);
+    render(<EventPicker basePath="/admin/checkin" title="Check-in" />);
+
+    expect(await screen.findByText("DevFest Ica 2026")).toBeVisible();
+    expect(mocks.listEvents).toHaveBeenCalled();
+    expect(mocks.listMyEvents).not.toHaveBeenCalled();
+  });
+
+  // El caso que hace usable el rol de voluntario. `/api/events` le responde
+  // 403, así que la fuente tiene que ser la otra — y elegirla por adelantado,
+  // no tras fallar: cada 403 escribe un evento de seguridad en el registro.
+  it("cae a los eventos asignados cuando no se pueden leer todos", async () => {
+    signedInWith([]);
+    render(<EventPicker basePath="/admin/checkin" title="Check-in" />);
+
+    expect(await screen.findByText("devfest-2026")).toBeVisible();
+    expect(mocks.listMyEvents).toHaveBeenCalled();
+    expect(mocks.listEvents).not.toHaveBeenCalled();
+  });
+
+  it("enlaza al panel con el slug puesto", async () => {
+    signedInWith([]);
+    render(<EventPicker basePath="/admin/checkin" title="Check-in" />);
+
+    const link = await screen.findByRole("link", { name: /devfest-2026/ });
+    expect(link).toHaveAttribute("href", "/admin/checkin?slug=devfest-2026");
+  });
+
+  it("escapa el slug en el enlace", async () => {
+    signedInWith([]);
+    mocks.listMyEvents.mockResolvedValue({
+      success: true,
+      data: [{ eventSlug: "a b&c", expiresAt: null }],
+    });
+    render(<EventPicker basePath="/admin/checkin" title="Check-in" />);
+
+    const link = await screen.findByRole("link");
+    expect(link).toHaveAttribute("href", "/admin/checkin?slug=a%20b%26c");
+  });
+
+  it("enseña hasta cuándo dura una asignación con caducidad", async () => {
+    signedInWith([]);
+    mocks.listMyEvents.mockResolvedValue({
+      success: true,
+      data: [{ eventSlug: "devfest-2026", expiresAt: "2026-08-15T00:00:00Z" }],
+    });
+    render(<EventPicker basePath="/admin/checkin" title="Check-in" />);
+
+    expect(await screen.findByText(/hasta el/)).toBeVisible();
+  });
+
+  // Sin asignaciones el mensaje tiene que decir qué hacer, no solo que no hay
+  // nada: quien llega aquí es alguien a quien acaban de dar un rol y no sabe
+  // por qué su panel está vacío.
+  it("dice qué hacer cuando no hay eventos asignados", async () => {
+    signedInWith([]);
+    mocks.listMyEvents.mockResolvedValue({ success: true, data: [] });
+    render(<EventPicker basePath="/admin/checkin" title="Check-in" />);
+
+    expect(await screen.findByText(/te asigne al evento/)).toBeVisible();
+  });
+
+  it("dice otra cosa a quien sí puede ver todos los eventos", async () => {
+    signedInWith(["events:read"]);
+    mocks.listEvents.mockResolvedValue({ success: true, data: [] });
+    render(<EventPicker basePath="/admin/checkin" title="Check-in" />);
+
+    expect(await screen.findByText(/no hay eventos creados/)).toBeVisible();
+  });
+
+  it("enseña el error si la carga falla", async () => {
+    signedInWith(["events:read"]);
+    mocks.listEvents.mockResolvedValue({ success: false, error: "explotó" });
+    render(<EventPicker basePath="/admin/checkin" title="Check-in" />);
+
+    expect(await screen.findByText("explotó")).toBeVisible();
+  });
+
+  it("no revienta si la petición lanza", async () => {
+    signedInWith(["events:read"]);
+    mocks.listEvents.mockRejectedValue(new Error("red caída"));
+    render(<EventPicker basePath="/admin/checkin" title="Check-in" />);
+
+    expect(
+      await screen.findByText(/No se pudieron cargar los eventos/)
+    ).toBeVisible();
+  });
+});

--- a/src/lib/__tests__/permissions.test.ts
+++ b/src/lib/__tests__/permissions.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { canAccessPanel, canReachByAssignment } from "../permissions";
+
+/**
+ * `canReachByAssignment` no tiene equivalente en el servidor —allí el alcance
+ * llega en la petición— así que el test de deriva de
+ * `functions/src/auth/permissions.test.ts` no la cubre. Se prueba aquí.
+ *
+ * Lo que decide: si el menú y el guard de página dejan pasar a alguien cuyos
+ * permisos son todos `perEvent`. `can()` evalúa a alcance GLOBAL, donde un
+ * voluntario no tiene ninguno, así que sin esto veía solo el dashboard.
+ */
+describe("canReachByAssignment", () => {
+  it("deja al voluntario alcanzar lo que su rol da por evento", () => {
+    const volunteer = { role: "volunteer" };
+    expect(canReachByAssignment(volunteer, "roster:read")).toBe(true);
+    expect(canReachByAssignment(volunteer, "checkin:operate")).toBe(true);
+    expect(canReachByAssignment(volunteer, "minigames:operate")).toBe(true);
+    expect(canReachByAssignment(volunteer, "credentials:operate")).toBe(true);
+  });
+
+  // La puerta es por PERMISO, no por página: un permiso que el rol no tiene ni
+  // por asignación no se alcanza por estar asignado a un evento.
+  it("no le deja alcanzar lo que su rol no da", () => {
+    const volunteer = { role: "volunteer" };
+    expect(canReachByAssignment(volunteer, "events:read")).toBe(false);
+    expect(canReachByAssignment(volunteer, "users:read")).toBe(false);
+    expect(canReachByAssignment(volunteer, "credentials:moderate")).toBe(false);
+  });
+
+  // Un organizador ya los tiene a alcance global, así que `can()` responde por
+  // él y esta vía no le añade nada.
+  it("es falsa para roles sin permisos por evento", () => {
+    expect(canReachByAssignment({ role: "organizer" }, "roster:read")).toBe(
+      false
+    );
+    expect(canReachByAssignment({ role: "member" }, "roster:read")).toBe(false);
+    expect(canReachByAssignment({ role: "contributor" }, "roster:read")).toBe(
+      false
+    );
+  });
+
+  // La suspensión es la palanca de emergencia: corta todo, también esta vía.
+  it("no deja pasar a una cuenta suspendida", () => {
+    expect(
+      canReachByAssignment(
+        { role: "volunteer", status: "suspended" },
+        "roster:read"
+      )
+    ).toBe(false);
+  });
+
+  it("trata un rol corrupto como member", () => {
+    expect(canReachByAssignment({ role: "superadmin" }, "roster:read")).toBe(
+      false
+    );
+    expect(canReachByAssignment({}, "roster:read")).toBe(false);
+  });
+});
+
+describe("canAccessPanel", () => {
+  // Un voluntario entra al panel para llegar a los eventos que tiene
+  // asignados, aunque a alcance global no tenga ni un permiso.
+  it("deja entrar al voluntario", () => {
+    expect(canAccessPanel({ role: "volunteer" })).toBe(true);
+  });
+
+  it("no deja entrar a un miembro", () => {
+    expect(canAccessPanel({ role: "member" })).toBe(false);
+  });
+
+  it("no deja entrar a un voluntario suspendido", () => {
+    expect(canAccessPanel({ role: "volunteer", status: "suspended" })).toBe(
+      false
+    );
+  });
+});

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -261,6 +261,28 @@ export function hasPermission(
  * llegar a los eventos que tiene asignados. Es solo la puerta de la UI — cada
  * sección y cada endpoint vuelven a comprobar el permiso con su alcance real.
  */
+/**
+ * `true` si el rol puede llegar a este permiso estando asignado a un evento,
+ * aunque a alcance global no lo tenga.
+ *
+ * Existe porque `can()` evalúa a alcance GLOBAL, y los permisos de un
+ * voluntario son todos `perEvent`: su conjunto global está vacío. Filtrando el
+ * menú solo por `can()`, un voluntario iniciaba sesión y veía únicamente el
+ * dashboard — sin un enlace al check-in que es su único trabajo.
+ *
+ * Es cosmético, como todo lo de este archivo: abre la puerta de la UI para que
+ * la persona llegue al selector de evento, y es el servidor quien decide sobre
+ * el evento concreto comprobando la asignación de staff.
+ */
+export function canReachByAssignment(
+  subject: PermissionSubject,
+  permission: Permission
+): boolean {
+  if (subject.status === "suspended") return false;
+  const role = isRole(subject.role) ? subject.role : "member";
+  return ROLE_BUNDLES[role].perEvent.includes(permission);
+}
+
 export function canAccessPanel(subject: PermissionSubject): boolean {
   if (subject.status === "suspended") return false;
   if (effectivePermissions(subject).size > 0) return true;


### PR DESCRIPTION
## What changed

- **`canReachByAssignment`** in `src/lib/permissions.ts`, shared by the nav and the page guard: `true` when the role can reach a permission by being assigned to an event.
- **New `EventPicker`** replaces the "type the URL yourself" message in check-in, credentials and mini-games. Callers with `events:read` get the catalogue; everyone else gets their own events from `GET /api/me/events`.
- **`PAGE_PERMISSIONS`** gains the missing `credentials` entry.
- **`SCOPED_PAGES` removed** — see below.

## Why

The `volunteer` role was well built in the backend and unreachable from the panel. Signing in left you with "Dashboard" and nothing else, whose two links are "Crear evento" and "Ver sitio" — neither of them yours.

Two causes, chained.

The nav filters with `can()`, which evaluates at **global** scope, and a volunteer's permissions are all `perEvent`: their global set is empty, so check-in, credentials and mini-games never appeared. This is cosmetic, like the whole client mirror — the server still decides on the specific event by checking the staff assignment.

And even on arrival, the three scoped screens read the slug **only** from `?slug=` and asked you to type it by hand if it was missing. Awkward for an organizer; a closed door for a volunteer, whose role does not grant `events:read` to look the slugs up either. `GET /api/me/events` has existed since per-event staff landed and **no component called it** — it is exactly the missing piece. The source is chosen up front rather than after a failure, because every 403 writes a security event to the log.

Separately, `PAGE_PERMISSIONS` had no `credentials` entry, and `renderPage` treats a missing entry as "no requirement": anyone who could enter the panel could open `/admin/credentials` and get the screen instead of the access-denied notice. Not a leak — the rules deny the data — but exactly the hole that constant's comment claims does not exist.

With the check keyed on the **permission** rather than the page, `SCOPED_PAGES` became redundant and is gone. It was a second source of truth you had to remember to extend when adding a page, and it had already forgotten `credentials`.

## How to test

```bash
pnpm test   # 398 (was 381)
```

New coverage: `canReachByAssignment` across every role plus the suspended case, and `EventPicker` — catalogue vs. assigned-only source, slug escaping in the link, the two distinct empty states, and both failure paths.

Worth seeing rather than reading: `pnpm dev`, sign in as a `volunteer` with a live assignment, and confirm they reach their event's check-in without typing a URL — and see nothing from any other event.