### PR TITLE
ci(deploy): authenticate with Workload Identity Federation instead of FIREBASE_TOKEN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: deploy-production
@@ -110,8 +111,12 @@ jobs:
       - name: Install Firebase CLI
         run: pnpm add -g firebase-tools@15.14.0
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
       - name: Deploy to Firebase
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: |
-          firebase deploy --only "hosting:gdgica,functions,firestore:rules,firestore:indexes,storage"
+          firebase deploy --project appgdgica --only "hosting:gdgica,functions,firestore:rules,firestore:indexes,storage"


### PR DESCRIPTION
## What changed

`FIREBASE_TOKEN` is replaced by Workload Identity Federation via `google-github-actions/auth`.

- `id-token: write` added so GitHub will mint the OIDC token.
- `--project appgdgica` added — without `FIREBASE_TOKEN` the CLI no longer infers the project on its own.
- After this, the workflow uses **no `secrets.*` at all**.

## Why

Every deploy already prints this:

> ⚠ Authenticating with `FIREBASE_TOKEN` is deprecated and **will be removed in a future major version** of `firebase-tools`. Instead, use a service account key with `GOOGLE_APPLICATION_CREDENTIALS`.

So this is not only hygiene — the pipeline is on a countdown to breaking when firebase-tools bumps its major.

The warning suggests a service account **key**. Workload Identity Federation is used here instead: a key file is still a long-lived credential sitting in repository secrets, which is the thing worth getting rid of. With OIDC, GitHub mints a short-lived token that GCP exchanges for temporary credentials, and nothing durable is stored.

## Setup required before merging

**These are for a human to run**, once, with an account holding project owner (or equivalent) on `appgdgica`.

1. Create a service account for the deploy, e.g. `github-deploy`, in project `appgdgica`. It ends up as `github-deploy@appgdgica.iam.gserviceaccount.com`.

2. Grant it the roles the deploy needs. Start narrow and add only what a failed deploy actually asks for — deliberately **not** `roles/owner`:
   - `roles/firebasehosting.admin`
   - `roles/cloudfunctions.admin`
   - `roles/firebaserules.admin`
   - `roles/datastore.indexAdmin`
   - `roles/firebase.admin`
   - `roles/iam.serviceAccountUser`
   - `roles/artifactregistry.writer`
   - `roles/serviceusage.serviceUsageConsumer`

3. Create a Workload Identity **pool** (e.g. `github`, location `global`) and an **OIDC provider** inside it (e.g. `github`) with:
   - issuer URI `https://token.actions.githubusercontent.com`
   - attribute mapping `google.subject=assertion.sub`, `attribute.repository=assertion.repository`
   - **attribute condition** `assertion.repository=='GDGXICA/gdgxica.github.io'`

4. Bind the service account so only this repository may impersonate it: grant `roles/iam.workloadIdentityUser` to the principal set
   `principalSet://iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github/attribute.repository/GDGXICA/gdgxica.github.io`

   `<PROJECT_NUMBER>` is the numeric project number of `appgdgica` (visible in the GCP console, or via `gcloud projects describe appgdgica --format='value(projectNumber)'`, which is read-only).

The attribute condition in step 3 and the principal set in step 4 both pin this to `GDGXICA/gdgxica.github.io`, so no other repository can use the provider to impersonate the account.

Then add two **repository variables** — Settings → Secrets and variables → Actions → *Variables*, not Secrets, since these are identifiers rather than credentials:

| Variable | Value |
|---|---|
| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/github/providers/github` |
| `GCP_DEPLOY_SERVICE_ACCOUNT` | `github-deploy@appgdgica.iam.gserviceaccount.com` |

The Google documentation for this setup is at https://github.com/google-github-actions/auth#preferred-direct-workload-identity-federation

## How to test

There is no way to verify this without the GCP side in place — that is why it is blocked. Suggested order:

1. Merge the deploy-hardening PR.
2. Do the setup above and add the two variables.
3. Mark this ready, merge, and watch the first deploy. Confirm the `Authenticate to Google Cloud` step succeeds and the deprecation warning is **gone** from the deploy step.
4. Only once a deploy has succeeded, delete the `FIREBASE_TOKEN` secret and revoke the old token.

If the deploy fails on a missing permission, the error names the role — add that one in step 2 rather than granting anything broader.

## Rollback

Revert this commit and the previous `FIREBASE_TOKEN` path works again, as long as the secret has not been deleted yet — which is why step 4 comes last.
