### PR TITLE
fix(api): validate the /api/forms request body with a Zod schema

### DIFF
--- a/functions/src/handlers/forms.ts
+++ b/functions/src/handlers/forms.ts
@@ -1,9 +1,11 @@
 import { Request, Response } from "express";
+import { z } from "zod";
 import { writeAuditLog } from "../utils/audit";
 import { AuthenticatedRequest } from "../middleware/auth";
 import { GitHubService } from "../services/github";
 import { readSheet } from "../services/sheets";
 import { safeError } from "../middleware/validate";
+import { formSchema, formUpdateSchema } from "../schemas";
 import { GITHUB_TOKEN } from "../config";
 
 interface FormEntry {
@@ -14,6 +16,10 @@ interface FormEntry {
   is_public: boolean;
   created_at: string;
 }
+
+// Lo que el middleware deja en `req.body`: validado, con defaults aplicados.
+type FormBody = z.infer<typeof formSchema>;
+type FormUpdateBody = z.infer<typeof formUpdateSchema>;
 
 export async function listForms(req: Request, res: Response) {
   try {
@@ -36,14 +42,10 @@ export async function listForms(req: Request, res: Response) {
 
 export async function addForm(req: Request, res: Response) {
   try {
-    const form = req.body as FormEntry;
-    if (!form.id || !form.name || !form.spreadsheet_id) {
-      res.status(400).json({
-        success: false,
-        error: "Missing required fields: id, name, spreadsheet_id",
-      });
-      return;
-    }
+    // `validateBody(formSchema)` ya rechazó lo que falte o sobre y aplicó los
+    // valores por defecto de `sheet_name` e `is_public`, así que aquí no queda
+    // nada que comprobar a mano.
+    const form = req.body as FormBody;
 
     const github = new GitHubService(GITHUB_TOKEN.value());
     const user = (req as AuthenticatedRequest).user;
@@ -52,8 +54,9 @@ export async function addForm(req: Request, res: Response) {
       id: form.id,
       name: form.name,
       spreadsheet_id: form.spreadsheet_id,
-      sheet_name: form.sheet_name || "Form Responses 1",
-      is_public: form.is_public ?? true,
+      sheet_name: form.sheet_name,
+      is_public: form.is_public,
+      // El panel envía `created_at: ""`; la hora la pone el servidor.
       created_at: new Date().toISOString(),
     };
 
@@ -88,7 +91,7 @@ export async function addForm(req: Request, res: Response) {
 export async function updateForm(req: Request, res: Response) {
   try {
     const formId = req.params.id as string;
-    const updates = req.body as Partial<FormEntry>;
+    const updates = req.body as FormUpdateBody;
     const github = new GitHubService(GITHUB_TOKEN.value());
     const user = (req as AuthenticatedRequest).user;
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -18,6 +18,8 @@ import {
   sponsorSchema,
   teamMemberSchema,
   locationSchema,
+  formSchema,
+  formUpdateSchema,
   minigameTemplateSchema,
   minigameInstanceCreateSchema,
   minigameStateSchema,
@@ -579,6 +581,7 @@ app.post(
   "/api/forms",
   requirePermission("forms:write"),
   writeLimiter,
+  validateBody(formSchema),
   forms.addForm
 );
 app.put(
@@ -586,6 +589,7 @@ app.put(
   requirePermission("forms:write"),
   vid,
   writeLimiter,
+  validateBody(formUpdateSchema),
   forms.updateForm
 );
 app.delete(

--- a/functions/src/schemas/forms.test.ts
+++ b/functions/src/schemas/forms.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { formSchema, formUpdateSchema } from "./index";
+
+/**
+ * `POST /api/forms` y `PUT /api/forms/:id` eran las últimas escrituras de la
+ * API sin esquema. Los handlers hacían `req.body as FormEntry` y
+ * `req.body as Partial<FormEntry>`, y `updateForm` mezclaba ese cuerpo sin
+ * validar sobre la entrada existente, así que cualquier clave inventada
+ * acababa publicada en `about/forms.json` del repo de datos.
+ */
+
+/** Cuerpo válido: lo que manda el panel al crear. */
+function validForm(over: Record<string, unknown> = {}) {
+  return {
+    id: "speakers-bwai-2026",
+    name: "Postulación de speakers BWAI 2026",
+    spreadsheet_id: "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms",
+    sheet_name: "Form Responses 1",
+    is_public: true,
+    created_at: "",
+    ...over,
+  };
+}
+
+describe("formSchema", () => {
+  it("acepta el cuerpo que manda el panel", () => {
+    expect(formSchema.safeParse(validForm()).success).toBe(true);
+  });
+
+  // El panel arrastra `created_at: ""` desde EMPTY_FORM hasta el cuerpo del
+  // POST — nunca se edita en la UI y el handler lo pisa con la hora del
+  // servidor. Rechazarlo rompería el alta de formularios, que es el único
+  // cliente que existe.
+  it("tolera el created_at vacío que arrastra el panel", () => {
+    expect(formSchema.safeParse(validForm({ created_at: "" })).success).toBe(
+      true
+    );
+  });
+
+  it("acepta que falte created_at", () => {
+    const sinFecha = validForm();
+    delete (sinFecha as Record<string, unknown>).created_at;
+    expect(formSchema.safeParse(sinFecha).success).toBe(true);
+  });
+
+  it("aplica los valores por defecto de sheet_name e is_public", () => {
+    const minimo = validForm();
+    delete (minimo as Record<string, unknown>).sheet_name;
+    delete (minimo as Record<string, unknown>).is_public;
+
+    const parsed = formSchema.safeParse(minimo);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.sheet_name).toBe("Form Responses 1");
+      expect(parsed.data.is_public).toBe(true);
+    }
+  });
+
+  // Lo que llega aquí acaba en el repo de datos público. Una clave inventada
+  // tenía que reventar aquí y no después, en el build del sitio.
+  it("rechaza campos que no están en la lista", () => {
+    expect(
+      formSchema.safeParse(validForm({ is_publico_typo: true })).success
+    ).toBe(false);
+  });
+
+  it("rechaza que falten los campos obligatorios", () => {
+    for (const campo of ["id", "name", "spreadsheet_id"]) {
+      const incompleto = validForm();
+      delete (incompleto as Record<string, unknown>)[campo];
+      expect(formSchema.safeParse(incompleto).success).toBe(false);
+    }
+  });
+
+  it("rechaza un nombre vacío", () => {
+    expect(formSchema.safeParse(validForm({ name: "" })).success).toBe(false);
+  });
+
+  // El id se concatena para buscar la entrada y viaja al mensaje de commit;
+  // el spreadsheet_id acaba en la llamada a la API de Sheets. Los dos se
+  // acotan al mismo patrón que el resto de identificadores de la API.
+  it("rechaza un id fuera del patrón seguro", () => {
+    for (const malo of ["../../etc/passwd", "con espacios", "punto.punto"]) {
+      expect(formSchema.safeParse(validForm({ id: malo })).success).toBe(false);
+    }
+  });
+
+  it("rechaza un spreadsheet_id fuera del patrón seguro", () => {
+    expect(
+      formSchema.safeParse(validForm({ spreadsheet_id: "a/b?range=Z" })).success
+    ).toBe(false);
+  });
+
+  it("rechaza un is_public que no es booleano", () => {
+    expect(formSchema.safeParse(validForm({ is_public: "true" })).success).toBe(
+      false
+    );
+  });
+
+  it("acota el texto libre", () => {
+    expect(
+      formSchema.safeParse(validForm({ name: "x".repeat(201) })).success
+    ).toBe(false);
+    expect(
+      formSchema.safeParse(validForm({ sheet_name: "x".repeat(201) })).success
+    ).toBe(false);
+  });
+});
+
+describe("formUpdateSchema", () => {
+  it("acepta una actualización parcial", () => {
+    expect(formUpdateSchema.safeParse({ is_public: false }).success).toBe(true);
+  });
+
+  it("acepta el objeto completo tal como lo devolvería el listado", () => {
+    expect(
+      formUpdateSchema.safeParse(
+        validForm({ created_at: "2026-07-30T12:00:00.000Z" })
+      ).success
+    ).toBe(true);
+  });
+
+  // `.partial()` tiene que conservar la política de claves desconocidas: si no,
+  // el PUT seguiría siendo la puerta abierta que este esquema viene a cerrar.
+  it("sigue rechazando campos fuera de la lista", () => {
+    expect(formUpdateSchema.safeParse({ is_publico_typo: true }).success).toBe(
+      false
+    );
+  });
+
+  it("sigue validando el formato de los campos que sí llegan", () => {
+    expect(formUpdateSchema.safeParse({ id: "../otro" }).success).toBe(false);
+    expect(formUpdateSchema.safeParse({ name: "" }).success).toBe(false);
+  });
+});

--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -184,6 +184,42 @@ export const locationSchema = z
   .strict();
 
 /**
+ * Registro de formularios de `about/forms.json`.
+ *
+ * Era la última escritura de la API sin esquema: los handlers hacían
+ * `req.body as FormEntry` y `req.body as Partial<FormEntry>`, y `updateForm`
+ * mezclaba ese cuerpo sin validar sobre la entrada existente, así que
+ * cualquier clave inventada acababa publicada en el repo de datos.
+ */
+export const formSchema = z
+  .object({
+    id: safeId,
+    name: shortText(200).min(1),
+    // Los IDs de Google Sheets son [A-Za-z0-9_-], así que `safeId` los acepta
+    // enteros y de paso acota lo que llega a `readSheet()`.
+    spreadsheet_id: safeId,
+    sheet_name: shortText(200).default("Form Responses 1"),
+    is_public: z.boolean().default(true),
+    // El panel manda SIEMPRE esta clave, y con la cadena vacía: `EMPTY_FORM`
+    // en FormRegistry la incluye y el estado se arrastra hasta el cuerpo del
+    // POST. El handler la pisa con la hora del servidor. Se acepta para no
+    // obligar al cliente a recortar el objeto, no porque su valor cuente —
+    // mismo tratamiento que `updated_at` en `statsSchema`.
+    created_at: shortText(100).optional(),
+  })
+  .strict();
+
+/**
+ * Cuerpo del PUT. Hoy no tiene cliente —`api.updateForm` existe y nadie la
+ * llama— y el handler hace una mezcla parcial sobre la entrada existente.
+ * Todo opcional para que el día que se añada el botón "Editar" siguiendo el
+ * patrón del panel (reenviar el objeto leído, con su `id` y su `created_at`
+ * reales) no choque contra `.strict()`, que es justo lo que pasó con
+ * `credential` en `eventSchema`. El handler sigue forzando `id: formId`.
+ */
+export const formUpdateSchema = formSchema.partial().strict();
+
+/**
  * Cifras de la comunidad que se pintan en la portada.
  *
  * Era la ÚNICA escritura de la API sin esquema: el handler cogía `req.body`


### PR DESCRIPTION
## What changed

`POST /api/forms` and `PUT /api/forms/:id` were the last API writes without a schema. They now go through `validateBody`, like every other collection.

- New `formSchema` / `formUpdateSchema` in `functions/src/schemas/index.ts`, reusing the existing `safeId` / `shortText` primitives.
- `functions/src/handlers/forms.ts`: dropped the manual required-field check and the improvised defaults (`|| "Form Responses 1"`, `?? true`) — the schema guarantees both now.
- New `functions/src/schemas/forms.test.ts` (15 cases).

## Why

The handlers did `req.body as FormEntry` and `req.body as Partial<FormEntry>` — casts, not validation. `updateForm` then merged that unvalidated body over the existing entry with `{ ...forms[index], ...updates, id: formId }`, so any invented key was written straight into `about/forms.json` in the public data repo. It needs `forms:write`, but it broke the guarantee `validateBody` makes for every other collection.

The schema also tightens `spreadsheet_id` to the same safe pattern as the rest of the API's identifiers — it previously reached `readSheet()` unfiltered.

Two deliberate choices worth reviewing:

- **`created_at` is accepted even though the handler overwrites it** with the server time. The admin panel always sends it, as an empty string, dragged along from `EMPTY_FORM` in `FormRegistry.tsx`. Rejecting it would have broken form creation — its only client. Same treatment as `updated_at` in `statsSchema`.
- **The PUT schema has everything optional.** It has no client today (`api.updateForm` is defined but never called) and the handler does a partial merge. Keeping it permissive means that adding an "Edit" button later — which would resend the object as read, `id` and `created_at` included — will not hit `.strict()`, which is exactly what happened with `credential` in `eventSchema`.

## How to test

```bash
cd functions && npm run build && npm test
```

751 tests pass, including the 15 new ones. The key regression case is `tolera el created_at vacío que arrastra el panel` — without it, this change would break form creation on day one.

Functionally, against the emulator: creating a form from `/admin/forms` must still return 201 (that is the payload carrying `created_at: ""`), and a `POST /api/forms` with an invented key must now return 400 with `{ error: "Invalid request body", issues: [...] }`.