### PR TITLE
chore(deps): move websocket-driver and protobufjs out of their vulnerable ranges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ auth-debug.log*
 
 # Cloud Functions build output
 functions/lib/
+# Copias de seguridad del build que deja alguna herramienta al reconstruir;
+# sin esto, un `git add -A` se las lleva por delante.
+functions/lib.bak.*/
 functions/node_modules/
 
 # Content images (copied from gdg-ica-data during build)

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -5335,9 +5335,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.0.tgz",
-      "integrity": "sha512-PIOO89BMGMXGz2333TVv/OqPNVWm7w30ll/4FtLbtLBaonzJMYwTbAZSSlobjIy9MoUgIAxSVUpK7aP7EpTtkg==",
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.6.tgz",
+      "integrity": "sha512-RkLIhE+Tdc2Kpq1F4Uw6OnpAXPca7B+GSDov/GqGCqNBpVyDskQ9yReZfgM+C7xw9AAix873iQZXbBWXj6NzYQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
@@ -6235,9 +6235,9 @@
       "optional": true
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,7 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "protobufjs": "8.6.0",
+    "protobufjs": "8.6.6",
     "@babel/core": "7.29.6",
     "@tootallnate/once": "2.0.1",
     "js-yaml": "3.15.0",
@@ -33,6 +33,7 @@
     "@grpc/grpc-js": "1.14.4",
     "fast-xml-parser": "5.7.0",
     "fast-xml-builder": "1.1.7",
+    "websocket-driver": "0.7.5",
     "vite": "8.0.16",
     "qs": "6.15.2"
   },


### PR DESCRIPTION
## What changed

Two pins in the `overrides` block that `functions/package.json` already used for other transitive dependencies.

| Package | Before | After | Advisory |
|---|---|---|---|
| `websocket-driver` | 0.7.4 | **0.7.5** | Critical — resource limit bypass via message compression, message corruption via protocol length headers |
| `protobufjs` | 8.6.0 | **8.6.6** | Moderate — text-format map parsing mutates the returned map, DoS via infinite loop in `.proto` option parsing |

`npm audit --omit=dev` goes from 13 advisories to 9.

## Why

Both sit in the **production** dependency tree, not just dev:

```
firebase-admin -> @firebase/database-compat -> @firebase/database
  -> faye-websocket -> websocket-driver@0.7.4
```

The `websocket-driver` path is not reachable in practice — this project uses Firestore, not Realtime Database — but it is in the shipped tree and the fix is a one-line pin.

`protobufjs` is the more interesting one: **the override itself was keeping the vulnerable version alive.** It was pinned to `8.6.0`, which falls inside the affected `8.0.0 - 8.6.5` range. Bumping to `8.6.6` is the first version outside it; staying on the `8.6.x` minor rather than jumping to `8.7.1`.

Two remaining advisories are left alone on purpose:

- **`uuid`** would require forcing a major bump on a transitive of `@google-cloud/*`, which `google-gax`/`gaxios` do not declare support for. The advisory covers v3/v5/v6 when an explicit `buf` is passed, and those libraries use v4 — so real exposure is essentially nil.
- **`body-parser`** is a DoS triggered by an invalid `limit` value, and the app sets its own.

Also folded in: `.gitignore` covered `functions/lib/` but not the `functions/lib.bak.*` copies some tooling leaves behind, so a `git add -A` would sweep 784K of build output into a commit.

## How to test

```bash
cd functions && npm install && npm audit --omit=dev
```

`websocket-driver` and `protobufjs` should be gone; only `uuid` and `body-parser` remain. Confirm the pins took with `npm ls websocket-driver protobufjs` — both should be marked `overridden`.

```bash
cd functions && npm test   # 751 pass
pnpm test:rules            # 181 pass — this is the suite that exercises @firebase/rules-unit-testing
```