### PR TITLE
docs: rewrite the README in English, shorter and without images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,158 +1,69 @@
-# Google Developer Group (GDG) ICA - Sitio Web Oficial
+# Google Developer Group (GDG) ICA — Official Website
 
-![gdg cover image](preview.png)
+[🌐 gdgica.com](https://gdgica.com) · [🖼️ Figma design](https://www.figma.com/design/OsE9m2hnvt7DjuI7e7Ocx3/GDG-ICA?node-id=0-1&t=XAHKhrJY81pkcRk6-1)
 
-[🌐 gdgica.com](https://gdgica.com) · [🖼️ Diseño en Figma](https://www.figma.com/design/OsE9m2hnvt7DjuI7e7Ocx3/GDG-ICA?node-id=0-1&t=XAHKhrJY81pkcRk6-1)
+Static site for the GDG ICA community, built with Astro. All public content — events, speakers, team, sponsors, gallery — lives in the separate [`GDGXICA/gdg-ica-data`](https://github.com/GDGXICA/gdg-ica-data) repository and is pulled in at build time by the custom loaders in `src/loaders/`. CI clones that repo instead of fetching it over the CDN, so a build never picks up stale JSON.
 
-## Sobre el Proyecto
+Public pages: `/`, `/events`, `/events/[slug]`, `/team`, `/about`, `/sponsors`, `/volunteers`, `/gallery`. There is also an authenticated admin panel under `/admin/*`, backed by an Express API on Cloud Functions that writes to the data repo through the GitHub API.
 
-Sitio web oficial del Google Developer Group (GDG) ICA, construido con Astro 5 como sitio estático. Todo el contenido (eventos, speakers, equipo, sponsors) se gestiona desde el repositorio externo [gdg-ica-data](https://github.com/GDGXICA/gdg-ica-data) y se consume en build time mediante custom loaders.
+## Stack
 
-### Tecnologías
+- [Astro 7](https://astro.build) — static site generator
+- [TailwindCSS 4](https://tailwindcss.com) — styling
+- [React 19](https://react.dev) — interactive islands only
+- [Firebase](https://firebase.google.com) — Hosting, Auth, Firestore, Cloud Functions
 
-- [Astro 5](https://astro.build) — Framework web estático
-- [TailwindCSS 4](https://tailwindcss.com) — Estilos utilitarios
-- [React 19](https://react.dev) — Islas interactivas (solo donde se necesita JS en el cliente)
-- [Firebase Hosting](https://firebase.google.com/docs/hosting) — Despliegue y CDN
+## Getting started
 
-### Páginas
-
-| Ruta             | Descripción                                                    |
-| ---------------- | -------------------------------------------------------------- |
-| `/`              | Homepage                                                       |
-| `/events`        | Listado de eventos                                             |
-| `/events/[slug]` | Detalle de evento (agenda, speakers, sponsors, QR de WhatsApp) |
-| `/team`          | Equipo organizador y miembros                                  |
-| `/about`         | Acerca de GDG ICA                                              |
-| `/sponsors`      | Sponsors                                                       |
-| `/volunteers`    | Voluntarios                                                    |
-| `/gallery`       | Galería de fotos                                               |
-
-### Datos
-
-Todo el contenido proviene de [`GDGXICA/gdg-ica-data`](https://github.com/GDGXICA/gdg-ica-data). Los loaders en `src/loaders/` fetchean los JSON en build time desde ese repositorio. En CI se usa un clone local para evitar staleness del CDN.
-
-## Requerimientos
-
-- Git
-- Node 22.15.0
-- PNPM 10.11.0
-
-## Instalación
+Requires Node 22.15.0 and pnpm 10.11.0.
 
 ```sh
 pnpm install
 pnpm dev
 ```
 
-El servidor de desarrollo corre en `http://localhost:4321`.
+The dev server runs at `http://localhost:4321`.
 
-## Comandos
+## Commands
 
-| Comando        | Acción                                     |
-| -------------- | ------------------------------------------ |
-| `pnpm install` | Instalar dependencias                      |
-| `pnpm dev`     | Servidor de desarrollo en `localhost:4321` |
-| `pnpm build`   | Build de producción en `./dist/`           |
-| `pnpm preview` | Preview del build                          |
-| `pnpm lint`    | Ejecutar ESLint                            |
-| `pnpm format`  | Formatear con Prettier                     |
+| Command               | Action                               |
+| --------------------- | ------------------------------------ |
+| `pnpm dev`            | Dev server at `localhost:4321`       |
+| `pnpm build`          | Production build into `./dist/`      |
+| `pnpm preview`        | Preview the build                    |
+| `pnpm lint`           | Run ESLint                           |
+| `pnpm format`         | Format with Prettier                 |
+| `pnpm test`           | Unit tests (Vitest)                  |
+| `pnpm test:functions` | Cloud Functions tests                |
+| `pnpm test:rules`     | Firestore rules against the emulator |
+| `pnpm test:all`       | All three suites                     |
 
-## Mini-juegos en eventos
-
-Esta sección guía al equipo organizador para correr mini-juegos en vivo durante un evento (encuestas, quiz, nube de palabras, bingo).
-
-### Pre-evento
-
-1. **Plantillas** — desde `/admin/minigame-templates` crea las plantillas que vas a usar (poll, quiz, wordcloud, bingo). Las plantillas son reutilizables entre eventos.
-2. **Adjuntar al evento** — desde `/admin/events`, haz click en "🎮 Mini-juegos" en la fila del evento para abrir `/admin/events/minigames?slug=<id>`. Adjunta cada plantilla que vayas a usar.
-3. **Anonymous Authentication** — confirma que está habilitado en Firebase Console (Authentication → Sign-in method → Anonymous). Sin esto los participantes no se pueden unir en producción. El emulador local lo activa solo.
-4. **Smoke test** — abre `https://gdgica.com/events/<slug>?play=1` en una pestaña incognito antes del evento y verifica que aparezca el modal de unión.
-
-### Durante el evento
-
-1. **Conecta el proyector** — desde el panel admin del evento, click en "📺 Abrir proyector". Se abre `/events/<slug>/projector` en una nueva pestaña; muévela a la pantalla del venue.
-2. **Activa los juegos globales** (bingo + wordcloud) al inicio. Están pensados para correr durante todo el evento.
-3. **Activa polls / quizzes** en momentos puntuales:
-   - Click "▶ Iniciar" en la card del juego cuando quieras lanzarlo.
-   - Para quiz, "⏭ Avanzar pregunta" controla el timer y la siguiente pregunta.
-   - Click "⏹ Cerrar" cuando termine.
-4. **Comparte la URL de unión** — el botón "📋 Copiar URL de unión" copia `https://gdgica.com/events/<slug>?play=1` al portapapeles; pégalo en el WhatsApp del evento o cualquier canal.
-5. **Modera el wordcloud** — el botón "Ver moderación" en cada card de wordcloud abre un panel donde admin oculta palabras inapropiadas. Los cambios se reflejan en el proyector y en los celulares en <1s.
-6. **Quiz en vivo** — la pantalla del proyector muestra timer, opciones, y leaderboard top-10. Los participantes ven lo mismo en sus celulares.
-
-### Post-evento
-
-1. **Cierra los juegos** (state=closed) desde el panel admin para detener escrituras.
-2. **Premia a los ganadores** — botón "Ver ganadores" en la card de bingo lista los participantes con `bingoWonAt` ordenados por timestamp.
-3. Los datos quedan en Firestore para análisis posterior — no es necesario borrar nada.
-
-### Solución de problemas comunes
-
-- **El modal no aparece para los participantes**: verifica que el juego esté en `live` y que Anonymous Authentication esté habilitado en Firebase Console.
-- **El QR del proyector apunta al dominio incorrecto**: el QR se genera al build con `https://gdgica.com`. Re-deployar después de cambios de dominio.
-- **"Demasiados intentos"** al unirse: el rate limiter por IP es 10/min. Para eventos grandes en una misma red WiFi, ajusta `joinLimiter` en `functions/src/index.ts`.
-- **Borrar una plantilla adjuntada**: solo se puede borrar una instancia en `state=scheduled`. Cierra el juego primero (`live` → `closed`) y luego archívalo visualmente; los datos históricos quedan.
-
-## Estructura del proyecto
+## Layout
 
 ```plaintext
-/
-├── public/              # Assets estáticos (imágenes, fonts)
-├── src/
-│   ├── components/      # Componentes Astro (.astro)
-│   │   └── react/       # Islas React (solo client-side interactivo)
-│   ├── layouts/         # Layout principal
-│   ├── loaders/         # Custom loaders para gdg-ica-data
-│   ├── pages/           # Rutas (file-based routing)
-│   ├── styles/          # CSS global y variables
-│   └── content.config.ts # Schemas Zod de las colecciones
-├── functions/           # Cloud Functions (API backend)
-└── .github/workflows/   # CI/CD con GitHub Actions
+src/
+├── components/       # Astro components; react/ holds the client-side islands
+├── layouts/          # Page layouts
+├── loaders/          # Content loaders for gdg-ica-data
+├── pages/            # File-based routing
+├── lib/              # Firebase client, auth, API wrapper, permissions
+└── content.config.ts # Zod schemas for the collections
+functions/            # Cloud Functions API
+docs/                 # Operational guides
 ```
 
-## Despliegue
+Architecture notes, the admin permission model and the testing setup are documented in [CLAUDE.md](CLAUDE.md).
 
-GitHub Actions (`.github/workflows/deploy.yml`) construye y despliega a Firebase Hosting en cada push a `main`. También se dispara automáticamente cuando el repositorio de datos se actualiza.
+## Deployment
 
-## Cómo Contribuir
+GitHub Actions (`.github/workflows/deploy.yml`) builds and deploys to Firebase on every push to `main`, and on a `repository_dispatch` from the data repo so content updates rebuild the site.
 
-1. Clona el proyecto
-2. Crea una rama (`git checkout -b feature/AmazingFeature`)
-3. Haz commit siguiendo Conventional Commits (`git commit -m 'feat: add amazing feature'`)
-4. Push a la rama (`git push origin feature/AmazingFeature`)
-5. Abre un Pull Request
+## Contributing
 
-> Antes de codificar, revisa los issues y PRs existentes para evitar trabajo duplicado.
+Branch off `main`, commit with [Conventional Commits](https://www.conventionalcommits.org) (`feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`), then open a pull request. PRs need at least one approval — keep them small and focused, and include screenshots for visual changes. Check the open issues and PRs first to avoid duplicate work.
 
-### Estándares
+Conventions: camelCase for variables and functions, PascalCase for components, Tailwind over custom CSS, no `!important`, no `console.log` in production code. Discuss new dependencies before adding them.
 
-**Commits** — Conventional Commits obligatorio:
+## License
 
-| Prefijo     | Uso                           |
-| ----------- | ----------------------------- |
-| `feat:`     | Nueva funcionalidad           |
-| `fix:`      | Corrección de bug             |
-| `docs:`     | Documentación                 |
-| `style:`    | Formato, sin cambio de lógica |
-| `refactor:` | Refactorización               |
-| `test:`     | Tests                         |
-| `chore:`    | Mantenimiento, tooling        |
-
-**Código:**
-
-- Variables y funciones en camelCase
-- Componentes Astro/React en PascalCase
-- Tailwind para estilos, evitar CSS custom
-- Sin `!important`, sin `console.log` en producción
-- No añadir dependencias sin discutirlo primero
-
-**Pull Requests:**
-
-- Requieren al menos una aprobación
-- PR pequeños y enfocados en una sola cosa
-- Capturas de pantalla para cambios visuales
-
-## Licencia
-
-MIT — ver [LICENSE.md](LICENSE.md)
+MIT — see [LICENSE.md](LICENSE.md)


### PR DESCRIPTION
## What changed

The README goes from 158 to 68 lines, is now written in English, and no longer embeds any image.

- Dropped the `![gdg cover image](preview.png)` header. `preview.png` itself stays in the repo — nothing references it anymore, but removing a 900 KB asset is a separate call and is left out of this PR on purpose.
- The mini-games runbook (34 of the original 158 lines) is removed. It documented the admin flow for running polls, quizzes, wordcloud and bingo during a live event — pre-event setup, projector controls, moderation, and a troubleshooting list. Nothing replaces it in the repo; the text stays recoverable from this repo's history.
- The page table, the commit-type table and the coding-standards block are condensed into prose, since the detail already lives in `CLAUDE.md`.

Three things were wrong or missing and are fixed along the way:

- It claimed Astro 5; `package.json` asks for `^7.1.1`.
- The commands table listed none of the four test scripts (`test`, `test:functions`, `test:rules`, `test:all`).
- It never mentioned the admin panel or its Cloud Functions API, which is roughly half the codebase.

## Why

The README was carrying three unrelated jobs at once — introducing the project, walking organizers through a live event, and restating conventions documented elsewhere — so the part a newcomer actually needs was buried.

## How to test

Read the rendered README on this branch. Worth checking specifically:

1. Every relative link resolves — `CLAUDE.md`, `LICENSE.md`.
2. No image is embedded (`grep '!\[' README.md` returns nothing).
3. The commands table matches the `scripts` block in `package.json`.

## Note for reviewers

Deleting the mini-games runbook loses the only written record of that operational flow outside git history. If the organizing team still runs those games, consider whether it should live somewhere else before this merges.