### PR TITLE
fix(api): accept is_active when saving a team member

### DIFF
--- a/functions/src/schemas/index.ts
+++ b/functions/src/schemas/index.ts
@@ -171,6 +171,7 @@ export const teamMemberSchema = z
     tags: z.array(shortText(200)).max(50).optional(),
     joined_date: shortText(100).optional(),
     responsibilities: z.array(shortText(500)).max(50).optional(),
+    is_active: z.boolean().optional(),
   })
   .strict();
 

--- a/functions/src/schemas/team.test.ts
+++ b/functions/src/schemas/team.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { teamMemberSchema } from "./index";
+
+function validMember(over: Record<string, unknown> = {}) {
+  return {
+    id: "alvaro-pena",
+    name: "Álvaro Peña",
+    role: "Organizador",
+    photo_url: "/team/alvaro.webp",
+    bio: "Community lead en GDG ICA.",
+    social_links: { github: "https://github.com/aalvaropc" },
+    type: "organizer",
+    ...over,
+  };
+}
+
+describe("teamMemberSchema", () => {
+  it("acepta un miembro sin is_active", () => {
+    expect(teamMemberSchema.safeParse(validMember()).success).toBe(true);
+  });
+
+  it("acepta el is_active que reenvía el panel", () => {
+    for (const valor of [true, false]) {
+      const parsed = teamMemberSchema.safeParse(
+        validMember({ is_active: valor })
+      );
+      expect(parsed.success).toBe(true);
+      if (parsed.success) expect(parsed.data.is_active).toBe(valor);
+    }
+  });
+
+  it("no inventa is_active cuando no venía", () => {
+    const parsed = teamMemberSchema.safeParse(validMember());
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect("is_active" in parsed.data).toBe(false);
+  });
+
+  it("rechaza un is_active que no es booleano", () => {
+    expect(
+      teamMemberSchema.safeParse(validMember({ is_active: "true" })).success
+    ).toBe(false);
+  });
+
+  it("sigue rechazando campos fuera de la lista", () => {
+    expect(
+      teamMemberSchema.safeParse(validMember({ is_activo_typo: true })).success
+    ).toBe(false);
+  });
+
+  it("exige los campos obligatorios", () => {
+    for (const campo of ["id", "name", "type"]) {
+      const incompleto = validMember();
+      delete (incompleto as Record<string, unknown>)[campo];
+      expect(teamMemberSchema.safeParse(incompleto).success).toBe(false);
+    }
+  });
+
+  it("acota el tipo a organizer o member", () => {
+    expect(
+      teamMemberSchema.safeParse(validMember({ type: "admin" })).success
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

`is_active` is now declared in `teamMemberSchema`, as an optional boolean.

## Why

**Editing any team member from `/admin/team` failed with 400 "Invalid request body".** Reproduced in production twice — `PUT /api/team/alvaro-pena` returned 400 on 2026-07-30 at 23:12 and again on 2026-07-31 at 10:52.

`about/team.json` stores `is_active` on all twelve members, but the schema did not declare it and is `.strict()`. `TeamList.handleSave` resends the object exactly as it was read from the server, that field included, so the whole body was rejected.

**The field is not leftover data.** `src/loaders/transform-team.ts` filters on `is_active !== false` to decide who appears on the public site. Stripping it from the data would have made hidden members reappear — so declaring it is the correct fix, not removing it.

`.optional()` with no default is deliberate: absence already means "visible", and a `.default(true)` would write the key into all twelve members the first time anyone was edited.

## Note for review

This is the **third** time this exact pattern has bitten — the admin panel resends a field the schema does not know about. The previous two are documented in the code: `updated_at` in `statsSchema` and `credential` in `eventSchema`.

I checked every other collection against its live data in `gdg-ica-data`, and there is no further drift:

| Collection | Verdict |
|---|---|
| `about/team.json` | `is_active` missing from schema — **this PR** |
| `about/partners.json` | aligned |
| `about/stats.json` | aligned (`updated_at` already handled) |
| `about/forms.json` | aligned |
| `events/*.json` | aligned (`credential` already handled) |
| `speakers/*.json` | aligned |

Worth considering separately: a guard that fails CI when a schema and its live data diverge would catch the fourth occurrence before a user does.

## How to test

```bash
cd functions && npm run build && npm test
```

758 tests pass, including 7 new ones in `functions/src/schemas/team.test.ts`. The regression case is `acepta el is_active que reenvía el panel` — that is literally the body the panel was sending.

After merge, the real check: edit any member at `/admin/team` and save. It should return 200 instead of 400, and the member's visibility on the public site should be unchanged.