### PR TITLE
fix(credential): make the public form's errors audible, not just visible

### DIFF
--- a/src/components/react/credential/CredentialForm.tsx
+++ b/src/components/react/credential/CredentialForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { cloneElement, useId, useState } from "react";
 import { CONSENT_ITEMS, missingConsentMessage } from "@/lib/consent";
 import { AvatarPicker } from "./AvatarPicker";
 import {
@@ -34,13 +34,29 @@ function Field({
 }: {
   label: string;
   error?: string;
-  children: React.ReactNode;
+  children: React.ReactElement<React.AriaAttributes>;
 }) {
+  const errorId = useId();
+  // The error is wired to the control instead of left as loose prose beside
+  // it. Inside a <label>, a screen reader announces the label text and stops;
+  // a trailing <span> is never reached, so without aria-describedby the
+  // reason a field was rejected only exists for people who can see the red.
+  const control = error
+    ? cloneElement(children, {
+        "aria-invalid": true,
+        "aria-describedby": errorId,
+      })
+    : children;
+
   return (
     <label className="flex flex-col gap-1">
       <span className="text-secondary text-sm font-medium">{label}</span>
-      {children}
-      {error && <span className="text-xs text-red-700">{error}</span>}
+      {control}
+      {error && (
+        <span id={errorId} className="text-xs text-red-700">
+          {error}
+        </span>
+      )}
     </label>
   );
 }
@@ -316,8 +332,15 @@ export function CredentialForm(props: Props) {
         ))}
       </fieldset>
 
+      {/* role="alert" because this appears in response to pressing submit and
+          the button itself keeps focus: without it the form looks unchanged
+          to a screen reader and the attendee is left waiting on a failure
+          that already happened. */}
       {serverError && (
-        <p className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">
+        <p
+          role="alert"
+          className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+        >
           {serverError}
         </p>
       )}
@@ -326,7 +349,7 @@ export function CredentialForm(props: Props) {
           rejection the attendee cannot trace back to a checkbox is a dead
           end, and this is the step where people abandon. */}
       {touched && missingConsent && (
-        <p className="text-sm text-red-700">
+        <p role="alert" className="text-sm text-red-700">
           {missingConsentMessage(missingConsent.id)}
         </p>
       )}

--- a/src/components/react/credential/ShareBar.tsx
+++ b/src/components/react/credential/ShareBar.tsx
@@ -71,11 +71,18 @@ export function ShareBar({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap gap-2">
+        {/* No href at all while there is no image, rather than href="#" with
+            aria-disabled. An anchor without href is not a link: it leaves the
+            tab order and cannot be activated. With "#" it stayed focusable and
+            clickable, and clicking it navigated — aria-disabled only relabels
+            an element, it never stops it doing anything. */}
         <a
-          href={imageDataUrl ?? "#"}
-          download={fileName}
+          href={imageDataUrl ?? undefined}
+          download={imageDataUrl ? fileName : undefined}
           aria-disabled={!imageDataUrl}
-          className="bg-google-green rounded-lg px-4 py-2 text-sm font-semibold text-white"
+          className={`bg-google-green rounded-lg px-4 py-3 text-sm font-semibold text-white ${
+            imageDataUrl ? "" : "opacity-50"
+          }`}
         >
           Descargar credencial
         </a>
@@ -83,19 +90,25 @@ export function ShareBar({
           type="button"
           onClick={share}
           disabled={!imageDataUrl}
-          className="bg-google-blue rounded-lg px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          className="bg-google-blue rounded-lg px-4 py-3 text-sm font-semibold text-white disabled:opacity-50"
         >
           Compartir
         </button>
         <button
           type="button"
           onClick={copyLink}
-          className="border-gray-custom text-secondary rounded-lg border px-4 py-2 text-sm"
+          className="border-gray-custom text-secondary rounded-lg border px-4 py-3 text-sm"
         >
           {copied ? "Enlace copiado" : "Copiar enlace"}
         </button>
       </div>
-      {status && <p className="text-tertiary text-xs">{status}</p>}
+      {/* Announced, not just drawn: every message here reports the outcome of
+          a button the user just pressed, and that button keeps focus. */}
+      {status && (
+        <p role="status" className="text-tertiary text-xs">
+          {status}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/react/credential/__tests__/CredentialPage.test.tsx
+++ b/src/components/react/credential/__tests__/CredentialPage.test.tsx
@@ -244,6 +244,57 @@ describe("CredentialPage — submission", () => {
   });
 });
 
+describe("CredentialPage — accesibilidad de los errores", () => {
+  it("anuncia el error del servidor en vez de solo pintarlo", async () => {
+    mocks.createCredential.mockResolvedValue({
+      success: false,
+      error: "Demasiados intentos desde esta red.",
+    });
+    const user = userEvent.setup();
+    render(<CredentialPage event={EVENT} />);
+    await reachStepTwo(user);
+    await fillRegistration(user);
+    await checkAllConsents(user);
+    await user.click(
+      screen.getByRole("button", { name: /guardar y continuar/i })
+    );
+
+    // El botón conserva el foco, así que sin role="alert" el lector de
+    // pantalla no ve ningún cambio y la persona se queda esperando.
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /demasiados intentos desde esta red/i
+    );
+  });
+
+  it("ata el error de un campo al propio control", async () => {
+    const user = userEvent.setup();
+    render(<CredentialPage event={EVENT} />);
+    const github = screen.getByLabelText("Usuario de GitHub (opcional)");
+    await user.type(github, "-no-vale-");
+
+    // Dentro de un <label>, un <span> final nunca se anuncia: hace falta
+    // aria-describedby para que el motivo del rechazo exista sin ver el rojo.
+    await waitFor(() => expect(github).toHaveAttribute("aria-invalid", "true"));
+    const describedBy = github.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)).toHaveTextContent(
+      /usuario de github no es válido/i
+    );
+  });
+
+  it("saca del foco el enlace de descarga mientras no hay imagen", async () => {
+    const user = userEvent.setup();
+    render(<CredentialPage event={EVENT} />);
+    await reachStepTwo(user);
+
+    // jsdom no implementa getContext, así que aquí no hay tarjeta compuesta:
+    // es exactamente el estado en el que el enlace debe estar inerte.
+    const download = screen.getByText("Descargar credencial");
+    expect(download).not.toHaveAttribute("href");
+    expect(download).toHaveAttribute("aria-disabled", "true");
+  });
+});
+
 describe("CredentialPage — success", () => {
   it("says plainly that the credential does not register anybody", async () => {
     // The whole risk of the hybrid funnel is someone believing the


### PR DESCRIPTION
> Stacked on #352 — base is `fix/credencial-submit-atascado`, so this diff shows only the accessibility work. Rebase to `main` once #352 merges.

## What changed

- `serverError` and the missing-consent message get `role="alert"`.
- `Field` wires its message to the control with `aria-describedby` + `aria-invalid` (via `useId` + `cloneElement`) instead of rendering a loose `<span>`.
- The download `<a>` no longer carries `href="#"` when there is no composed card yet.
- Share buttons go from `py-2` to `py-3`.

## Why

All four were the same failure: the error was **drawn but did not exist** for anyone not looking at it.

The alerts appear in response to pressing submit, and the button keeps focus — so without a live region the form looks unchanged to a screen reader and the attendee waits on a failure that already happened.

`Field` puts its children inside a `<label>`. A screen reader announces the label text and stops; a trailing `<span>` is never reached. So the reason a field was rejected only existed for people who could see the red text.

The download link was the worst of the four: `aria-disabled` only relabels an element, it never stops it doing anything. With `href="#"` the link stayed focusable **and** clickable, and clicking it navigated. An anchor with no `href` is not a link at all — it leaves the tab order and cannot be activated, which is the actual intent.

The touch-target change is the one cosmetic item: ~36 px is under the usual 44 px guidance, and this bar is used almost entirely on phones.

## How to test

```
pnpm test
```

402 pass (was 399). Three new tests cover the changes, each asserting the behaviour rather than the markup: that the server error is reachable via `getByRole("alert")`, that the GitHub-username error is reachable through the input's own `aria-describedby`, and that the download link exposes no `href` while there is no image.

That last one runs in the natural jsdom state — `getContext` is unimplemented there, so `exportedImage` is `null`, which is exactly the case the link must be inert in.