### PR TITLE
fix(credential): stop the submit button hanging forever on $"Guardando…$"

### DIFF
--- a/src/components/react/credential/CredentialForm.tsx
+++ b/src/components/react/credential/CredentialForm.tsx
@@ -25,7 +25,6 @@ interface Props {
   onSubmit: () => void;
   submitting: boolean;
   serverError: string | null;
-  fieldErrors: Record<string, string>;
 }
 
 function Field({
@@ -62,7 +61,6 @@ export function CredentialForm(props: Props) {
     onSubmit,
     submitting,
     serverError,
-    fieldErrors,
   } = props;
 
   const [touched, setTouched] = useState(false);
@@ -188,7 +186,7 @@ export function CredentialForm(props: Props) {
       </header>
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <Field label="DNI" error={fieldErrors.dni}>
+        <Field label="DNI">
           <input
             className={inputClass}
             value={registration.dni}
@@ -201,7 +199,7 @@ export function CredentialForm(props: Props) {
             }
           />
         </Field>
-        <Field label="Correo electrónico" error={fieldErrors.email}>
+        <Field label="Correo electrónico">
           <input
             className={inputClass}
             type="email"
@@ -237,7 +235,7 @@ export function CredentialForm(props: Props) {
       </Field>
 
       {registration.heardAbout === "otro" && (
-        <Field label="Cuéntanos cómo" error={fieldErrors.heardAboutOther}>
+        <Field label="Cuéntanos cómo">
           <input
             className={inputClass}
             value={registration.heardAboutOther}

--- a/src/components/react/credential/CredentialForm.tsx
+++ b/src/components/react/credential/CredentialForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { cloneElement, useId, useState } from "react";
 import { CONSENT_ITEMS, missingConsentMessage } from "@/lib/consent";
 import { AvatarPicker } from "./AvatarPicker";
 import {
@@ -34,13 +34,29 @@ function Field({
 }: {
   label: string;
   error?: string;
-  children: React.ReactNode;
+  children: React.ReactElement<React.AriaAttributes>;
 }) {
+  const errorId = useId();
+  // The error is wired to the control instead of left as loose prose beside
+  // it. Inside a <label>, a screen reader announces the label text and stops;
+  // a trailing <span> is never reached, so without aria-describedby the
+  // reason a field was rejected only exists for people who can see the red.
+  const control = error
+    ? cloneElement(children, {
+        "aria-invalid": true,
+        "aria-describedby": errorId,
+      })
+    : children;
+
   return (
     <label className="flex flex-col gap-1">
       <span className="text-secondary text-sm font-medium">{label}</span>
-      {children}
-      {error && <span className="text-xs text-red-700">{error}</span>}
+      {control}
+      {error && (
+        <span id={errorId} className="text-xs text-red-700">
+          {error}
+        </span>
+      )}
     </label>
   );
 }
@@ -316,8 +332,15 @@ export function CredentialForm(props: Props) {
         ))}
       </fieldset>
 
+      {/* role="alert" because this appears in response to pressing submit and
+          the button itself keeps focus: without it the form looks unchanged
+          to a screen reader and the attendee is left waiting on a failure
+          that already happened. */}
       {serverError && (
-        <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">
+        <p
+          role="alert"
+          className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+        >
           {serverError}
         </p>
       )}
@@ -326,7 +349,7 @@ export function CredentialForm(props: Props) {
           rejection the attendee cannot trace back to a checkbox is a dead
           end, and this is the step where people abandon. */}
       {touched && missingConsent && (
-        <p className="text-sm text-red-700">
+        <p role="alert" className="text-sm text-red-700">
           {missingConsentMessage(missingConsent.id)}
         </p>
       )}

--- a/src/components/react/credential/CredentialPage.tsx
+++ b/src/components/react/credential/CredentialPage.tsx
@@ -58,7 +58,6 @@ export function CredentialPage({ event: eventJson }: Props) {
   const [step, setStep] = useState<1 | 2>(1);
   const [submitting, setSubmitting] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
-  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [done, setDone] = useState<{ groupLetter: string } | null>(null);
 
   const fontsReady = useFontsReady();
@@ -100,68 +99,82 @@ export function CredentialPage({ event: eventJson }: Props) {
   const submit = async () => {
     setSubmitting(true);
     setServerError(null);
-    setFieldErrors({});
 
-    // MUST come first: request() in src/lib/api.ts hard-returns
-    // { success: false, error: "Not authenticated" } with no token, which
-    // would surface as an English string in a Spanish form.
-    await signInAnonymouslyIfNeeded();
+    // Everything below runs inside try/finally so `submitting` is ALWAYS
+    // cleared. signInAnonymouslyIfNeeded throws on a blocked or offline
+    // identitytoolkit — an ad blocker or a corporate proxy is enough — and
+    // without this the button sat on "Guardando…" forever with no message,
+    // which reads as a hung page at the exact moment someone is registering.
+    try {
+      // MUST come first: request() in src/lib/api.ts hard-returns
+      // { success: false, error: "Not authenticated" } with no token, which
+      // would surface as an English string in a Spanish form.
+      await signInAnonymouslyIfNeeded();
 
-    const res = await api.createCredential(event.slug, {
-      firstName: card.firstName.trim(),
-      lastName: card.lastName.trim(),
-      dni: registration.dni.trim(),
-      email: registration.email.trim(),
-      company: registration.company.trim(),
-      githubUsername: card.githubUsername.trim() || null,
-      heardAbout: registration.heardAbout as never,
-      heardAboutOther: registration.heardAboutOther.trim(),
-      yearsExperience: registration.yearsExperience as never,
-      googleToolsLevel: registration.googleToolsLevel as never,
-      consentGdgTerms: true,
-      consentGooglePrivacy: true,
-      consentCodeOfConduct: true,
-      consentDataProcessing: true,
-      consentAgeAttested: true,
-      consentPolicyVersion: PRIVACY_POLICY_VERSION,
-      avatarKind: card.avatarKind,
-      mascotId: card.avatarKind === "mascot" ? card.mascotId : null,
-      photoDataUrl: card.avatarKind === "photo" ? card.photoDataUrl : null,
-      // Always null here: the card is attached below, once the server
-      // has told us the group letter. Sending it now would store a copy
-      // with a placeholder in place of the letter.
-      credentialImageDataUrl: null,
-    });
+      const res = await api.createCredential(event.slug, {
+        firstName: card.firstName.trim(),
+        lastName: card.lastName.trim(),
+        dni: registration.dni.trim(),
+        email: registration.email.trim(),
+        company: registration.company.trim(),
+        githubUsername: card.githubUsername.trim() || null,
+        heardAbout: registration.heardAbout as never,
+        heardAboutOther: registration.heardAboutOther.trim(),
+        yearsExperience: registration.yearsExperience as never,
+        googleToolsLevel: registration.googleToolsLevel as never,
+        consentGdgTerms: true,
+        consentGooglePrivacy: true,
+        consentCodeOfConduct: true,
+        consentDataProcessing: true,
+        consentAgeAttested: true,
+        consentPolicyVersion: PRIVACY_POLICY_VERSION,
+        avatarKind: card.avatarKind,
+        mascotId: card.avatarKind === "mascot" ? card.mascotId : null,
+        photoDataUrl: card.avatarKind === "photo" ? card.photoDataUrl : null,
+        // Always null here: the card is attached below, once the server
+        // has told us the group letter. Sending it now would store a copy
+        // with a placeholder in place of the letter.
+        credentialImageDataUrl: null,
+      });
 
-    setSubmitting(false);
-
-    if (!res.success) {
-      setServerError(res.error ?? "No pudimos guardar tu inscripción.");
-      return;
-    }
-    const groupLetter = res.data?.groupLetter ?? "?";
-    const credentialId = res.data?.credentialId;
-    setDone({ groupLetter });
-
-    // The card is attached in a SECOND call rather than sent with create.
-    // The group letter comes from a server-assigned sequence number, so a
-    // card rendered before the response carries a placeholder where the
-    // letter belongs — the first end-to-end run stored exactly that.
-    if (credentialId) {
-      try {
-        const canvas = renderToCanvas({ ...renderInput, groupLetter });
-        const encoded = encodeUnderBudget(canvas, MAX_CREDENTIAL_DATAURL_CHARS);
-        if (encoded) {
-          // Not awaited into the UI path: the attendee already has their
-          // credential on screen, and a failed attach must not turn a
-          // successful registration into an error message.
-          void api.attachCredentialImage(event.slug, credentialId, {
-            credentialImageDataUrl: encoded.dataUrl,
-          });
-        }
-      } catch {
-        // Same reasoning — the registration is the part that matters.
+      if (!res.success) {
+        setServerError(res.error ?? "No pudimos guardar tu inscripción.");
+        return;
       }
+      const groupLetter = res.data?.groupLetter ?? "?";
+      const credentialId = res.data?.credentialId;
+      setDone({ groupLetter });
+
+      // The card is attached in a SECOND call rather than sent with create.
+      // The group letter comes from a server-assigned sequence number, so a
+      // card rendered before the response carries a placeholder where the
+      // letter belongs — the first end-to-end run stored exactly that.
+      if (credentialId) {
+        try {
+          const canvas = renderToCanvas({ ...renderInput, groupLetter });
+          const encoded = encodeUnderBudget(
+            canvas,
+            MAX_CREDENTIAL_DATAURL_CHARS
+          );
+          if (encoded) {
+            // Not awaited into the UI path: the attendee already has their
+            // credential on screen, and a failed attach must not turn a
+            // successful registration into an error message.
+            void api.attachCredentialImage(event.slug, credentialId, {
+              credentialImageDataUrl: encoded.dataUrl,
+            });
+          }
+        } catch {
+          // Same reasoning — the registration is the part that matters.
+        }
+      }
+    } catch {
+      // Only reachable when something outside request() throws — request()
+      // already turns fetch failures into an { success: false } response.
+      // Same wording as api.ts so the attendee sees one consistent message.
+      setServerError("No se pudo conectar con el servidor.");
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -212,7 +225,6 @@ export function CredentialPage({ event: eventJson }: Props) {
             onSubmit={submit}
             submitting={submitting}
             serverError={serverError}
-            fieldErrors={fieldErrors}
           />
         )}
       </div>

--- a/src/components/react/credential/ShareBar.tsx
+++ b/src/components/react/credential/ShareBar.tsx
@@ -71,11 +71,18 @@ export function ShareBar({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap gap-2">
+        {/* No href at all while there is no image, rather than href="#" with
+            aria-disabled. An anchor without href is not a link: it leaves the
+            tab order and cannot be activated. With "#" it stayed focusable and
+            clickable, and clicking it navigated — aria-disabled only relabels
+            an element, it never stops it doing anything. */}
         <a
-          href={imageDataUrl ?? "#"}
-          download={fileName}
+          href={imageDataUrl ?? undefined}
+          download={imageDataUrl ? fileName : undefined}
           aria-disabled={!imageDataUrl}
-          className="bg-google-green rounded-lg px-4 py-2 text-sm font-semibold text-white"
+          className={`bg-google-green rounded-lg px-4 py-3 text-sm font-semibold text-white ${
+            imageDataUrl ? "" : "opacity-50"
+          }`}
         >
           Descargar credencial
         </a>
@@ -83,19 +90,25 @@ export function ShareBar({
           type="button"
           onClick={share}
           disabled={!imageDataUrl}
-          className="bg-google-blue rounded-lg px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          className="bg-google-blue rounded-lg px-4 py-3 text-sm font-semibold text-white disabled:opacity-50"
         >
           Compartir
         </button>
         <button
           type="button"
           onClick={copyLink}
-          className="border-gray-custom text-secondary rounded-lg border px-4 py-2 text-sm"
+          className="border-gray-custom text-secondary rounded-lg border px-4 py-3 text-sm"
         >
           {copied ? "Enlace copiado" : "Copiar enlace"}
         </button>
       </div>
-      {status && <p className="text-tertiary text-xs">{status}</p>}
+      {/* Announced, not just drawn: every message here reports the outcome of
+          a button the user just pressed, and that button keeps focus. */}
+      {status && (
+        <p role="status" className="text-tertiary text-xs">
+          {status}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/react/credential/__tests__/CredentialPage.test.tsx
+++ b/src/components/react/credential/__tests__/CredentialPage.test.tsx
@@ -212,6 +212,36 @@ describe("CredentialPage — submission", () => {
       await screen.findByText(/demasiados intentos desde esta red/i)
     ).toBeInTheDocument();
   });
+
+  // Regression. signInAnonymouslyIfNeeded was awaited unguarded, so a throw
+  // skipped setSubmitting(false) entirely: the button sat on "Guardando…"
+  // forever with no message and an unhandled rejection in the console. An
+  // ad blocker or a corporate proxy on identitytoolkit is enough to hit it,
+  // and it fails at the exact moment someone is registering.
+  it("recovers the button and explains itself when sign-in throws", async () => {
+    mocks.signInAnonymouslyIfNeeded.mockRejectedValue(
+      new Error("identitytoolkit blocked")
+    );
+    const user = userEvent.setup();
+    render(<CredentialPage event={EVENT} />);
+    await reachStepTwo(user);
+    await fillRegistration(user);
+    await checkAllConsents(user);
+    await user.click(
+      screen.getByRole("button", { name: /guardar y continuar/i })
+    );
+
+    expect(
+      await screen.findByText(/no se pudo conectar con el servidor/i)
+    ).toBeInTheDocument();
+    // Usable again rather than stuck on "Guardando…", so the attendee can
+    // retry once the network recovers.
+    expect(
+      screen.getByRole("button", { name: /guardar y continuar/i })
+    ).toBeEnabled();
+    // The registration never left the browser, so nothing was half-created.
+    expect(mocks.createCredential).not.toHaveBeenCalled();
+  });
 });
 
 describe("CredentialPage — success", () => {

--- a/src/components/react/credential/__tests__/CredentialPage.test.tsx
+++ b/src/components/react/credential/__tests__/CredentialPage.test.tsx
@@ -244,6 +244,57 @@ describe("CredentialPage — submission", () => {
   });
 });
 
+describe("CredentialPage — accesibilidad de los errores", () => {
+  it("anuncia el error del servidor en vez de solo pintarlo", async () => {
+    mocks.createCredential.mockResolvedValue({
+      success: false,
+      error: "Demasiados intentos desde esta red.",
+    });
+    const user = userEvent.setup();
+    render(<CredentialPage event={EVENT} />);
+    await reachStepTwo(user);
+    await fillRegistration(user);
+    await checkAllConsents(user);
+    await user.click(
+      screen.getByRole("button", { name: /guardar y continuar/i })
+    );
+
+    // El botón conserva el foco, así que sin role="alert" el lector de
+    // pantalla no ve ningún cambio y la persona se queda esperando.
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /demasiados intentos desde esta red/i
+    );
+  });
+
+  it("ata el error de un campo al propio control", async () => {
+    const user = userEvent.setup();
+    render(<CredentialPage event={EVENT} />);
+    const github = screen.getByLabelText("Usuario de GitHub (opcional)");
+    await user.type(github, "-no-vale-");
+
+    // Dentro de un <label>, un <span> final nunca se anuncia: hace falta
+    // aria-describedby para que el motivo del rechazo exista sin ver el rojo.
+    await waitFor(() => expect(github).toHaveAttribute("aria-invalid", "true"));
+    const describedBy = github.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)).toHaveTextContent(
+      /usuario de github no es válido/i
+    );
+  });
+
+  it("saca del foco el enlace de descarga mientras no hay imagen", async () => {
+    const user = userEvent.setup();
+    render(<CredentialPage event={EVENT} />);
+    await reachStepTwo(user);
+
+    // jsdom no implementa getContext, así que aquí no hay tarjeta compuesta:
+    // es exactamente el estado en el que el enlace debe estar inerte.
+    const download = screen.getByText("Descargar credencial");
+    expect(download).not.toHaveAttribute("href");
+    expect(download).toHaveAttribute("aria-disabled", "true");
+  });
+});
+
 describe("CredentialPage — success", () => {
   it("says plainly that the credential does not register anybody", async () => {
     // The whole risk of the hybrid funnel is someone believing the

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -54,12 +54,16 @@ async function request<T>(
   path: string,
   body?: unknown
 ): Promise<ApiResponse<T>> {
-  const token = await getIdToken();
-  if (!token) {
-    return { success: false, error: "Not authenticated" };
-  }
-
   try {
+    // Inside the try: getIdToken() reaches the network to refresh an expired
+    // token, so it throws when identitytoolkit is blocked or offline. Left
+    // outside, that throw escaped request() entirely and every caller had to
+    // guard it — which none of them did.
+    const token = await getIdToken();
+    if (!token) {
+      return { success: false, error: "Not authenticated" };
+    }
+
     // Proves the call came from this web app rather than a script that
     // minted an anonymous token elsewhere. Omitted when unavailable; the
     // server decides what that means.


### PR DESCRIPTION
## What changed

`submit()` in `CredentialPage.tsx` now wraps its body in `try/catch/finally`, with `setSubmitting(false)` in the `finally`.

`getIdToken()` in `src/lib/api.ts` moves inside `request()`'s existing `try`.

The dead `fieldErrors` state is removed — it was declared, cleared and threaded down to the form, but nothing ever wrote into it. `Field`'s `error` prop stays, since the inline GitHub-username error still uses it.

## Why

`submit()` awaited `signInAnonymouslyIfNeeded()` with no guard. When that throws, `setSubmitting(false)` never ran: the button sat on "Guardando…" forever, `serverError` stayed `null` so **no message was shown at all**, and an unhandled rejection went to the console. An ad blocker or a corporate proxy on `identitytoolkit.googleapis.com` is enough to trigger it, and it fails at the exact moment somebody is registering.

`getIdToken()` had the same shape of problem one layer down: it reaches the network to refresh an expired token, so it throws under the same conditions — but sitting outside the `try`, its throw escaped `request()` entirely, leaving every caller to guard it. None of them did.

## How to test

```
pnpm test
```

399 pass (was 398). The new regression test — `recovers the button and explains itself when sign-in throws` — fails without the fix: it throws the unhandled error and never clears the button. Verified by reintroducing the bug and re-running it.

No behaviour change on the happy path: `setSubmitting(false)` simply moved from mid-function to the `finally`, and the attach-image call it precedes is still fire-and-forget.