### PR TITLE
refactor(events): render QR codes as <img> instead of injecting raw HTML

### DIFF
--- a/src/components/react/event/ProjectorView.tsx
+++ b/src/components/react/event/ProjectorView.tsx
@@ -15,10 +15,11 @@ interface Props {
   slug: string;
   eventName: string;
   joinUrl: string;
-  qrSvg: string;
+  /** PNG data URL built at build time by projector.astro. */
+  qrDataUrl: string;
 }
 
-export function ProjectorView({ slug, eventName, joinUrl, qrSvg }: Props) {
+export function ProjectorView({ slug, eventName, joinUrl, qrDataUrl }: Props) {
   const { liveInstances } = useLiveMinigames(slug);
   const [qrExpanded, setQrExpanded] = useState(false);
 
@@ -52,7 +53,7 @@ export function ProjectorView({ slug, eventName, joinUrl, qrSvg }: Props) {
         </div>
       </header>
 
-      {!hasLive && <HeroQr qrSvg={qrSvg} joinUrl={joinUrl} />}
+      {!hasLive && <HeroQr qrDataUrl={qrDataUrl} joinUrl={joinUrl} />}
 
       {hasLive && (
         <main className="flex-1 p-8">
@@ -97,7 +98,9 @@ export function ProjectorView({ slug, eventName, joinUrl, qrSvg }: Props) {
               className="h-24 w-24 rounded bg-white p-1 transition hover:ring-2 hover:ring-white/60"
               aria-label="Agrandar QR"
             >
-              <div dangerouslySetInnerHTML={{ __html: qrSvg }} />
+              {/* alt vacío a propósito: el botón ya aporta el nombre
+                  accesible, y repetirlo lo anunciaría dos veces. */}
+              <img src={qrDataUrl} alt="" className="h-full w-full" />
             </button>
           </div>
         </footer>
@@ -116,11 +119,13 @@ export function ProjectorView({ slug, eventName, joinUrl, qrSvg }: Props) {
           >
             ✕ Achicar
           </button>
-          <div
-            className="h-[60vh] max-h-[640px] w-[60vh] max-w-[640px] rounded-2xl bg-white p-6"
-            dangerouslySetInnerHTML={{ __html: qrSvg }}
-            aria-label="QR de unión ampliado"
-          />
+          <div className="h-[60vh] max-h-[640px] w-[60vh] max-w-[640px] rounded-2xl bg-white p-6">
+            <img
+              src={qrDataUrl}
+              alt="QR de unión ampliado"
+              className="h-full w-full object-contain"
+            />
+          </div>
           <p className="font-mono text-xl text-white/80">{joinUrl}</p>
         </div>
       )}
@@ -130,15 +135,23 @@ export function ProjectorView({ slug, eventName, joinUrl, qrSvg }: Props) {
 
 export default ProjectorView;
 
-function HeroQr({ qrSvg, joinUrl }: { qrSvg: string; joinUrl: string }) {
+function HeroQr({
+  qrDataUrl,
+  joinUrl,
+}: {
+  qrDataUrl: string;
+  joinUrl: string;
+}) {
   return (
     <main className="flex flex-1 flex-col items-center justify-center gap-8 p-8 text-center">
       <p className="text-2xl text-white/70">Escanea para participar</p>
-      <div
-        className="h-[60vh] max-h-[640px] w-[60vh] max-w-[640px] rounded-2xl bg-white p-6"
-        dangerouslySetInnerHTML={{ __html: qrSvg }}
-        aria-label="QR de unión"
-      />
+      <div className="h-[60vh] max-h-[640px] w-[60vh] max-w-[640px] rounded-2xl bg-white p-6">
+        <img
+          src={qrDataUrl}
+          alt="QR de unión"
+          className="h-full w-full object-contain"
+        />
+      </div>
       <p className="font-mono text-xl text-white/80">{joinUrl}</p>
     </main>
   );

--- a/src/components/react/event/__tests__/ProjectorView.test.tsx
+++ b/src/components/react/event/__tests__/ProjectorView.test.tsx
@@ -23,7 +23,8 @@ vi.mock("../useBingoWinners", () => ({
 
 import { ProjectorView } from "../ProjectorView";
 
-const QR_SVG = '<svg data-testid="qr-svg"><rect /></svg>';
+const QR_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==";
 const JOIN_URL = "https://gdgica.com/events/x?play=1";
 const NOW_MS = 1_700_000_000_000;
 
@@ -59,7 +60,7 @@ function renderProjector() {
       slug="x"
       eventName="DevFest ICA 2026"
       joinUrl={JOIN_URL}
-      qrSvg={QR_SVG}
+      qrDataUrl={QR_DATA_URL}
     />
   );
 }
@@ -69,7 +70,9 @@ describe("ProjectorView", () => {
     renderProjector();
     expect(screen.getByText("DevFest ICA 2026")).toBeInTheDocument();
     expect(screen.getByText(/Escanea para participar/i)).toBeInTheDocument();
-    expect(screen.getByLabelText("QR de unión")).toBeInTheDocument();
+    // getByAltText, no getByLabelText: el QR es un <img> y su nombre
+    // accesible viene del alt, no de un aria-label.
+    expect(screen.getByAltText("QR de unión")).toBeInTheDocument();
     expect(screen.getAllByText(JOIN_URL)).not.toHaveLength(0);
   });
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -128,11 +128,13 @@ const hasSchedule = isArraySchedule
     : false;
 
 const whatsappGroupLink = event.data.whatsappGroupLink;
-const whatsappQrSvg = whatsappGroupLink
-  ? await QRCode.toString(whatsappGroupLink, {
-      type: "svg",
+// Data URL rather than an SVG string so it goes into an <img src>, without
+// injecting raw HTML into the page. Same approach as credencial.astro.
+const whatsappQrDataUrl = whatsappGroupLink
+  ? await QRCode.toDataURL(whatsappGroupLink, {
       errorCorrectionLevel: "M",
       margin: 1,
+      width: 480,
       color: { dark: "#111827", light: "#ffffff" },
     })
   : null;
@@ -413,7 +415,7 @@ const whatsappQrSvg = whatsappGroupLink
             </div>
           </div>
           {
-            whatsappGroupLink && whatsappQrSvg && (
+            whatsappGroupLink && whatsappQrDataUrl && (
               <div class="border-gray-custom rounded-lg border p-6 shadow-sm">
                 <h2 class="text-primary mb-4 text-2xl font-semibold">
                   Grupo de WhatsApp
@@ -422,10 +424,13 @@ const whatsappQrSvg = whatsappGroupLink
                   Únete al grupo del evento para recibir información sobre
                   salones, charlas y novedades en tiempo real.
                 </p>
-                <div
-                  class="mb-4 flex items-center justify-center rounded-lg bg-white p-4 [&>svg]:h-auto [&>svg]:w-full [&>svg]:max-w-[240px]"
-                  set:html={whatsappQrSvg}
-                />
+                <div class="mb-4 flex items-center justify-center rounded-lg bg-white p-4">
+                  <img
+                    src={whatsappQrDataUrl}
+                    alt="QR del grupo de WhatsApp del evento"
+                    class="h-auto w-full max-w-[240px]"
+                  />
+                </div>
                 <div class="flex justify-center">
                   <Button
                     variant="solid"

--- a/src/pages/events/[slug]/projector.astro
+++ b/src/pages/events/[slug]/projector.astro
@@ -20,10 +20,15 @@ const joinUrl = `https://gdgica.com/events/${slug}?play=1`;
 // works the moment it's served — even before the React island
 // hydrates. Standard black-on-white; all containers (footer, overlay,
 // hero) already have a white background so no inversion is needed.
-const qrSvg = await QRCode.toString(joinUrl, {
-  type: "svg",
+//
+// A data URL rather than an SVG string: the component renders it as the
+// `src` of an <img>, so nothing here has to be injected as raw HTML.
+// Same approach as credencial.astro. 512px covers the largest on-screen
+// size (a 640px-capped container on a projector).
+const qrDataUrl = await QRCode.toDataURL(joinUrl, {
   errorCorrectionLevel: "H",
   margin: 1,
+  width: 512,
   color: { dark: "#000000", light: "#ffffff" },
 });
 ---
@@ -34,6 +39,6 @@ const qrSvg = await QRCode.toString(joinUrl, {
     slug={slug!}
     eventName={event.data.name}
     joinUrl={joinUrl}
-    qrSvg={qrSvg}
+    qrDataUrl={qrDataUrl}
   />
 </ProjectorLayout>


### PR DESCRIPTION
## What changed

All four QR codes on the site were built as SVG strings with `QRCode.toString` and injected as raw HTML — three via `dangerouslySetInnerHTML` in `ProjectorView.tsx`, one via `set:html` for the WhatsApp group QR in `[slug].astro`.

They now use `QRCode.toDataURL` and the result goes into the `src` of an `<img>`, which is the pattern `credencial.astro` already followed.

After this there is no `dangerouslySetInnerHTML` left anywhere in `src/`, and no `set:html` used for a QR.

## Why

**This was not exploitable.** All four QRs are generated at build time from URLs the server constructs (`https://gdgica.com/events/${slug}?play=1` and the event's WhatsApp link, both from Zod-validated content), so there is no path from user data into that HTML.

It is a fragile pattern rather than a live bug: the day one of those URLs picks up a caller-controllable value, it becomes an XSS — and none of it was needed to draw a QR code. This came out of a security audit as hygiene, not as a finding.

## Notes for review

- The SVG that `toString` returns carries no `width`/`height`, so it stretched to fill its container on its own. An `<img>` does not inherit that, so the containers now carry `h-full w-full` with `object-contain`. The `[&>svg]:*` arbitrary variants on the WhatsApp container are gone for the same reason.
- The small footer QR uses `alt=""` on purpose — the wrapping `<button>` already supplies the accessible name via `aria-label="Agrandar QR"`, and repeating it would announce the control twice.
- In the test, `getByLabelText` becomes `getByAltText`: the QR's accessible name now comes from `alt` rather than an `aria-label`. The `"Agrandar QR"` assertions are unchanged — that label lives on the `<button>`, which this PR does not touch.

## How to test

```bash
pnpm test        # 398 pass, incl. ProjectorView.test.tsx
pnpm run build   # 47 pages
```

The build is the real check, since the QRs are generated at build time. Verified against the generated output rather than only the tests:

```bash
grep -o 'data:image/png;base64,[A-Za-z0-9+/]\{0,40\}' dist/events/*/projector/index.html   # data URLs present
grep -rl 'shape-rendering="crispEdges"' dist/                                              # empty — no raw QR SVG left
```

Visually: open `/events/<slug>/projector` and check the three QR states (small footer QR, expanded overlay on click, and the hero QR when no game is live), plus the WhatsApp QR on the event page.