### PR TITLE
ci(deploy): serialise deploys so they cannot race each other

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

A `concurrency` block on the deploy workflow, so only one deploy runs at a time.

```yaml
concurrency:
  group: deploy-production
  cancel-in-progress: false
```

## Why

Merging #324–#327 within a couple of minutes launched four `firebase deploy` runs at once against the same project. The first was creating a new function; the other three found it half-created and failed with:

```
[onRosterCheckinWritten] Changing from an HTTPS function to a background
triggered function is not allowed. Please delete your function and create
a new one instead.
```

The message misleads — that function was never HTTPS, it simply had not finished being created. The timeline shows it plainly: creation started at 17:36:34, the three failures land between 17:37:12 and 17:37:34, and creation completed successfully at 17:38:23.

The failure itself was harmless. **Its consequence was not:** the tests passed, the PRs merged, and the code sat in `main` without reaching production. Nothing surfaces that except opening the Actions tab. Three of the five changes were live in `main` and absent from the deployed site.

`cancel-in-progress: false` is deliberate and is **not** the usual choice. Cancelling a deploy midway is precisely what leaves a function in the intermediate state that caused this. What we want is for deploys to queue. The cost is that a batch of merges takes the sum of its deploys; that is cheap next to a `main` that believes it is deployed and is not.

## How to test

Validated locally that the workflow still parses and that both jobs survive the edit:

```bash
python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/deploy.yml')); print(d['concurrency'], list(d['jobs']))"
# {'group': 'deploy-production', 'cancel-in-progress': False} ['test', 'build-and-deploy']
```

Real verification is the next time two PRs merge close together: the second run should show "waiting for the deploy-production group" instead of deploying in parallel.

## Note

This does not fix the runs that already failed — those needed a re-run once nothing was competing, which has been done separately.