### PR TITLE
fix(api): validate the /api/stats body and guard the last admin in grants

### DIFF
--- a/functions/src/handlers/stats.ts
+++ b/functions/src/handlers/stats.ts
@@ -45,7 +45,12 @@ export async function updateStats(req: Request, res: Response) {
         performedBy: user.uid,
         targetId: "stats",
         targetType: "stats",
-        details: stats,
+        // Un resumen, no el cuerpo entero. El esquema ya acota lo que puede
+        // llegar, pero volcar el objeto completo en cada fila hace crecer el
+        // registro sin decir nada que el propio `about/stats.json` no diga ya
+        // — y el registro se paga por documento y se lee entero en el panel.
+        // Lo que hace falta saber al revisarlo es qué se tocó y cuándo.
+        details: { fields: Object.keys(stats).sort() },
       },
       req
     );

--- a/functions/src/handlers/users.test.ts
+++ b/functions/src/handlers/users.test.ts
@@ -550,3 +550,91 @@ describe("updateGrants", () => {
     expect(res.__status).toBe(400);
   });
 });
+
+// Degradar o suspender al último admin ya estaba cubierto; vaciarlo por
+// revocaciones lo dejaba igual de inútil y no lo impedía nada. Y como
+// `countActiveAdmins()` cuenta por rol y estado, seguía contando como admin
+// activo mientras no podía hacer nada.
+describe("updateGrants — último admin", () => {
+  it("no deja revocar la administración de usuarios al único admin", async () => {
+    docs.clear();
+    seed("solo-admin", { role: "admin" });
+    const res = buildRes();
+    await handler.updateGrants(
+      buildReq("admin", "solo-admin", {
+        grants: [],
+        revocations: ["users:role:write"],
+        reason: "x",
+      }),
+      res
+    );
+    expect(res.__status).toBe(400);
+    expect(res.__body?.error).toMatch(/last active admin/i);
+    expect(updates).toHaveLength(0);
+  });
+
+  it("sí deja hacerlo cuando queda otro admin activo", async () => {
+    seed("admin-a", { role: "admin" });
+    seed("admin-b", { role: "admin" });
+    const res = buildRes();
+    await handler.updateGrants(
+      buildReq("admin", "admin-a", {
+        grants: [],
+        revocations: ["users:role:write"],
+        reason: "Se queda solo con lectura",
+      }),
+      res
+    );
+    expect(res.__body?.success).toBe(true);
+  });
+
+  it("un admin suspendido no cuenta para el mínimo", async () => {
+    seed("admin-a", { role: "admin" });
+    seed("admin-b", { role: "admin", status: "suspended" });
+    const res = buildRes();
+    await handler.updateGrants(
+      buildReq("admin", "admin-a", {
+        grants: [],
+        revocations: ["users:role:write"],
+        reason: "x",
+      }),
+      res
+    );
+    expect(res.__status).toBe(400);
+  });
+
+  // La guarda es específica: retirarle otra cosa al último admin no lo deja
+  // sin gobierno, así que no hay motivo para impedirlo.
+  it("deja revocar un permiso que no sea el de administrar usuarios", async () => {
+    docs.clear();
+    seed("solo-admin", { role: "admin" });
+    const res = buildRes();
+    await handler.updateGrants(
+      buildReq("admin", "solo-admin", {
+        grants: [],
+        revocations: ["events:delete"],
+        reason: "Ya no borra eventos",
+      }),
+      res
+    );
+    expect(res.__body?.success).toBe(true);
+  });
+
+  // Sobre un no-admin la guarda no aplica: el rol no otorga ese permiso, así
+  // que revocarlo no quita nada que nadie más pueda cubrir.
+  it("no estorba al tocar los permisos de alguien que no es admin", async () => {
+    docs.clear();
+    seed("solo-admin", { role: "admin" });
+    seed("t1", { role: "organizer" });
+    const res = buildRes();
+    await handler.updateGrants(
+      buildReq("admin", "t1", {
+        grants: [],
+        revocations: ["users:role:write"],
+        reason: "x",
+      }),
+      res
+    );
+    expect(res.__body?.success).toBe(true);
+  });
+});

--- a/functions/src/handlers/users.ts
+++ b/functions/src/handlers/users.ts
@@ -7,6 +7,7 @@ import {
   GLOBAL_SCOPE,
   ROLES,
   canGrant,
+  effectivePermissions,
   isPermission,
   isRole,
   type Permission,
@@ -345,12 +346,43 @@ export async function updateGrants(req: Request, res: Response) {
       return;
     }
 
-    if (!actorDominates(performer.permissions, userDoc.data()?.role)) {
+    const targetRole = userDoc.data()?.role;
+    const targetStatus = userDoc.data()?.status;
+
+    if (!actorDominates(performer.permissions, targetRole)) {
       res.status(403).json({
         success: false,
         error: "Cannot manage a user whose role exceeds your own permissions",
       });
       return;
+    }
+
+    // Guarda de último admin, que este camino no tenía.
+    //
+    // `countActiveAdmins()` cuenta por rol y estado, así que un admin al que se
+    // le hayan revocado los permisos sigue contando como admin activo mientras
+    // no puede hacer nada. Degradar o suspender al último ya estaba cubierto;
+    // vaciarlo por revocaciones lo dejaba igual de inútil y sin que nada lo
+    // impidiera, y la plataforma se quedaba sin nadie capaz de repartir roles
+    // salvo entrando a mano por la consola de Firebase.
+    //
+    // Se mira el estado RESULTANTE y no la lista de revocaciones: es la misma
+    // función que decide los permisos en cada petición, así que no puede
+    // discrepar de ella.
+    if (targetRole === "admin" && targetStatus !== "suspended") {
+      const after = effectivePermissions({
+        role: targetRole,
+        status: targetStatus,
+        grants,
+        revocations,
+      });
+      if (!after.has("users:role:write") && (await countActiveAdmins()) <= 1) {
+        res.status(400).json({
+          success: false,
+          error: "Cannot revoke user administration from the last active admin",
+        });
+        return;
+      }
     }
 
     const batch = admin.firestore().batch();

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -31,6 +31,7 @@ import {
   credentialPhotoModerationSchema,
   credentialReminderSchema,
   emailTransportSchema,
+  statsSchema,
 } from "./schemas";
 import { register } from "./handlers/auth";
 import * as events from "./handlers/events";
@@ -389,6 +390,7 @@ app.put(
   "/api/stats",
   requirePermission("stats:write"),
   writeLimiter,
+  validateBody(statsSchema),
   stats.updateStats
 );
 

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -183,6 +183,47 @@ export const locationSchema = z
   })
   .strict();
 
+/**
+ * Cifras de la comunidad que se pintan en la portada.
+ *
+ * Era la ÚNICA escritura de la API sin esquema: el handler cogía `req.body`
+ * entero, lo esparcía en `about/stats.json` del repo de datos y lo metía tal
+ * cual en los detalles del registro. Dos consecuencias, las dos silenciosas.
+ * Un cuerpo con la forma equivocada llegaba al repo público y solo reventaba
+ * después, en el build del sitio. Y un cuerpo grande —hasta 1 MB deja pasar
+ * `express.json`— podía superar el límite por documento de Firestore al
+ * escribir la fila de auditoría; como `writeAuditLog` se traga sus errores,
+ * el cambio quedaba hecho y sin registrar.
+ *
+ * `.strict()` cierra la puerta a campos inventados: lo que llegue aquí acaba
+ * publicado, así que la lista de claves es la que es.
+ */
+const counter = z.number().int().min(0).max(10_000_000);
+
+export const statsSchema = z
+  .object({
+    total_members: counter,
+    total_events: counter,
+    total_talks: counter,
+    total_speakers: counter,
+    years_active: counter,
+    total_organizers: counter,
+    developers_mentored: counter,
+    total_sponsors: counter,
+    annual_support: shortText(100),
+    sponsored_events: counter,
+    developers_reached: counter,
+    active_volunteers: counter,
+    volunteer_hours: counter,
+    events_supported: counter,
+    volunteer_areas: counter,
+    // El panel reenvía el documento que leyó, así que llega — pero el handler
+    // lo sobrescribe con la hora del servidor. Se acepta para no obligar al
+    // cliente a recortar el objeto, no porque su valor cuente.
+    updated_at: shortText(100).optional(),
+  })
+  .strict();
+
 // Mini-game templates ------------------------------------------------------
 //
 // Each template is one of four discriminated types. The schema is the

--- a/functions/src/schemas/stats.test.ts
+++ b/functions/src/schemas/stats.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { statsSchema } from "./index";
+
+/**
+ * `PUT /api/stats` era la única escritura de la API sin esquema. El handler
+ * cogía `req.body` entero, lo esparcía en `about/stats.json` del repo de datos
+ * y lo metía tal cual en los detalles de auditoría.
+ */
+
+/** Cuerpo válido: lo que manda el panel. */
+function validStats(over: Record<string, unknown> = {}) {
+  return {
+    total_members: 1200,
+    total_events: 48,
+    total_talks: 96,
+    total_speakers: 60,
+    years_active: 7,
+    total_organizers: 12,
+    developers_mentored: 300,
+    total_sponsors: 15,
+    annual_support: "S/ 20 000",
+    sponsored_events: 9,
+    developers_reached: 5000,
+    active_volunteers: 25,
+    volunteer_hours: 1800,
+    events_supported: 30,
+    volunteer_areas: 6,
+    ...over,
+  };
+}
+
+describe("statsSchema", () => {
+  it("acepta el cuerpo que manda el panel", () => {
+    expect(statsSchema.safeParse(validStats()).success).toBe(true);
+  });
+
+  // El panel reenvía el documento que leyó, `updated_at` incluido. El handler
+  // lo sobrescribe, pero rechazarlo rompería el único cliente que existe.
+  it("tolera el updated_at que reenvía el panel", () => {
+    const parsed = statsSchema.safeParse(
+      validStats({ updated_at: "2026-07-30T12:00:00.000Z" })
+    );
+    expect(parsed.success).toBe(true);
+  });
+
+  // Lo que llega aquí acaba publicado en el repo de datos, y el sitio lo valida
+  // después, en el build. Una clave inventada tenía que reventar aquí y no en
+  // un despliegue.
+  it("rechaza campos que no están en la lista", () => {
+    const parsed = statsSchema.safeParse(
+      validStats({ total_miembros_typo: 5 })
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rechaza que falte un campo", () => {
+    const incompleto = validStats();
+    delete (incompleto as Record<string, unknown>).total_members;
+    expect(statsSchema.safeParse(incompleto).success).toBe(false);
+  });
+
+  it("rechaza un contador que no es número", () => {
+    expect(
+      statsSchema.safeParse(validStats({ total_events: "48" })).success
+    ).toBe(false);
+  });
+
+  it("rechaza un contador negativo", () => {
+    expect(statsSchema.safeParse(validStats({ total_talks: -1 })).success).toBe(
+      false
+    );
+  });
+
+  it("rechaza un contador con decimales", () => {
+    expect(
+      statsSchema.safeParse(validStats({ years_active: 7.5 })).success
+    ).toBe(false);
+  });
+
+  // El motivo del tope. `express.json` deja pasar hasta 1 MB, y un cuerpo así
+  // podía superar el límite por documento de Firestore al escribir la fila de
+  // auditoría. Como `writeAuditLog` se traga sus errores, el cambio quedaba
+  // hecho y sin registrar.
+  it("acota el texto libre", () => {
+    expect(
+      statsSchema.safeParse(validStats({ annual_support: "x".repeat(101) }))
+        .success
+    ).toBe(false);
+  });
+
+  it("acota los contadores por arriba", () => {
+    expect(
+      statsSchema.safeParse(validStats({ developers_reached: 10_000_001 }))
+        .success
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

- **`statsSchema`** in `functions/src/schemas/index.ts` (`.strict()`), wired into the route with `validateBody`. Audit details now record which fields were touched instead of the whole body.
- **Last-admin guard in `updateGrants`**, keyed on `users:role:write`.

## Why

**`PUT /api/stats` was the only API write without `validateBody`.** The handler took `req.body` whole, spread it into `about/stats.json` in the data repo, and put it verbatim into the audit details. Two silent failure modes: a malformed body reached the public repo and only blew up later, during the site build; and a large one — `express.json` allows up to 1 MB — could exceed Firestore's per-document limit when writing the audit row, and since `writeAuditLog` swallows its errors, the change would land **unrecorded**.

The schema accepts `updated_at` even though the handler overwrites it: the panel echoes back the document it loaded, and rejecting it would break the only client there is.

**`updateGrants` did not apply the last-admin guard** that every other access path has. Because `countActiveAdmins()` counts by role and status, an admin emptied out by revocations still counted as active while being unable to do anything — leaving the platform with nobody able to hand out roles short of going into the Firebase console by hand. The guard inspects the **resulting** state via `effectivePermissions` — the same function that decides permissions on every request, so it cannot disagree with it — and is specific to `users:role:write`: revoking anything else from the last admin does not leave the platform ungoverned, so there is no reason to block it.

## How to test

```bash
pnpm test:functions  # 717 (was 703)
```

New coverage: the schema (unknown keys, missing fields, non-numeric / negative / fractional counters, and both ceilings), plus the guard — refused for the sole admin, allowed when another active admin remains, a suspended admin not counting toward the minimum, an unrelated permission still revocable, and non-admins unaffected.

Against the emulator: `curl` an invalid body and an oversized one at `/api/stats` — 400 on both, and `about/stats.json` untouched.