### PR TITLE
ci: run the test suite on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+        with:
+          version: 10.11.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "22.15.0"
+          cache: pnpm
+
+      - name: Setup Java (for Firestore emulator)
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Cache npm (Cloud Functions)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('functions/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
+
+      - name: Install root dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Cloud Functions dependencies
+        run: cd functions && npm ci
+
+      - name: Run unit tests (root)
+        run: pnpm test
+
+      - name: Run Cloud Functions tests
+        run: pnpm test:functions
+
+      - name: Run security rules tests
+        run: pnpm test:rules


### PR DESCRIPTION
## What changed

A new `.github/workflows/ci.yml` that runs the three test suites (root, Cloud Functions, security rules) on every PR targeting `main`.

## Why

Until now the tests ran **only after merging**, inside `deploy.yml` — there was no workflow bound to `pull_request` at all. Two consequences:

- Whoever reviews a PR has no test result to lean on. `main` requires one approval, and that approval is given blind.
- A failure surfaces with the code already on `main`.

It compounds with the deploy's concurrency group. GitHub keeps only **one pending run per group**, so a newer run cancels the previously pending one — `cancel-in-progress: false` protects the *running* job, not the queue. On 2026-07-30 three PRs merged within 45 seconds and the middle run was cancelled after 20 seconds, so its tests never ran at all. It happened to be covered because a later run tested the merged tree, but nothing guaranteed that.

Running the same three suites here means a green check on the PR carries the same weight as the one on `main`.

## ⚠️ This does not block merging on its own

`main` currently has **one required approval and zero required status checks**. Until this workflow is added as a required status check, it is advisory — GitHub will still let a red PR merge.

Once this lands and you have seen it pass once, it needs to be enabled under **Settings → Branches → `main` → Require status checks to pass**, selecting the `test` check. Happy to do that via the API if you would rather I did.

## Notes

- `cancel-in-progress: true` here is the opposite of the deploy's setting, deliberately: if a PR gets several pushes, the result for a superseded commit is of no use to anyone. For a deploy, cancelling the in-flight job is the wrong move.
- `timeout-minutes: 20` against a suite that takes ~2 minutes. GitHub's default is 6 hours; one deploy run already sat idle for 3 hours this month.
- Dependency caching is included: `cache: pnpm` on `setup-node` (which is why `pnpm/action-setup` runs *before* it — the cache needs the store to exist), plus a separate `actions/cache` for `~/.npm`, since Cloud Functions has its own lockfile and uses npm.
- Every action is pinned by full commit SHA, matching the convention already used in `deploy.yml`.

## How to test

This PR is itself the test: the `test` job should appear on it and go green. Locally the same commands are:

```bash
pnpm test            # 398
pnpm test:functions  # 751
pnpm test:rules      # 181
```